### PR TITLE
Add message factories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "psr/http-message": "~1.0"
+        "psr/http-message": "~1.0",
+        "php-http/message-factory": "~1.0@dev"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0"

--- a/src/MessageFactory.php
+++ b/src/MessageFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace GuzzleHttp\Psr7;
+
+/**
+ * Creates Request and Response.
+ *
+ * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
+ */
+final class MessageFactory implements \Http\Message\MessageFactory
+{
+    use ResponseFactoryTrait;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createRequest(
+        $method,
+        $uri,
+        array $headers = [],
+        $body = null,
+        $protocolVersion = '1.1'
+    ) {
+        return new Request(
+            $method,
+            $uri,
+            $headers,
+            $body,
+            $protocolVersion
+        );
+    }
+}

--- a/src/ResponseFactoryTrait.php
+++ b/src/ResponseFactoryTrait.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace GuzzleHttp\Psr7;
+
+/**
+ * Creates Response.
+ *
+ * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
+ */
+trait ResponseFactoryTrait
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function createResponse(
+        $statusCode = 200,
+        $reasonPhrase = null,
+        array $headers = [],
+        $body = null,
+        $protocolVersion = '1.1'
+    ) {
+        return new Response(
+            $statusCode,
+            $headers,
+            $body,
+            $protocolVersion,
+            $reasonPhrase
+        );
+    }
+}

--- a/src/StreamFactory.php
+++ b/src/StreamFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace GuzzleHttp\Psr7;
+
+/**
+ * Creates streams.
+ *
+ * @author Михаил Красильников <m.krasilnikov@yandex.ru>
+ */
+final class StreamFactory implements \Http\Message\StreamFactory
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function createStream($body = null)
+    {
+        return stream_for($body);
+    }
+}

--- a/src/UriFactory.php
+++ b/src/UriFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace GuzzleHttp\Psr7;
+
+/**
+ * Creates URI.
+ *
+ * @author David de Boer <david@ddeboer.nl>
+ */
+final class UriFactory implements \Http\Message\UriFactory
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function createUri($uri)
+    {
+        return uri_for($uri);
+    }
+}

--- a/tests/MessageFactoryTest.php
+++ b/tests/MessageFactoryTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace GuzzleHttp\Tests\Psr7;
+
+use GuzzleHttp\Psr7\MessageFactory;
+
+class MessageFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    public function testItIsAMessageFactory()
+    {
+        $this->assertInstanceOf('Http\\Message\\MessageFactory', new MessageFactory());
+    }
+
+    public function testReturnsRequest()
+    {
+        $mf = new MessageFactory();
+
+        $request = $mf->createRequest('GET', '/', ['Content-Type' => 'text/html'], 'body', '1.0');
+
+        $this->assertInstanceOf('Psr\\Http\\Message\\RequestInterface', $request);
+        $this->assertInstanceOf('GuzzleHttp\\Psr7\\Request', $request);
+
+        $this->assertEquals('GET', $request->getMethod());
+        $this->assertEquals('/', $request->getRequestTarget());
+        $this->assertEquals(['Content-Type' => ['text/html']], $request->getHeaders());
+        $this->assertEquals('body', (string) $request->getBody());
+        $this->assertEquals('1.0', $request->getProtocolVersion());
+    }
+
+    public function testReturnsResponse()
+    {
+        $mf = new MessageFactory();
+
+        $response = $mf->createResponse(200, null, ['Content-Type' => 'text/html'], 'response', '1.0');
+
+        $this->assertInstanceOf('Psr\\Http\\Message\\ResponseInterface', $response);
+        $this->assertInstanceOf('GuzzleHttp\\Psr7\\Response', $response);
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('OK', $response->getReasonPhrase());
+        $this->assertEquals(['Content-Type' => ['text/html']], $response->getHeaders());
+        $this->assertEquals('response', (string) $response->getBody());
+        $this->assertEquals('1.0', $response->getProtocolVersion());
+    }
+}

--- a/tests/StreamFactoryTest.php
+++ b/tests/StreamFactoryTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace GuzzleHttp\Tests\Psr7;
+
+use GuzzleHttp\Psr7\StreamFactory;
+
+class StreamFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    public function testItIsAStreamFactory()
+    {
+        $this->assertInstanceOf('Http\\Message\\StreamFactory', new StreamFactory());
+    }
+
+    public function testCreatesStreamFromString()
+    {
+        $sf = new StreamFactory();
+
+        $stream = $sf->createStream('body');
+
+        $this->assertInstanceOf('Psr\\Http\\Message\\StreamInterface', $stream);
+        $this->assertInstanceOf('GuzzleHttp\\Psr7\\Stream', $stream);
+
+        $this->assertEquals('body', (string) $stream);
+    }
+
+    public function testCreatesEmptyStream()
+    {
+        $sf = new StreamFactory();
+
+        $stream = $sf->createStream();
+
+        $this->assertInstanceOf('Psr\\Http\\Message\\StreamInterface', $stream);
+        $this->assertInstanceOf('GuzzleHttp\\Psr7\\Stream', $stream);
+
+        $this->assertEquals('', (string) $stream);
+    }
+
+    public function testReturnsSameStream()
+    {
+        $sf = new StreamFactory();
+
+        $originalStream = \GuzzleHttp\Psr7\stream_for('');
+
+        $stream = $sf->createStream($originalStream);
+
+        $this->assertSame($originalStream, $stream);
+    }
+}

--- a/tests/UriFactoryTest.php
+++ b/tests/UriFactoryTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace GuzzleHttp\Tests\Psr7;
+
+use GuzzleHttp\Psr7\UriFactory;
+
+class UriFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    public function testItIsAUriFactory()
+    {
+        $this->assertInstanceOf('Http\\Message\\UriFactory', new UriFactory());
+    }
+
+    public function testReturnsUri()
+    {
+        $uf = new UriFactory();
+
+        $uri = $uf->createUri('/');
+
+        $this->assertInstanceOf('Psr\\Http\\Message\\UriInterface', $uri);
+        $this->assertInstanceOf('GuzzleHttp\\Psr7\\Uri', $uri);
+
+        $this->assertEquals('/', (string) $uri);
+    }
+
+    public function testReturnsSameUri()
+    {
+        $uf = new UriFactory();
+
+        $originalUri = \GuzzleHttp\Psr7\uri_for('');
+
+        $uri = $uf->createUri($originalUri);
+
+        $this->assertSame($originalUri, $uri);
+    }
+}


### PR DESCRIPTION
Factory implementations for PSR-7 related objects.

It adds one external dependency (which becomes stable this week). It provides Factory interfaces.

The idea behind this project is that message construction COULD also be standardized. It's not a requirement, but can be useful in some cases. Actually it is useful in any cases where you allow using any kind of PSR-7 implementation, not just one.

We regularly use it in HTTPlug and any packages which rely on it: FOS HTTP Cache, FXMLRPC, possibly in the future Geocoder too.

We had these interfaces implemented in a custom repository along with factories for Diactoros, but we realized that it would be cool if factories were provided by implementations themselves. In case of Diactoros it is possibly harder, because it already provides some factories which are incompatible with these interfaces. In such cases we have to use bridge packages, like this:

https://github.com/mekras/httplug-diactoros-bridge

However it adds an extra dependency, and somewhat redundancy, as you require a message implementation AND a bridge package for it.

Not sure if it is something that you want to merge, but I thought I would submit it anyway.

/cc @dbu @joelwurtz @mekras