### PR TITLE
Updated Uri to prevent instigation with an invalid scheme

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -328,8 +328,13 @@ class Uri implements UriInterface
     {
         $scheme = $this->filterScheme($scheme);
 
+        if ($this->scheme === $scheme) {
+            return clone $this;
+        }
+
         $new = clone $this;
         $new->scheme = $scheme;
+        $new->port = $new->filterPort($new->scheme, $new->host, $new->port);
         return $new;
     }
 

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -329,7 +329,7 @@ class Uri implements UriInterface
         $scheme = $this->filterScheme($scheme);
 
         if ($this->scheme === $scheme) {
-            return clone $this;
+            return $this;
         }
 
         $new = clone $this;
@@ -345,6 +345,10 @@ class Uri implements UriInterface
             $info .= ':' . $password;
         }
 
+        if ($this->userInfo === $info) {
+            return $this;
+        }
+
         $new = clone $this;
         $new->userInfo = $info;
         return $new;
@@ -352,6 +356,10 @@ class Uri implements UriInterface
 
     public function withHost($host)
     {
+        if ($this->host === $host) {
+            return $this;
+        }
+
         $new = clone $this;
         $new->host = $host;
         return $new;
@@ -360,6 +368,10 @@ class Uri implements UriInterface
     public function withPort($port)
     {
         $port = $this->filterPort($this->scheme, $this->host, $port);
+
+        if ($this->port === $port) {
+            return $this;
+        }
 
         $new = clone $this;
         $new->port = $port;
@@ -374,8 +386,14 @@ class Uri implements UriInterface
             );
         }
 
+        $path = $this->filterPath($path);
+
+        if ($this->path === $path) {
+            return $this;
+        }
+
         $new = clone $this;
-        $new->path = $this->filterPath($path);
+        $new->path = $path;
         return $new;
     }
 
@@ -392,8 +410,14 @@ class Uri implements UriInterface
             $query = substr($query, 1);
         }
 
+        $query = $this->filterQueryAndFragment($query);
+
+        if ($this->query === $query) {
+            return $this;
+        }
+
         $new = clone $this;
-        $new->query = $this->filterQueryAndFragment($query);
+        $new->query = $query;
         return $new;
     }
 
@@ -403,8 +427,14 @@ class Uri implements UriInterface
             $fragment = substr($fragment, 1);
         }
 
+        $fragment = $this->filterQueryAndFragment($fragment);
+
+        if ($this->fragment === $fragment) {
+            return $this;
+        }
+
         $new = clone $this;
-        $new->fragment = $this->filterQueryAndFragment($fragment);
+        $new->fragment = $fragment;
         return $new;
     }
 
@@ -504,10 +534,6 @@ class Uri implements UriInterface
     {
         $scheme = strtolower($scheme);
         $scheme = rtrim($scheme, ':/');
-
-        if (empty($scheme)) {
-            return '';
-        }
 
         return $scheme;
     }

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -23,7 +23,7 @@ class UriTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('test', $uri->getFragment());
         $this->assertEquals('test.com', $uri->getHost());
         $this->assertEquals('/path/123', $uri->getPath());
-        $this->assertEquals(443, $uri->getPort());
+        $this->assertEquals(null, $uri->getPort());
         $this->assertEquals('q=abc', $uri->getQuery());
         $this->assertEquals('https', $uri->getScheme());
         $this->assertEquals('michael:test', $uri->getUserInfo());
@@ -66,6 +66,14 @@ class UriTest extends \PHPUnit_Framework_TestCase
     public function testSchemeMustBeValid()
     {
         (new Uri(''))->withScheme('foo');
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testSchemeMustBeValidWhenConstructed()
+    {
+        new Uri('foo://example.com');
     }
 
     /**

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -63,22 +63,6 @@ class UriTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \InvalidArgumentException
      */
-    public function testSchemeMustBeValid()
-    {
-        (new Uri(''))->withScheme('foo');
-    }
-
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testSchemeMustBeValidWhenConstructed()
-    {
-        new Uri('foo://example.com');
-    }
-
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testPortMustBeValid()
     {
         (new Uri(''))->withPort(100000);


### PR DESCRIPTION
Uri::applyParts() now validates the scheme so a Uri can not be instigated with an invalid scheme.

Changed Uri::getPort() to return null if the port is the default port for the scheme. See PSR-7 specification.