### PR TITLE
Adds virtual package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,9 @@
         "phpunit/phpunit": "^4.0",
         "psr/http-message": "^0.11"
     },
+    "provide": {
+        "psr/http-message-implementation": "0.11"
+    },
     "autoload": {
         "psr-4": {
             "GuzzleHttp\\Psr7\\": "src/"


### PR DESCRIPTION
This is the second implementation of the PSR 7 interfaces I met.

The first one is probably [phly/http](https://github.com/phly/http). While that tries to focus on the message interfaces, this package contains a lot of Stream implementations which makes it a good competitor.

See the rationale here: phly/http#65