### PR TITLE
Fixes for issue-24 (support full URL's in requests, such as proxied requests)

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -440,7 +440,8 @@ function readline(StreamInterface $stream, $maxLength = null)
 function parse_request($message)
 {
     $data = _parse_message($message);
-    if (!preg_match('/^[a-zA-Z]+\s+\/.*/', $data['start-line'])) {
+    $matches = [];
+    if (!preg_match('/^[a-zA-Z]+\s+([a-zA-Z]+:\/\/|\/).*/', $data['start-line'], $matches)) {
         throw new \InvalidArgumentException('Invalid request string');
     }
     $parts = explode(' ', $data['start-line'], 3);
@@ -448,7 +449,7 @@ function parse_request($message)
 
     return new Request(
         $parts[0],
-        _parse_request_uri($parts[1], $data['headers']),
+        $matches[1] === '/' ? _parse_request_uri($parts[1], $data['headers']) : $parts[1],
         $data['headers'],
         $data['body'],
         $version

--- a/src/functions.php
+++ b/src/functions.php
@@ -447,13 +447,15 @@ function parse_request($message)
     $parts = explode(' ', $data['start-line'], 3);
     $version = isset($parts[2]) ? explode('/', $parts[2])[1] : '1.1';
 
-    return new Request(
+    $request = new Request(
         $parts[0],
         $matches[1] === '/' ? _parse_request_uri($parts[1], $data['headers']) : $parts[1],
         $data['headers'],
         $data['body'],
         $version
     );
+
+    return $matches[1] === '/' ? $request : $request->withRequestTarget($parts[1]);
 }
 
 /**

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -275,7 +275,7 @@ class FunctionsTest extends \PHPUnit_Framework_TestCase
         $req = "GET https://www.google.com:443/search?q=foobar HTTP/1.1\r\nHost: www.google.com\r\n\r\n";
         $request = Psr7\parse_request($req);
         $this->assertEquals('GET', $request->getMethod());
-        $this->assertEquals('/search?q=foobar', $request->getRequestTarget());
+        $this->assertEquals('https://www.google.com:443/search?q=foobar', $request->getRequestTarget());
         $this->assertEquals('1.1', $request->getProtocolVersion());
         $this->assertEquals('www.google.com', $request->getHeaderLine('Host'));
         $this->assertEquals('', (string) $request->getBody());

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -270,6 +270,18 @@ class FunctionsTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('http://foo.com/', (string) $request->getUri());
     }
 
+    public function testParsesRequestMessagesWithFullUri()
+    {
+        $req = "GET https://www.google.com:443/search?q=foobar HTTP/1.1\r\nHost: www.google.com\r\n\r\n";
+        $request = Psr7\parse_request($req);
+        $this->assertEquals('GET', $request->getMethod());
+        $this->assertEquals('/search?q=foobar', $request->getRequestTarget());
+        $this->assertEquals('1.1', $request->getProtocolVersion());
+        $this->assertEquals('www.google.com', $request->getHeaderLine('Host'));
+        $this->assertEquals('', (string) $request->getBody());
+        $this->assertEquals('https://www.google.com/search?q=foobar', (string) $request->getUri());
+    }
+
     /**
      * @expectedException \InvalidArgumentException
      */


### PR DESCRIPTION
See issue #24. When used as a proxy server, the client sends the full URI (not only the relative one). This patch supports both and added a test.

Looking forward for your feedback/comments!