### PR TITLE
[Response] Fixing issue with body that cast to the boolean false

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -93,7 +93,7 @@ class Response implements ResponseInterface
     ) {
         $this->statusCode = (int) $status;
 
-        if ($body) {
+        if ($body !== null) {
             $this->stream = stream_for($body);
         }
 

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -136,4 +136,11 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $this->assertNotSame($r, $r2);
         $this->assertEquals('Bam', $r2->getHeaderLine('Foo'));
     }
+
+    public function testBodyConsistent()
+    {
+        $r = new Response(200, [], '0');
+        $this->assertEquals('0', (string)$r->getBody());
+    }
+    
 }


### PR DESCRIPTION
Issue is described in guzzle/guzzle#1210.

If `(bool)$body === false` we have a not consistent reprenstation of the body in the `Response` object.