### PR TITLE
Copy SEEK_END behavior from fseek

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## next release
+
+* Now supporting negative offsets when seeking to SEEK_END.
+
 ## 1.2.0 - 2015-08-15
 
 * Body as `"0"` is now properly added to a response.

--- a/src/CachingStream.php
+++ b/src/CachingStream.php
@@ -52,8 +52,7 @@ class CachingStream implements StreamInterface
             if ($size === null) {
                 $size = $this->cacheEntireStream();
             }
-            // Because 0 is the first byte, we seek to size - 1.
-            $byte = $size - 1 - $offset;
+            $byte = $size + $offset;
         } else {
             throw new \InvalidArgumentException('Invalid whence');
         }

--- a/tests/CachingStreamTest.php
+++ b/tests/CachingStreamTest.php
@@ -44,9 +44,9 @@ class CachingStreamTest extends \PHPUnit_Framework_TestCase
     {
         $baseStream = Psr7\stream_for(implode('', range('a', 'z')));
         $cached = new CachingStream($baseStream);
-        $cached->seek(1, SEEK_END);
-        $this->assertEquals(24, $baseStream->tell());
-        $this->assertEquals('y', $cached->read(1));
+        $cached->seek(-1, SEEK_END);
+        $this->assertEquals(25, $baseStream->tell());
+        $this->assertEquals('z', $cached->read(1));
         $this->assertEquals(26, $cached->getSize());
     }
 
@@ -55,8 +55,8 @@ class CachingStreamTest extends \PHPUnit_Framework_TestCase
         $baseStream = Psr7\stream_for(implode('', range('a', 'z')));
         $cached = new CachingStream($baseStream);
         $cached->seek(0, SEEK_END);
-        $this->assertEquals(25, $baseStream->tell());
-        $this->assertEquals('z', $cached->read(1));
+        $this->assertEquals(26, $baseStream->tell());
+        $this->assertEquals('', $cached->read(1));
         $this->assertEquals(26, $cached->getSize());
     }
 
@@ -67,8 +67,8 @@ class CachingStreamTest extends \PHPUnit_Framework_TestCase
             'getSize' => function () { return null; }
         ]);
         $cached = new CachingStream($decorated);
-        $cached->seek(1, SEEK_END);
-        $this->assertEquals('ng', $cached->read(2));
+        $cached->seek(-1, SEEK_END);
+        $this->assertEquals('g', $cached->read(1));
     }
 
     public function testRewindUsesSeek()


### PR DESCRIPTION
This PR allows you to seek to a number of bytes before the end of a stream by passing a negative offset and SEEK_END to seek (to match the behavior of `fseek` on file handles). 

It also fixes the off-by-one error when seeking to the end of a `CachingStream` as reported in https://github.com/aws/aws-sdk-php/issues/809