### PR TITLE
add constructor option to keep standard ports in the uri if passed

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -41,11 +41,17 @@ class Uri implements UriInterface
     /** @var string Uri fragment. */
     private $fragment = '';
 
+    /** @var bool Flag whether to include standard ports in uri if specified. */
+    private $stripPort = true;
+
     /**
      * @param string $uri URI to parse and wrap.
+     * @param bool $stripPort Optionally prevent a standard port number from being stripped from the formatted uri.
      */
-    public function __construct($uri = '')
+    public function __construct($uri = '', $stripPort = true)
     {
+        $this->stripPort = $stripPort;
+
         if ($uri != null) {
             $parts = parse_url($uri);
             if ($parts === false) {
@@ -282,7 +288,7 @@ class Uri implements UriInterface
             $authority = $this->userInfo . '@' . $authority;
         }
 
-        if ($this->isNonStandardPort($this->scheme, $this->host, $this->port)) {
+        if (!$this->stripPort || $this->isNonStandardPort($this->scheme, $this->host, $this->port)) {
             $authority .= ':' . $this->port;
         }
 
@@ -557,7 +563,7 @@ class Uri implements UriInterface
             }
         }
 
-        return $this->isNonStandardPort($scheme, $host, $port) ? $port : null;
+        return (!$this->stripPort || $this->isNonStandardPort($scheme, $host, $port)) ? $port : null;
     }
 
     /**

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -29,6 +29,24 @@ class UriTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('michael:test', $uri->getUserInfo());
     }
 
+    public function testParseProvidedUrlWithStripsUriFalseKeepsDefaultPorts()
+    {
+        $uri = new Uri('https://michael:test@test.com:443/path/123?q=abc#test', false);
+
+        $this->assertEquals(
+            'https://michael:test@test.com:443/path/123?q=abc#test',
+            (string) $uri
+        );
+
+        $this->assertEquals('test', $uri->getFragment());
+        $this->assertEquals('test.com', $uri->getHost());
+        $this->assertEquals('/path/123', $uri->getPath());
+        $this->assertEquals(443, $uri->getPort());
+        $this->assertEquals('q=abc', $uri->getQuery());
+        $this->assertEquals('https', $uri->getScheme());
+        $this->assertEquals('michael:test', $uri->getUserInfo());
+    }
+
     /**
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Unable to parse URI
@@ -195,6 +213,15 @@ class UriTest extends \PHPUnit_Framework_TestCase
         // No host or port
         $uri = new Uri('http://foo.co');
         $this->assertEquals('foo.co', $uri->getAuthority());
+    }
+
+    public function testGetAuthorityReturnsStandardPortWithOptionSet()
+    {
+        $uri = new Uri('https://foo.co:443', false);
+        $this->assertEquals('foo.co:443', $uri->getAuthority());
+
+        $uri = new Uri('http://foo.co:80', false);
+        $this->assertEquals('foo.co:80', $uri->getAuthority());
     }
 
     public function pathTestProvider()


### PR DESCRIPTION
Some server configurations may require that a standard port number be included in the request.

By default the standard ports will be stripped, however this option allows a user to maintain the port if required.

In reference to the `getPort` method psr7 states: `If the port is the standard port used with the current scheme, this method SHOULD return null.`
And in reference to `getAuthority` psr7 states: `If the port component is not set or is the standard port for the current scheme, it SHOULD NOT be included.`
