### PR TITLE
Conditionally require functions.php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "psr-4": {
             "GuzzleHttp\\Psr7\\": "src/"
         },
-        "files": ["src/functions.php"]
+        "files": ["src/functions_include.php"]
     },
     "extra": {
         "branch-alias": {

--- a/src/functions_include.php
+++ b/src/functions_include.php
@@ -1,0 +1,6 @@
+<?php
+
+// Don't redefine the functions if included multiple times.
+if (!function_exists('GuzzleHttp\Psr7\str')) {
+    require __DIR__ . '/functions.php';
+}


### PR DESCRIPTION
Composer unconditionally "autoloads" files using `require` (see composer/composer#3003): this causes problems with globally-installed dependencies or where the composer autoload happens to be called more than once (see guzzle/guzzle#676).

One solution is to guard against function redeclaration using `function_exists()`, something that both guzzle/promises and React do (see [L4-7 in functions.php](https://github.com/guzzle/promises/blob/master/src/functions.php#L4-L7) and reactphp/promise#25, respectively).

The solution guzzle/promises currently uses does not work: PHP will attempt to load the functions before the conditional is evaluated. I've opted for the React solution, which is to point to a shim `functions_include.php` file that checks for the existence of the first function within `functions.php` before including `functions.php`.