### PR TITLE
Allowing relative URIs

### DIFF
--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -87,9 +87,10 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     {
         $r1 = new Request('GET', '');
         $this->assertEquals('/', $r1->getRequestTarget());
-
-        $r2 = new Request('GET', '0');
-        $this->assertEquals('/0', $r2->getRequestTarget());
+        $r2 = new Request('GET', '*');
+        $this->assertEquals('*', $r2->getRequestTarget());
+        $r3 = new Request('GET', 'http://foo.com/bar baz/');
+        $this->assertEquals('/bar%20baz/', $r3->getRequestTarget());
     }
 
     public function testBuildsRequestTarget()

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -93,12 +93,12 @@ class UriTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('0', (string) $url->getQuery());
         $this->assertSame('0', $url->getFragment());
         $this->assertEquals('http://a:1/0?0#0', (string) $url);
-
         $url = new Uri('');
         $this->assertSame('', (string) $url);
-
         $url = new Uri('0');
-        $this->assertSame('/0', (string) $url);
+        $this->assertSame('0', (string) $url);
+        $url = new Uri('/');
+        $this->assertSame('/', (string) $url);
     }
 
     /**
@@ -221,5 +221,49 @@ class UriTest extends \PHPUnit_Framework_TestCase
     {
         $uri = new Uri($input);
         $this->assertEquals((string) $uri, $output);
+    }
+
+    public function testAddSlashToPathWhenHostAndNoLeadingSlash()
+    {
+        $uri = (new Uri(''))
+            ->withScheme('http')
+            ->withHost('example.com')
+            ->withPath('path/123');
+        $this->assertEquals('/path/123', $uri->getPath());
+        $this->assertEquals('http://example.com/path/123', (string) $uri);
+    }
+
+    public function testAddSlashToPathWhenApplyingPartsIfNeeded()
+    {
+        $uri = Uri::fromParts([
+            'scheme' => 'http',
+            'host' => 'example.com',
+            'path' => 'path/123'
+        ]);
+        $this->assertEquals('/path/123', $uri->getPath());
+        $this->assertEquals('http://example.com/path/123', (string) $uri);
+    }
+
+    public function testDoesNotAddSlashWhenPathIsEmpty()
+    {
+        $uri = Uri::fromParts([
+            'scheme' => 'http',
+            'host' => 'example.com',
+            'path' => '',
+            'query' => 'foo'
+        ]);
+        $this->assertEquals('', $uri->getPath());
+        $this->assertEquals('http://example.com?foo', (string) $uri);
+    }
+
+    public function testDoesNotAddSlashToPathWhenEmptyAndHostIsPresent()
+    {
+        $uri = (new Uri(''))
+            ->withScheme('http')
+            ->withHost('example.com')
+            ->withPath('')
+            ->withQuery('foo');
+        $this->assertEquals('', $uri->getPath());
+        $this->assertEquals('http://example.com?foo', (string) $uri);
     }
 }


### PR DESCRIPTION
Closes #18.

This commit updates the Uri class to allow for relative paths. A leading
slash is now only added to a path when it is necessary in order to make
the URI valid: when there is a host and the URI is not '' and does not
start with '/'.

@jeremeamia @jeskew