### PR TITLE
Add HTTP 451 Unavailable For Legal Reasons

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -59,6 +59,7 @@ class Response implements ResponseInterface
         428 => 'Precondition Required',
         429 => 'Too Many Requests',
         431 => 'Request Header Fields Too Large',
+        451 => 'Unavailable For Legal Reasons',
         500 => 'Internal Server Error',
         501 => 'Not Implemented',
         502 => 'Bad Gateway',


### PR DESCRIPTION
This new status code has been approved by the IETF.  It is awaiting final publication and RFC number assignment.  According to Mark Nottingham, the IETF HTTP Working Group Chair, “you can start using it now.”

(I wouldn't be opposed to waiting until the final RFC is published before merging this)

- https://datatracker.ietf.org/doc/draft-ietf-httpbis-legally-restricted-status/
- http://thenextweb.com/dd/2015/12/21/theres-now-an-official-http-status-code-for-legal-takedowns-451/