### PR TITLE
Use strict equality checks where possible

### DIFF
--- a/src/AppendStream.php
+++ b/src/AppendStream.php
@@ -162,7 +162,7 @@ class AppendStream implements StreamableInterface
             $this->read(min(8096, $offset - $this->pos));
         }
 
-        return $this->pos == $offset;
+        return $this->pos === $offset;
     }
 
     /**
@@ -179,7 +179,7 @@ class AppendStream implements StreamableInterface
         while ($remaining > 0) {
             // Progress to the next stream if needed.
             if ($this->streams[$this->current]->eof()) {
-                if ($this->current == $total) {
+                if ($this->current === $total) {
                     break;
                 }
                 $this->current++;

--- a/src/BufferStream.php
+++ b/src/BufferStream.php
@@ -127,7 +127,7 @@ class BufferStream implements StreamableInterface
 
     public function getMetadata($key = null)
     {
-        if ($key == 'hwm') {
+        if ($key === 'hwm') {
             return $this->hwm;
         }
 

--- a/src/CachingStream.php
+++ b/src/CachingStream.php
@@ -48,9 +48,9 @@ class CachingStream implements StreamableInterface
      */
     public function seek($offset, $whence = SEEK_SET)
     {
-        if ($whence == SEEK_SET) {
+        if ($whence === SEEK_SET) {
             $byte = $offset;
-        } elseif ($whence == SEEK_CUR) {
+        } elseif ($whence === SEEK_CUR) {
             $byte = $offset + $this->tell();
         } else {
             return false;

--- a/src/LimitStream.php
+++ b/src/LimitStream.php
@@ -41,7 +41,7 @@ class LimitStream implements StreamableInterface
         }
 
         // No limit and the underlying stream is not at EOF
-        if ($this->limit == -1) {
+        if ($this->limit === -1) {
             return false;
         }
 
@@ -61,7 +61,7 @@ class LimitStream implements StreamableInterface
     {
         if (null === ($length = $this->stream->getSize())) {
             return null;
-        } elseif ($this->limit == -1) {
+        } elseif ($this->limit === -1) {
             return $length - $this->offset;
         } else {
             return min($this->limit, $length - $this->offset);
@@ -143,7 +143,7 @@ class LimitStream implements StreamableInterface
 
     public function read($length)
     {
-        if ($this->limit == -1) {
+        if ($this->limit === -1) {
             return $this->stream->read($length);
         }
 

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -48,7 +48,7 @@ class Stream implements StreamableInterface
     {
         $type = gettype($resource);
 
-        if ($type == 'string') {
+        if ($type === 'string') {
             $stream = fopen('php://temp', 'r+');
             if ($resource !== '') {
                 fwrite($stream, $resource);
@@ -57,7 +57,7 @@ class Stream implements StreamableInterface
             return new self($stream, $options);
         }
 
-        if ($type == 'resource') {
+        if ($type === 'resource') {
             return new self($resource, $options);
         }
 
@@ -65,7 +65,7 @@ class Stream implements StreamableInterface
             return $resource;
         }
 
-        if ($type == 'object' && method_exists($resource, '__toString')) {
+        if ($type === 'object' && method_exists($resource, '__toString')) {
             return self::factory((string) $resource, $options);
         }
 

--- a/src/StreamDecoratorTrait.php
+++ b/src/StreamDecoratorTrait.php
@@ -27,7 +27,7 @@ trait StreamDecoratorTrait
      */
     public function __get($name)
     {
-        if ($name == 'stream') {
+        if ($name === 'stream') {
             $this->stream = $this->createStream();
             return $this->stream;
         }

--- a/src/StreamWrapper.php
+++ b/src/StreamWrapper.php
@@ -48,7 +48,7 @@ class StreamWrapper
      */
     public static function register()
     {
-        if (!in_array('guzzle', stream_get_wrappers())) {
+        if (!in_array('guzzle', stream_get_wrappers(), true)) {
             stream_wrapper_register('guzzle', __CLASS__);
         }
     }

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -81,7 +81,7 @@ class Uri implements UriInterface
         $results = [];
         $segments = explode('/', $path);
         foreach ($segments as $segment) {
-            if ($segment == '..') {
+            if ($segment === '..') {
                 array_pop($results);
             } elseif (!isset($ignoreSegments[$segment])) {
                 $results[] = $segment;
@@ -97,7 +97,7 @@ class Uri implements UriInterface
         }
 
         // Add the trailing slash if necessary
-        if ($newPath != '/' && isset($ignoreSegments[end($segments)])) {
+        if ($newPath !== '/' && isset($ignoreSegments[end($segments)])) {
             $newPath .= '/';
         }
 
@@ -160,7 +160,7 @@ class Uri implements UriInterface
             $parts['query'] = $relParts['query'];
             $parts['fragment'] = $relParts['fragment'];
         } elseif (!empty($relParts['path'])) {
-            if (substr($relParts['path'], 0, 1) == '/') {
+            if (substr($relParts['path'], 0, 1) === '/') {
                 $parts['path'] = self::removeDotSegments($relParts['path']);
                 $parts['query'] = $relParts['query'];
                 $parts['fragment'] = $relParts['fragment'];

--- a/src/functions.php
+++ b/src/functions.php
@@ -270,7 +270,7 @@ function copy_to_stream(
         }
         $bytes += $len;
         $dest->write($buf);
-        if ($bytes == $maxLen) {
+        if ($bytes === $maxLen) {
             break;
         }
     }
@@ -327,7 +327,7 @@ function readline(StreamableInterface $stream, $maxLength = null)
         }
         $buffer .= $byte;
         // Break when a new line is found or the max length - 1 is reached
-        if ($byte == PHP_EOL || ++$size == $maxLength - 1) {
+        if ($byte === PHP_EOL || ++$size === $maxLength - 1) {
             break;
         }
     }
@@ -409,9 +409,9 @@ function parse_query($str, $urlEncoding = true)
         $decoder = function ($value) {
             return rawurldecode(str_replace('+', ' ', $value));
         };
-    } elseif ($urlEncoding == PHP_QUERY_RFC3986) {
+    } elseif ($urlEncoding === PHP_QUERY_RFC3986) {
         $decoder = 'rawurldecode';
-    } elseif ($urlEncoding == PHP_QUERY_RFC1738) {
+    } elseif ($urlEncoding === PHP_QUERY_RFC1738) {
         $decoder = 'urldecode';
     } else {
         $decoder = function ($str) { return $str; };
@@ -455,9 +455,9 @@ function build_query(array $params, $encoding = PHP_QUERY_RFC3986)
 
     if ($encoding === false) {
         $encoder = function ($str) { return $str; };
-    } elseif ($encoding == PHP_QUERY_RFC3986) {
+    } elseif ($encoding === PHP_QUERY_RFC3986) {
         $encoder = 'rawurlencode';
-    } elseif ($encoding == PHP_QUERY_RFC1738) {
+    } elseif ($encoding === PHP_QUERY_RFC1738) {
         $encoder = 'urlencode';
     } else {
         throw new \InvalidArgumentException('Invalid type');


### PR DESCRIPTION
There are also a couple of tests that I'm not sure if they should be strict or weak:

In `Request::getRequestTarget()`

    if ($target == null) {

In `Uri::getPath()`

    return $this->path == null ? '' : $this->path;

I'm guessing they should return true for `null` or `""` but probably not `0` or `0.0`.