### PR TITLE
ServerRequest and UploadedFIle Implementation

### DIFF
--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -47,7 +47,7 @@ class ServerRequest extends Request implements ServerRequestInterface
     /**
      * @var array
      */
-    private $serverParams = [];
+    private $serverParams;
 
     /**
      * @var array

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -1,0 +1,330 @@
+<?php
+
+namespace GuzzleHttp\Psr7;
+
+use InvalidArgumentException;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\UriInterface;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UploadedFileInterface;
+
+/**
+ * Server-side HTTP request
+ *
+ * Extends the Request definition to add methods for accessing incoming data,
+ * specifically server parameters, cookies, matched path parameters, query
+ * string arguments, body parameters, and upload file information.
+ *
+ * "Attributes" are discovered via decomposing the request (and usually
+ * specifically the URI path), and typically will be injected by the application.
+ *
+ * Requests are considered immutable; all methods that might change state are
+ * implemented such that they retain the internal state of the current
+ * message and return a new instance that contains the changed state.
+ */
+class ServerRequest extends Request implements ServerRequestInterface
+{
+    /**
+     * Return an UploadedFile instance array.
+     *
+     * @param array  $files A array which respect $_FILES structure.
+     * @throws InvalidArgumentException for unrecognized values
+     * @return array
+     */
+    public static function normalizeFiles($files)
+    {
+        $normalized = [];
+
+        foreach ($files as $key => $value) {
+            if ($value instanceof UploadedFileInterface) {
+                $normalized[$key] = $value;
+            } elseif (is_array($value) && isset($value['tmp_name'])) {
+                $normalized[$key] = self::createUploadedFileFromSpec($value);
+            } elseif (is_array($value)) {
+                $normalized[$key] = self::normalizeFiles($value);
+                continue;
+            } else {
+                throw new InvalidArgumentException('Invalid value in files specification');
+            }
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * Create and return an UploadedFile instance from a $_FILES specification.
+     *
+     * If the specification represents an array of values, this method will
+     * delegate to normalizeNestedFileSpec() and return that return value.
+     *
+     * @param array $value $_FILES struct
+     * @return array|UploadedFileInterface
+     */
+    private static function createUploadedFileFromSpec(array $value)
+    {
+        if (is_array($value['tmp_name'])) {
+            return self::normalizeNestedFileSpec($value);
+        }
+
+        return new UploadedFile(
+            $value['tmp_name'],
+            $value['size'],
+            $value['error'],
+            $value['name'],
+            $value['type']
+        );
+    }
+
+    /**
+     * Normalize an array of file specifications.
+     *
+     * Loops through all nested files and returns a normalized array of
+     * UploadedFileInterface instances.
+     *
+     * @param array $files
+     * @return UploadedFileInterface[]
+     */
+    private static function normalizeNestedFileSpec(array $files = [])
+    {
+        $normalizedFiles = [];
+        foreach (array_keys($files['tmp_name']) as $key) {
+            $spec = [
+                'tmp_name' => $files['tmp_name'][$key],
+                'size'     => $files['size'][$key],
+                'error'    => $files['error'][$key],
+                'name'     => $files['name'][$key],
+                'type'     => $files['type'][$key],
+            ];
+            $normalizedFiles[$key] = self::createUploadedFileFromSpec($spec);
+        }
+
+        return $normalizedFiles;
+    }
+
+    /**
+     * Return a ServerRequest populated with superglobals :
+     * $_GET
+     * $_POST
+     * $_COOKIE
+     * $_FILES
+     * $_SERVER
+     *
+     * @return ServerRequestInterface
+     */
+    public static function fromGlobals()
+    {
+        $method = isset($_SERVER['REQUEST_METHOD']) ? $_SERVER['REQUEST_METHOD'] : 'GET';
+        $headers = function_exists('getallheaders') ? getallheaders() : [];
+        $uri = self::getUriFromGlobals();
+        $body = new LazyOpenStream('php://input', 'r+');
+        $protocol = isset($_SERVER['SERVER_PROTOCOL']) ? str_replace('HTTP/', '', $_SERVER['SERVER_PROTOCOL']) : '1.1';
+
+        $serverRequest = new ServerRequest($method, $uri, $headers, $body, $protocol, $_SERVER);
+
+        return $serverRequest
+            ->withCookieParams($_COOKIE)
+            ->withQueryParams($_GET)
+            ->withParsedBody($_POST)
+            ->withUploadedFiles(self::normalizeFiles($_FILES));
+    }
+
+    /**
+     * Get a Uri populated with values from $_SERVER
+     *
+     * @return UriInterface
+     */
+    public static function getUriFromGlobals() {
+        $uri = new Uri('');
+
+        return $uri
+            ->withScheme(isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on' ? 'https' : 'http')
+            ->withHost($_SERVER['SERVER_NAME'])
+            ->withPort($_SERVER['SERVER_PORT'])
+            ->withPath(current(explode('?', $_SERVER['REQUEST_URI'])))
+            ->withQuery(isset($_SERVER['QUERY_STRING']) ? $_SERVER['QUERY_STRING'] : '');
+    }
+
+    /**
+     * @var array
+     */
+    private $attributes = [];
+
+    /**
+     * @var array
+     */
+    private $cookieParams = [];
+
+    /**
+     * @var null|array|object
+     */
+    private $parsedBody;
+
+    /**
+     * @var array
+     */
+    private $queryParams = [];
+
+    /**
+     * @var array
+     */
+    private $serverParams;
+
+    /**
+     * @var array
+     */
+    private $uploadedFiles;
+
+    /**
+     * @param array $serverParams the value of $_SERVER superglobal
+     * @param array $uploadedFiles the value of $_FILES superglobal
+     * @param null|string $method HTTP method for the request.
+     * @param null|string|UriInterface $uri URI for the request.
+     * @param array $headers Headers for the message.
+     * @param string|resource|StreamInterface $body Message body.
+     * @param string $protocolVersion HTTP protocol version.
+     *
+     * @throws InvalidArgumentException for an invalid URI
+     */
+    public function __construct(
+        $method,
+        $uri,
+        array $headers = [],
+        $body = null,
+        $protocolVersion = '1.1',
+        array $serverParams = []
+    ) {
+        $this->serverParams = $serverParams;
+
+        parent::__construct($method, $uri, $headers, $body, $protocolVersion);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getServerParams()
+    {
+        return $this->serverParams;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getUploadedFiles()
+    {
+        return $this->uploadedFiles;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function withUploadedFiles(array $uploadedFiles)
+    {
+        $new = clone $this;
+        $new->uploadedFiles = $uploadedFiles;
+
+        return $new;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCookieParams()
+    {
+        return $this->cookieParams;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function withCookieParams(array $cookies)
+    {
+        $new = clone $this;
+        $new->cookieParams = $cookies;
+
+        return $new;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getQueryParams()
+    {
+        return $this->queryParams;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function withQueryParams(array $query)
+    {
+        $new = clone $this;
+        $new->queryParams = $query;
+
+        return $new;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParsedBody()
+    {
+        return $this->parsedBody;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function withParsedBody($data)
+    {
+        $new = clone $this;
+        $new->parsedBody = $data;
+
+        return $new;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAttributes()
+    {
+        return $this->attributes;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAttribute($attribute, $default = null)
+    {
+        if (! array_key_exists($attribute, $this->attributes)) {
+            return $default;
+        }
+
+        return $this->attributes[$attribute];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function withAttribute($attribute, $value)
+    {
+        $new = clone $this;
+        $new->attributes[$attribute] = $value;
+
+        return $new;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function withoutAttribute($attribute)
+    {
+        if (false === isset($this->attributes[$attribute])) {
+            return clone $this;
+        }
+
+        $new = clone $this;
+        unset($new->attributes[$attribute]);
+
+        return $new;
+    }
+}

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -136,12 +136,27 @@ class ServerRequest extends Request implements ServerRequestInterface
     public static function getUriFromGlobals() {
         $uri = new Uri('');
 
-        return $uri
-            ->withScheme(isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on' ? 'https' : 'http')
-            ->withHost($_SERVER['SERVER_NAME'])
-            ->withPort($_SERVER['SERVER_PORT'])
-            ->withPath(current(explode('?', $_SERVER['REQUEST_URI'])))
-            ->withQuery(isset($_SERVER['QUERY_STRING']) ? $_SERVER['QUERY_STRING'] : '');
+        if (isset($_SERVER['HTTPS'])) {
+            $uri = $uri->withScheme($_SERVER['HTTPS'] == 'on' ? 'https' : 'http');
+        }
+
+        if (isset($_SERVER['SERVER_NAME'])) {
+            $uri = $uri->withHost($_SERVER['SERVER_NAME']);
+        }
+
+        if (isset($_SERVER['SERVER_PORT'])) {
+            $uri = $uri->withPort($_SERVER['SERVER_PORT']);
+        }
+
+        if (isset($_SERVER['REQUEST_URI'])) {
+            $uri = $uri->withPath(current(explode('?', $_SERVER['REQUEST_URI'])));
+        }
+
+        if (isset($_SERVER['QUERY_STRING'])) {
+            $uri = $uri->withQuery($_SERVER['QUERY_STRING']);
+        }
+
+        return $uri;
     }
 
     /**

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -194,7 +194,9 @@ class ServerRequest extends Request implements ServerRequestInterface
             $uri = $uri->withScheme($_SERVER['HTTPS'] == 'on' ? 'https' : 'http');
         }
 
-        if (isset($_SERVER['SERVER_NAME'])) {
+        if (isset($_SERVER['HTTP_HOST'])) {
+            $uri = $uri->withHost($_SERVER['HTTP_HOST']);
+        } elseif (isset($_SERVER['SERVER_NAME'])) {
             $uri = $uri->withHost($_SERVER['SERVER_NAME']);
         }
 

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -55,8 +55,8 @@ class ServerRequest extends Request implements ServerRequestInterface
     private $uploadedFiles;
 
     /**
-     * @param array $serverParams the value of $_SERVER superglobal
-     * @param array $uploadedFiles the value of $_FILES superglobal
+     * @param array $serverParams the value of $_SERVER superglobal.
+     * @param array $uploadedFiles the value of $_FILES superglobal.
      * @param null|string $method HTTP method for the request.
      * @param null|string|UriInterface $uri URI for the request.
      * @param array $headers Headers for the message.
@@ -81,11 +81,11 @@ class ServerRequest extends Request implements ServerRequestInterface
     /**
      * Return an UploadedFile instance array.
      *
-     * @param array  $files A array which respect $_FILES structure.
+     * @param array $files A array which respect $_FILES structure.
      * @throws InvalidArgumentException for unrecognized values
      * @return array
      */
-    public static function normalizeFiles($files)
+    public static function normalizeFiles(array $files)
     {
         $normalized = [];
 
@@ -141,6 +141,7 @@ class ServerRequest extends Request implements ServerRequestInterface
     private static function normalizeNestedFileSpec(array $files = [])
     {
         $normalizedFiles = [];
+
         foreach (array_keys($files['tmp_name']) as $key) {
             $spec = [
                 'tmp_name' => $files['tmp_name'][$key],
@@ -156,7 +157,7 @@ class ServerRequest extends Request implements ServerRequestInterface
     }
 
     /**
-     * Return a ServerRequest populated with superglobals :
+     * Return a ServerRequest populated with superglobals:
      * $_GET
      * $_POST
      * $_COOKIE
@@ -183,7 +184,7 @@ class ServerRequest extends Request implements ServerRequestInterface
     }
 
     /**
-     * Get a Uri populated with values from $_SERVER
+     * Get a Uri populated with values from $_SERVER.
      *
      * @return UriInterface
      */

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -311,7 +311,7 @@ class ServerRequest extends Request implements ServerRequestInterface
      */
     public function getAttribute($attribute, $default = null)
     {
-        if (! array_key_exists($attribute, $this->attributes)) {
+        if (false === array_key_exists($attribute, $this->attributes)) {
             return $default;
         }
 

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -47,21 +47,20 @@ class ServerRequest extends Request implements ServerRequestInterface
     /**
      * @var array
      */
-    private $serverParams;
+    private $serverParams = [];
 
     /**
      * @var array
      */
-    private $uploadedFiles;
+    private $uploadedFiles = [];
 
     /**
-     * @param array $serverParams the value of $_SERVER superglobal.
-     * @param array $uploadedFiles the value of $_FILES superglobal.
-     * @param null|string $method HTTP method for the request.
-     * @param null|string|UriInterface $uri URI for the request.
-     * @param array $headers Headers for the message.
-     * @param string|resource|StreamInterface $body Message body.
-     * @param string $protocolVersion HTTP protocol version.
+     * @param null|string $method HTTP method for the request
+     * @param null|string|UriInterface $uri URI for the request
+     * @param array $headers Headers for the message
+     * @param string|resource|StreamInterface $body Message body
+     * @param string $protocolVersion HTTP protocol version
+     * @param array $serverParams the value of $_SERVER superglobal
      *
      * @throws InvalidArgumentException for an invalid URI
      */
@@ -81,7 +80,7 @@ class ServerRequest extends Request implements ServerRequestInterface
     /**
      * Return an UploadedFile instance array.
      *
-     * @param array $files A array which respect $_FILES structure.
+     * @param array $files A array which respect $_FILES structure
      * @throws InvalidArgumentException for unrecognized values
      * @return array
      */

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -68,8 +68,8 @@ class ServerRequest extends Request implements ServerRequestInterface
 
         return new UploadedFile(
             $value['tmp_name'],
-            $value['size'],
-            $value['error'],
+            (int) $value['size'],
+            (int) $value['error'],
             $value['name'],
             $value['type']
         );

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -25,6 +25,60 @@ use Psr\Http\Message\UploadedFileInterface;
 class ServerRequest extends Request implements ServerRequestInterface
 {
     /**
+     * @var array
+     */
+    private $attributes = [];
+
+    /**
+     * @var array
+     */
+    private $cookieParams = [];
+
+    /**
+     * @var null|array|object
+     */
+    private $parsedBody;
+
+    /**
+     * @var array
+     */
+    private $queryParams = [];
+
+    /**
+     * @var array
+     */
+    private $serverParams;
+
+    /**
+     * @var array
+     */
+    private $uploadedFiles;
+
+    /**
+     * @param array $serverParams the value of $_SERVER superglobal
+     * @param array $uploadedFiles the value of $_FILES superglobal
+     * @param null|string $method HTTP method for the request.
+     * @param null|string|UriInterface $uri URI for the request.
+     * @param array $headers Headers for the message.
+     * @param string|resource|StreamInterface $body Message body.
+     * @param string $protocolVersion HTTP protocol version.
+     *
+     * @throws InvalidArgumentException for an invalid URI
+     */
+    public function __construct(
+        $method,
+        $uri,
+        array $headers = [],
+        $body = null,
+        $protocolVersion = '1.1',
+        array $serverParams = []
+    ) {
+        $this->serverParams = $serverParams;
+
+        parent::__construct($method, $uri, $headers, $body, $protocolVersion);
+    }
+
+    /**
      * Return an UploadedFile instance array.
      *
      * @param array  $files A array which respect $_FILES structure.
@@ -159,59 +213,6 @@ class ServerRequest extends Request implements ServerRequestInterface
         return $uri;
     }
 
-    /**
-     * @var array
-     */
-    private $attributes = [];
-
-    /**
-     * @var array
-     */
-    private $cookieParams = [];
-
-    /**
-     * @var null|array|object
-     */
-    private $parsedBody;
-
-    /**
-     * @var array
-     */
-    private $queryParams = [];
-
-    /**
-     * @var array
-     */
-    private $serverParams;
-
-    /**
-     * @var array
-     */
-    private $uploadedFiles;
-
-    /**
-     * @param array $serverParams the value of $_SERVER superglobal
-     * @param array $uploadedFiles the value of $_FILES superglobal
-     * @param null|string $method HTTP method for the request.
-     * @param null|string|UriInterface $uri URI for the request.
-     * @param array $headers Headers for the message.
-     * @param string|resource|StreamInterface $body Message body.
-     * @param string $protocolVersion HTTP protocol version.
-     *
-     * @throws InvalidArgumentException for an invalid URI
-     */
-    public function __construct(
-        $method,
-        $uri,
-        array $headers = [],
-        $body = null,
-        $protocolVersion = '1.1',
-        array $serverParams = []
-    ) {
-        $this->serverParams = $serverParams;
-
-        parent::__construct($method, $uri, $headers, $body, $protocolVersion);
-    }
 
     /**
      * {@inheritdoc}

--- a/src/UploadedFile.php
+++ b/src/UploadedFile.php
@@ -1,0 +1,310 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       http://github.com/zendframework/zend-diactoros for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
+ */
+
+namespace GuzzleHttp\Psr7;
+
+use InvalidArgumentException;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UploadedFileInterface;
+use RuntimeException;
+
+class UploadedFile implements UploadedFileInterface
+{
+    private static $errors = [
+        UPLOAD_ERR_OK,
+        UPLOAD_ERR_INI_SIZE,
+        UPLOAD_ERR_FORM_SIZE,
+        UPLOAD_ERR_PARTIAL,
+        UPLOAD_ERR_NO_FILE,
+        UPLOAD_ERR_NO_TMP_DIR,
+        UPLOAD_ERR_CANT_WRITE,
+        UPLOAD_ERR_EXTENSION,
+    ];
+
+    /**
+     * @var string
+     */
+    private $clientFilename;
+
+    /**
+     * @var string
+     */
+    private $clientMediaType;
+
+    /**
+     * @var int
+     */
+    private $error;
+
+    /**
+     * @var null|string
+     */
+    private $file;
+
+    /**
+     * @var bool
+     */
+    private $moved = false;
+
+    /**
+     * @var int
+     */
+    private $size;
+
+    /**
+     * @var StreamInterface|null
+     */
+    private $stream;
+
+    /**
+     * @param StreamInterface|string|resource $streamOrFile
+     * @param int                             $size
+     * @param int                             $errorStatus
+     * @param string|null                     $clientFilename
+     * @param string|null                     $clientMediaType
+     */
+    public function __construct(
+        $streamOrFile,
+        $size,
+        $errorStatus,
+        $clientFilename = null,
+        $clientMediaType = null
+    ) {
+        $this->setError($errorStatus);
+        $this->setSize($size);
+        $this->setClientFilename($clientFilename);
+        $this->setClientMediaType($clientMediaType);
+
+        if ($this->isOk()) {
+            $this->setStreamOrFile($streamOrFile);
+        }
+    }
+
+    /**
+     * Depending on the value set file or stream variable
+     *
+     * @param  mixed                    $streamOrFile
+     * @throws InvalidArgumentException
+     */
+    private function setStreamOrFile($streamOrFile)
+    {
+        if (is_string($streamOrFile)) {
+            $this->file = $streamOrFile;
+        } elseif (is_resource($streamOrFile)) {
+            $this->stream = new Stream($streamOrFile);
+        } elseif ($streamOrFile instanceof StreamInterface) {
+            $this->stream = $streamOrFile;
+        } else {
+            throw new InvalidArgumentException(
+                'Invalid stream or file provided for UploadedFile'
+            );
+        }
+    }
+
+    /**
+     * @param int $error
+     * @throws InvalidArgumentException
+     */
+    private function setError($error)
+    {
+        if (false === is_int($error)) {
+            throw new InvalidArgumentException(
+                'Upload file error status must be an integer'
+            );
+        }
+
+        if (false === in_array($error, UploadedFile::$errors)) {
+            throw new InvalidArgumentException(
+                'Invalid error status for UploadedFile'
+            );
+        }
+
+        $this->error = $error;
+    }
+
+    /**
+     * @param int $size
+     * @throws InvalidArgumentException
+     */
+    private function setSize($size)
+    {
+        if (false === is_int($size)) {
+            throw new InvalidArgumentException(
+                'Upload file size must be an integer'
+            );
+        }
+
+        $this->size = $size;
+    }
+
+    /**
+     * @param  mixed   $param
+     * @return boolean
+     */
+    private function isStringOrNull($param)
+    {
+        return in_array(gettype($param), ['string', 'NULL']);
+    }
+
+    /**
+     * @param  mixed   $param
+     * @return boolean
+     */
+    private function isStringNotEmpty($param)
+    {
+        return is_string($param) && false == empty($param);
+    }
+
+    /**
+     * @param string|null $clientFilename
+     * @throws InvalidArgumentException
+     */
+    private function setClientFilename($clientFilename)
+    {
+        if (false === $this->isStringOrNull($clientFilename)) {
+            throw new InvalidArgumentException(
+                'Upload file client filename must be a string or null'
+            );
+        }
+
+        $this->clientFilename = $clientFilename;
+    }
+
+    /**
+     * @param string|null $clientMediaType
+     * @throws InvalidArgumentException
+     */
+    private function setClientMediaType($clientMediaType)
+    {
+        if (false === $this->isStringOrNull($clientMediaType)) {
+            throw new InvalidArgumentException(
+                'Upload file client media type must be a string or null'
+            );
+        }
+
+        $this->clientMediaType = $clientMediaType;
+    }
+
+    private function isOk()
+    {
+        return $this->error === UPLOAD_ERR_OK;
+    }
+
+    public function isMoved()
+    {
+        return $this->moved;
+    }
+
+    private function validateActive()
+    {
+        if (false === $this->isOk()) {
+            throw new RuntimeException('Cannot retrieve stream due to upload error');
+        }
+
+        if ($this->isMoved()) {
+            throw new RuntimeException('Cannot retrieve stream after it has already been moved');
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     * @throws \RuntimeException if the upload was not successful.
+     */
+    public function getStream()
+    {
+        $this->validateActive();
+
+        if ($this->stream instanceof StreamInterface) {
+            return $this->stream;
+        }
+
+        return new LazyOpenStream($this->file, 'r+');
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see http://php.net/is_uploaded_file
+     * @see http://php.net/move_uploaded_file
+     * @param string $targetPath Path to which to move the uploaded file.
+     * @throws \RuntimeException if the upload was not successful.
+     * @throws \InvalidArgumentException if the $path specified is invalid.
+     * @throws \RuntimeException on any error during the move operation, or on
+     *     the second or subsequent call to the method.
+     */
+    public function moveTo($targetPath)
+    {
+        $this->validateActive();
+
+        if (false === $this->isStringNotEmpty($targetPath)) {
+            throw new InvalidArgumentException(
+                'Invalid path provided for move operation; must be a non-empty string'
+            );
+        }
+
+        if ($this->file) {
+            $this->moved = php_sapi_name() == 'cli'
+                ? rename($this->file, $targetPath)
+                : move_uploaded_file($this->file, $targetPath);
+        } else {
+            copy_to_stream(
+                $this->getStream(),
+                new LazyOpenStream($targetPath, 'w')
+            );
+
+            $this->moved = true;
+        }
+
+        if (false === $this->moved) {
+            throw new RuntimeException(
+                sprintf('Uploaded file could not be moved to %s', $targetPath)
+            );
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return int|null The file size in bytes or null if unknown.
+     */
+    public function getSize()
+    {
+        return $this->size;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see http://php.net/manual/en/features.file-upload.errors.php
+     * @return int One of PHP's UPLOAD_ERR_XXX constants.
+     */
+    public function getError()
+    {
+        return $this->error;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return string|null The filename sent by the client or null if none
+     *     was provided.
+     */
+    public function getClientFilename()
+    {
+        return $this->clientFilename;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getClientMediaType()
+    {
+        return $this->clientMediaType;
+    }
+}

--- a/src/UploadedFile.php
+++ b/src/UploadedFile.php
@@ -8,6 +8,9 @@ use RuntimeException;
 
 class UploadedFile implements UploadedFileInterface
 {
+    /**
+     * @var int[]
+     */
     private static $errors = [
         UPLOAD_ERR_OK,
         UPLOAD_ERR_INI_SIZE,
@@ -56,10 +59,10 @@ class UploadedFile implements UploadedFileInterface
 
     /**
      * @param StreamInterface|string|resource $streamOrFile
-     * @param int                             $size
-     * @param int                             $errorStatus
-     * @param string|null                     $clientFilename
-     * @param string|null                     $clientMediaType
+     * @param int $size
+     * @param int $errorStatus
+     * @param string|null $clientFilename
+     * @param string|null $clientMediaType
      */
     public function __construct(
         $streamOrFile,
@@ -81,7 +84,7 @@ class UploadedFile implements UploadedFileInterface
     /**
      * Depending on the value set file or stream variable
      *
-     * @param  mixed                    $streamOrFile
+     * @param mixed $streamOrFile
      * @throws InvalidArgumentException
      */
     private function setStreamOrFile($streamOrFile)
@@ -136,7 +139,7 @@ class UploadedFile implements UploadedFileInterface
     }
 
     /**
-     * @param  mixed   $param
+     * @param mixed $param
      * @return boolean
      */
     private function isStringOrNull($param)
@@ -145,7 +148,7 @@ class UploadedFile implements UploadedFileInterface
     }
 
     /**
-     * @param  mixed   $param
+     * @param mixed $param
      * @return boolean
      */
     private function isStringNotEmpty($param)
@@ -183,16 +186,27 @@ class UploadedFile implements UploadedFileInterface
         $this->clientMediaType = $clientMediaType;
     }
 
+    /**
+     * Return true if there is no upload error
+     *
+     * @return boolean
+     */
     private function isOk()
     {
         return $this->error === UPLOAD_ERR_OK;
     }
 
+    /**
+     * @return boolean
+     */
     public function isMoved()
     {
         return $this->moved;
     }
 
+    /**
+     * @throws RuntimeException if is moved or not ok
+     */
     private function validateActive()
     {
         if (false === $this->isOk()) {
@@ -206,7 +220,7 @@ class UploadedFile implements UploadedFileInterface
 
     /**
      * {@inheritdoc}
-     * @throws \RuntimeException if the upload was not successful.
+     * @throws RuntimeException if the upload was not successful.
      */
     public function getStream()
     {
@@ -225,9 +239,9 @@ class UploadedFile implements UploadedFileInterface
      * @see http://php.net/is_uploaded_file
      * @see http://php.net/move_uploaded_file
      * @param string $targetPath Path to which to move the uploaded file.
-     * @throws \RuntimeException if the upload was not successful.
-     * @throws \InvalidArgumentException if the $path specified is invalid.
-     * @throws \RuntimeException on any error during the move operation, or on
+     * @throws RuntimeException if the upload was not successful.
+     * @throws InvalidArgumentException if the $path specified is invalid.
+     * @throws RuntimeException on any error during the move operation, or on
      *     the second or subsequent call to the method.
      */
     public function moveTo($targetPath)

--- a/src/UploadedFile.php
+++ b/src/UploadedFile.php
@@ -1,12 +1,4 @@
 <?php
-/**
- * Zend Framework (http://framework.zend.com/)
- *
- * @see       http://github.com/zendframework/zend-diactoros for the canonical source repository
- * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
- */
-
 namespace GuzzleHttp\Psr7;
 
 use InvalidArgumentException;

--- a/src/UploadedFile.php
+++ b/src/UploadedFile.php
@@ -150,7 +150,7 @@ class UploadedFile implements UploadedFileInterface
      */
     private function isStringNotEmpty($param)
     {
-        return is_string($param) && false == empty($param);
+        return is_string($param) && false === empty($param);
     }
 
     /**

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -1,0 +1,515 @@
+<?php
+namespace GuzzleHttp\Tests\Psr7;
+
+use GuzzleHttp\Psr7\ServerRequest;
+use GuzzleHttp\Psr7\UploadedFile;
+use GuzzleHttp\Psr7\Uri;
+
+/**
+ * @covers GuzzleHttp\Psr7\ServerRequest
+ */
+class ServerRequestTest extends \PHPUnit_Framework_TestCase
+{
+    public function dataNormalizeFiles()
+    {
+        return [
+            'Single file' => [
+                [
+                    'file' => [
+                        'name' => 'MyFile.txt',
+                        'type' => 'text/plain',
+                        'tmp_name' => '/tmp/php/php1h4j1o',
+                        'error' => UPLOAD_ERR_OK,
+                        'size' => 123
+                    ]
+                ],
+                [
+                    'file' => new UploadedFile(
+                        '/tmp/php/php1h4j1o',
+                        123,
+                        UPLOAD_ERR_OK,
+                        'MyFile.txt',
+                        'text/plain'
+                    )
+                ]
+            ],
+            'Empty file' => [
+                [
+                    'image_file' => [
+                        'name' => '',
+                        'type' => '',
+                        'tmp_name' => '',
+                        'error' => UPLOAD_ERR_NO_FILE,
+                        'size' => 0
+                    ]
+                ],
+                [
+                    'image_file' => new UploadedFile(
+                        '',
+                        0,
+                        UPLOAD_ERR_NO_FILE,
+                        '',
+                        ''
+                    )
+                ]
+            ],
+            'Already Converted' => [
+                [
+                    'file' => new UploadedFile(
+                        '/tmp/php/php1h4j1o',
+                        123,
+                        UPLOAD_ERR_OK,
+                        'MyFile.txt',
+                        'text/plain'
+                    )
+                ],
+                [
+                    'file' => new UploadedFile(
+                        '/tmp/php/php1h4j1o',
+                        123,
+                        UPLOAD_ERR_OK,
+                        'MyFile.txt',
+                        'text/plain'
+                    )
+                ]
+            ],
+            'Already Converted array' => [
+                [
+                    'file' => [
+                        new UploadedFile(
+                            '/tmp/php/php1h4j1o',
+                            123,
+                            UPLOAD_ERR_OK,
+                            'MyFile.txt',
+                            'text/plain'
+                        ),
+                        new UploadedFile(
+                            '',
+                            0,
+                            UPLOAD_ERR_NO_FILE,
+                            '',
+                            ''
+                        )
+                    ],
+                ],
+                [
+                    'file' => [
+                        new UploadedFile(
+                            '/tmp/php/php1h4j1o',
+                            123,
+                            UPLOAD_ERR_OK,
+                            'MyFile.txt',
+                            'text/plain'
+                        ),
+                        new UploadedFile(
+                            '',
+                            0,
+                            UPLOAD_ERR_NO_FILE,
+                            '',
+                            ''
+                        )
+                    ],
+                ]
+            ],
+            'Multiple files' => [
+                [
+                    'text_file' => [
+                        'name' => 'MyFile.txt',
+                        'type' => 'text/plain',
+                        'tmp_name' => '/tmp/php/php1h4j1o',
+                        'error' => UPLOAD_ERR_OK,
+                        'size' => 123
+                    ],
+                    'image_file' => [
+                        'name' => '',
+                        'type' => '',
+                        'tmp_name' => '',
+                        'error' => UPLOAD_ERR_NO_FILE,
+                        'size' => 0
+                    ]
+                ],
+                [
+                    'text_file' => new UploadedFile(
+                        '/tmp/php/php1h4j1o',
+                        123,
+                        UPLOAD_ERR_OK,
+                        'MyFile.txt',
+                        'text/plain'
+                    ),
+                    'image_file' => new UploadedFile(
+                        '',
+                        0,
+                        UPLOAD_ERR_NO_FILE,
+                        '',
+                        ''
+                    )
+                ]
+            ],
+            'Nested files' => [
+                [
+                    'file' => [
+                        'name' => [
+                            0 => 'MyFile.txt',
+                            1 => 'Image.png',
+                        ],
+                        'type' => [
+                            0 => 'text/plain',
+                            1 => 'image/png',
+                        ],
+                        'tmp_name' => [
+                            0 => '/tmp/php/hp9hskjhf',
+                            1 => '/tmp/php/php1h4j1o',
+                        ],
+                        'error' => [
+                            0 => UPLOAD_ERR_OK,
+                            1 => UPLOAD_ERR_OK,
+                        ],
+                        'size' => [
+                            0 => 123,
+                            1 => 7349,
+                        ],
+                    ],
+                    'nested' => [
+                        'name' => [
+                            'other' => 'Flag.txt',
+                            'test' => [
+                                0 => 'Stuff.txt',
+                                1 => '',
+                            ],
+                        ],
+                        'type' => [
+                            'other' => 'text/plain',
+                            'test' => [
+                                0 => 'text/plain',
+                                1 => '',
+                            ],
+                        ],
+                        'tmp_name' => [
+                            'other' => '/tmp/php/hp9hskjhf',
+                            'test' => [
+                                0 => '/tmp/php/asifu2gp3',
+                                1 => '',
+                            ],
+                        ],
+                        'error' => [
+                            'other' => UPLOAD_ERR_OK,
+                            'test' => [
+                                0 => UPLOAD_ERR_OK,
+                                1 => UPLOAD_ERR_NO_FILE,
+                            ],
+                        ],
+                        'size' => [
+                            'other' => 421,
+                            'test' => [
+                                0 => 32,
+                                1 => 0,
+                            ]
+                        ]
+                    ],
+                ],
+                [
+                    'file' => [
+                        0 => new UploadedFile(
+                            '/tmp/php/hp9hskjhf',
+                            123,
+                            UPLOAD_ERR_OK,
+                            'MyFile.txt',
+                            'text/plain'
+                        ),
+                        1 => new UploadedFile(
+                            '/tmp/php/php1h4j1o',
+                            7349,
+                            UPLOAD_ERR_OK,
+                            'Image.png',
+                            'image/png'
+                        ),
+                    ],
+                    'nested' => [
+                        'other' => new UploadedFile(
+                            '/tmp/php/hp9hskjhf',
+                            421,
+                            UPLOAD_ERR_OK,
+                            'Flag.txt',
+                            'text/plain'
+                        ),
+                        'test' => [
+                            0 => new UploadedFile(
+                                '/tmp/php/asifu2gp3',
+                                32,
+                                UPLOAD_ERR_OK,
+                                'Stuff.txt',
+                                'text/plain'
+                            ),
+                            1 => new UploadedFile(
+                                '',
+                                0,
+                                UPLOAD_ERR_NO_FILE,
+                                '',
+                                ''
+                            ),
+                        ]
+                    ]
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider dataNormalizeFiles
+     */
+    public function testNormalizeFiles($files, $expected)
+    {
+        $result = ServerRequest::normalizeFiles($files);
+
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testNormalizeFilesRaisesException()
+    {
+        $this->setExpectedException('InvalidArgumentException', 'Invalid value in files specification');
+
+        ServerRequest::normalizeFiles(['test' => 'something']);
+    }
+
+    public function dataGetUriFromGlobals()
+    {
+        $server = [
+            'PHP_SELF' => '/blog/article.php',
+            'GATEWAY_INTERFACE' => 'CGI/1.1',
+            'SERVER_ADDR' => 'Server IP: 217.112.82.20',
+            'SERVER_NAME' => 'www.blakesimpson.co.uk',
+            'SERVER_SOFTWARE' => 'Apache/2.2.15 (Win32) JRun/4.0 PHP/5.2.13',
+            'SERVER_PROTOCOL' => 'HTTP/1.0',
+            'REQUEST_METHOD' => 'POST',
+            'REQUEST_TIME' => 'Request start time: 1280149029',
+            'QUERY_STRING' => 'id=10&user=foo',
+            'DOCUMENT_ROOT' => '/path/to/your/server/root/',
+            'HTTP_ACCEPT' => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+            'HTTP_ACCEPT_CHARSET' => 'ISO-8859-1,utf-8;q=0.7,*;q=0.7',
+            'HTTP_ACCEPT_ENCODING' => 'gzip,deflate',
+            'HTTP_ACCEPT_LANGUAGE' => 'en-gb,en;q=0.5',
+            'HTTP_CONNECTION' => 'keep-alive',
+            'HTTP_HOST' => 'www.blakesimpson.co.uk',
+            'HTTP_REFERER' => 'http://previous.url.com',
+            'HTTP_USER_AGENT' => 'Mozilla/5.0 (Windows; U; Windows NT 6.0; en-GB; rv:1.9.2.6) Gecko/20100625 Firefox/3.6.6 ( .NET CLR 3.5.30729)',
+            'HTTPS' => '1',
+            'REMOTE_ADDR' => '193.60.168.69',
+            'REMOTE_HOST' => 'Client server\'s host name',
+            'REMOTE_PORT' => '5390',
+            'SCRIPT_FILENAME' => '/path/to/this/script.php',
+            'SERVER_ADMIN' => 'webmaster@blakesimpson.co.uk',
+            'SERVER_PORT' => '80',
+            'SERVER_SIGNATURE' => 'Version signature: 5.123',
+            'SCRIPT_NAME' => '/blog/article.php',
+            'REQUEST_URI' => '/blog/article.php?id=10&user=foo',
+        ];
+
+        return [
+            'Normal request' => [
+                'http://www.blakesimpson.co.uk/blog/article.php?id=10&user=foo',
+                $server,
+            ],
+            'Secure request' => [
+                'https://www.blakesimpson.co.uk/blog/article.php?id=10&user=foo',
+                array_merge($server, ['HTTPS' => 'on', 'SERVER_PORT' => '443']),
+            ],
+            'Host changed by client' => [
+                'http://www.blakesimpson.co.uk/blog/article.php?id=10&user=foo',
+                array_merge($server, ['HTTP_HOST' => 'changed']),
+            ],
+            'No query String' => [
+                'http://www.blakesimpson.co.uk/blog/article.php',
+                array_merge($server, ['REQUEST_URI' => '/blog/article.php', 'QUERY_STRING' => '']),
+            ],
+            'Different port' => [
+                'http://www.blakesimpson.co.uk:8324/blog/article.php?id=10&user=foo',
+                array_merge($server, ['SERVER_PORT' => '8324']),
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataGetUriFromGlobals
+     */
+    public function testGetUriFromGlobals($expected, $serverParams)
+    {
+        $_SERVER = $serverParams;
+
+        $this->assertEquals(new Uri($expected), ServerRequest::getUriFromGlobals());
+    }
+
+    public function testFromGlobals()
+    {
+        $_SERVER = [
+            'PHP_SELF' => '/blog/article.php',
+            'GATEWAY_INTERFACE' => 'CGI/1.1',
+            'SERVER_ADDR' => 'Server IP: 217.112.82.20',
+            'SERVER_NAME' => 'www.blakesimpson.co.uk',
+            'SERVER_SOFTWARE' => 'Apache/2.2.15 (Win32) JRun/4.0 PHP/5.2.13',
+            'SERVER_PROTOCOL' => 'HTTP/1.0',
+            'REQUEST_METHOD' => 'POST',
+            'REQUEST_TIME' => 'Request start time: 1280149029',
+            'QUERY_STRING' => 'id=10&user=foo',
+            'DOCUMENT_ROOT' => '/path/to/your/server/root/',
+            'HTTP_ACCEPT' => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+            'HTTP_ACCEPT_CHARSET' => 'ISO-8859-1,utf-8;q=0.7,*;q=0.7',
+            'HTTP_ACCEPT_ENCODING' => 'gzip,deflate',
+            'HTTP_ACCEPT_LANGUAGE' => 'en-gb,en;q=0.5',
+            'HTTP_CONNECTION' => 'keep-alive',
+            'HTTP_HOST' => 'www.blakesimpson.co.uk',
+            'HTTP_REFERER' => 'http://previous.url.com',
+            'HTTP_USER_AGENT' => 'Mozilla/5.0 (Windows; U; Windows NT 6.0; en-GB; rv:1.9.2.6) Gecko/20100625 Firefox/3.6.6 ( .NET CLR 3.5.30729)',
+            'HTTPS' => '1',
+            'REMOTE_ADDR' => '193.60.168.69',
+            'REMOTE_HOST' => 'Client server\'s host name',
+            'REMOTE_PORT' => '5390',
+            'SCRIPT_FILENAME' => '/path/to/this/script.php',
+            'SERVER_ADMIN' => 'webmaster@blakesimpson.co.uk',
+            'SERVER_PORT' => '80',
+            'SERVER_SIGNATURE' => 'Version signature: 5.123',
+            'SCRIPT_NAME' => '/blog/article.php',
+            'REQUEST_URI' => '/blog/article.php?id=10&user=foo',
+        ];
+
+        $_COOKIE = [
+            'logged-in' => 'yes!'
+        ];
+
+        $_POST = [
+            'name' => 'Pesho',
+            'email' => 'pesho@example.com',
+        ];
+
+        $_GET = [
+            'id' => 10,
+            'user' => 'foo',
+        ];
+
+        $_FILES = [
+            'file' => [
+                'name' => 'MyFile.txt',
+                'type' => 'text/plain',
+                'tmp_name' => '/tmp/php/php1h4j1o',
+                'error' => UPLOAD_ERR_OK,
+                'size' => 123,
+            ]
+        ];
+
+        $server = ServerRequest::fromGlobals();
+
+        $this->assertEquals('POST', $server->getMethod());
+        $this->assertEquals(['Host' => ['www.blakesimpson.co.uk']], $server->getHeaders());
+        $this->assertEquals('', (string) $server->getBody());
+        $this->assertEquals('1.0', $server->getProtocolVersion());
+        $this->assertEquals($_COOKIE, $server->getCookieParams());
+        $this->assertEquals($_POST, $server->getParsedBody());
+        $this->assertEquals($_GET, $server->getQueryParams());
+
+        $this->assertEquals(
+            new Uri('http://www.blakesimpson.co.uk/blog/article.php?id=10&user=foo'),
+            $server->getUri()
+        );
+
+        $expectedFiles = [
+            'file' => new UploadedFile(
+                '/tmp/php/php1h4j1o',
+                123,
+                UPLOAD_ERR_OK,
+                'MyFile.txt',
+                'text/plain'
+            ),
+        ];
+
+        $this->assertEquals($expectedFiles, $server->getUploadedFiles());
+    }
+
+    public function testUploadedFiles()
+    {
+        $request1 = new ServerRequest('GET', '/');
+
+        $files = [
+            'file' => new UploadedFile('test', 123, UPLOAD_ERR_OK)
+        ];
+
+        $request2 = $request1->withUploadedFiles($files);
+
+        $this->assertNotSame($request2, $request1);
+        $this->assertEmpty($request1->getUploadedFiles());
+        $this->assertSame($files, $request2->getUploadedFiles());
+    }
+
+    public function testServerParams()
+    {
+        $params = ['name' => 'value'];
+
+        $request = new ServerRequest('GET', '/', [], null, '1.1', $params);
+        $this->assertSame($params, $request->getServerParams());
+    }
+
+    public function testCookieParams()
+    {
+        $request1 = new ServerRequest('GET', '/');
+
+        $params = ['name' => 'value'];
+
+        $request2 = $request1->withCookieParams($params);
+
+        $this->assertNotSame($request2, $request1);
+        $this->assertEmpty($request1->getCookieParams());
+        $this->assertSame($params, $request2->getCookieParams());
+    }
+
+    public function testQueryParams()
+    {
+        $request1 = new ServerRequest('GET', '/');
+
+        $params = ['name' => 'value'];
+
+        $request2 = $request1->withQueryParams($params);
+
+        $this->assertNotSame($request2, $request1);
+        $this->assertEmpty($request1->getQueryParams());
+        $this->assertSame($params, $request2->getQueryParams());
+    }
+
+    public function testParsedBody()
+    {
+        $request1 = new ServerRequest('GET', '/');
+
+        $params = ['name' => 'value'];
+
+        $request2 = $request1->withParsedBody($params);
+
+        $this->assertNotSame($request2, $request1);
+        $this->assertEmpty($request1->getParsedBody());
+        $this->assertSame($params, $request2->getParsedBody());
+    }
+
+    public function testAttributes()
+    {
+        $request1 = new ServerRequest('GET', '/');
+
+        $request2 = $request1->withAttribute('name', 'value');
+        $request3 = $request2->withAttribute('other', 'otherValue');
+        $request4 = $request3->withoutAttribute('other');
+        $request5 = $request3->withoutAttribute('unknown');
+
+        $this->assertNotSame($request2, $request1);
+        $this->assertNotSame($request3, $request2);
+        $this->assertNotSame($request4, $request3);
+        $this->assertNotSame($request5, $request4);
+
+        $this->assertEmpty($request1->getAttributes());
+        $this->assertEmpty($request1->getAttribute('name'));
+        $this->assertEquals(
+            'something',
+            $request1->getAttribute('name', 'something'),
+            'Should return the default value'
+        );
+
+        $this->assertEquals('value', $request2->getAttribute('name'));
+        $this->assertEquals(['name' => 'value'], $request2->getAttributes());
+        $this->assertEquals(['name' => 'value', 'other' => 'otherValue'], $request3->getAttributes());
+        $this->assertEquals(['name' => 'value'], $request4->getAttributes());
+    }
+}

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -325,6 +325,10 @@ class ServerRequestTest extends \PHPUnit_Framework_TestCase
                 'http://www.blakesimpson.co.uk:8324/blog/article.php?id=10&user=foo',
                 array_merge($server, ['SERVER_PORT' => '8324']),
             ],
+            'Empty server variable' => [
+                '',
+                [],
+            ],
         ];
     }
 

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -313,9 +313,9 @@ class ServerRequestTest extends \PHPUnit_Framework_TestCase
                 'https://www.blakesimpson.co.uk/blog/article.php?id=10&user=foo',
                 array_merge($server, ['HTTPS' => 'on', 'SERVER_PORT' => '443']),
             ],
-            'Host changed by client' => [
+            'HTTP_HOST missing' => [
                 'http://www.blakesimpson.co.uk/blog/article.php?id=10&user=foo',
-                array_merge($server, ['HTTP_HOST' => 'changed']),
+                array_merge($server, ['HTTP_HOST' => null]),
             ],
             'No query String' => [
                 'http://www.blakesimpson.co.uk/blog/article.php',

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -19,8 +19,8 @@ class ServerRequestTest extends \PHPUnit_Framework_TestCase
                         'name' => 'MyFile.txt',
                         'type' => 'text/plain',
                         'tmp_name' => '/tmp/php/php1h4j1o',
-                        'error' => UPLOAD_ERR_OK,
-                        'size' => 123
+                        'error' => '0',
+                        'size' => '123'
                     ]
                 ],
                 [
@@ -39,8 +39,8 @@ class ServerRequestTest extends \PHPUnit_Framework_TestCase
                         'name' => '',
                         'type' => '',
                         'tmp_name' => '',
-                        'error' => UPLOAD_ERR_NO_FILE,
-                        'size' => 0
+                        'error' => '4',
+                        'size' => '0'
                     ]
                 ],
                 [
@@ -117,15 +117,15 @@ class ServerRequestTest extends \PHPUnit_Framework_TestCase
                         'name' => 'MyFile.txt',
                         'type' => 'text/plain',
                         'tmp_name' => '/tmp/php/php1h4j1o',
-                        'error' => UPLOAD_ERR_OK,
-                        'size' => 123
+                        'error' => '0',
+                        'size' => '123'
                     ],
                     'image_file' => [
                         'name' => '',
                         'type' => '',
                         'tmp_name' => '',
-                        'error' => UPLOAD_ERR_NO_FILE,
-                        'size' => 0
+                        'error' => '4',
+                        'size' => '0'
                     ]
                 ],
                 [
@@ -161,12 +161,12 @@ class ServerRequestTest extends \PHPUnit_Framework_TestCase
                             1 => '/tmp/php/php1h4j1o',
                         ],
                         'error' => [
-                            0 => UPLOAD_ERR_OK,
-                            1 => UPLOAD_ERR_OK,
+                            0 => '0',
+                            1 => '0',
                         ],
                         'size' => [
-                            0 => 123,
-                            1 => 7349,
+                            0 => '123',
+                            1 => '7349',
                         ],
                     ],
                     'nested' => [
@@ -192,17 +192,17 @@ class ServerRequestTest extends \PHPUnit_Framework_TestCase
                             ],
                         ],
                         'error' => [
-                            'other' => UPLOAD_ERR_OK,
+                            'other' => '0',
                             'test' => [
-                                0 => UPLOAD_ERR_OK,
-                                1 => UPLOAD_ERR_NO_FILE,
+                                0 => '0',
+                                1 => '4',
                             ],
                         ],
                         'size' => [
-                            'other' => 421,
+                            'other' => '421',
                             'test' => [
-                                0 => 32,
-                                1 => 0,
+                                0 => '32',
+                                1 => '0',
                             ]
                         ]
                     ],

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -438,7 +438,7 @@ class ServerRequestTest extends \PHPUnit_Framework_TestCase
         $request2 = $request1->withUploadedFiles($files);
 
         $this->assertNotSame($request2, $request1);
-        $this->assertEmpty($request1->getUploadedFiles());
+        $this->assertSame([], $request1->getUploadedFiles());
         $this->assertSame($files, $request2->getUploadedFiles());
     }
 

--- a/tests/UploadedFileTest.php
+++ b/tests/UploadedFileTest.php
@@ -1,0 +1,280 @@
+<?php
+namespace GuzzleHttp\Tests\Psr7;
+
+use ReflectionProperty;
+use GuzzleHttp\Psr7\Stream;
+use GuzzleHttp\Psr7\UploadedFile;
+
+/**
+ * @covers GuzzleHttp\Psr7\UploadedFile
+ */
+class UploadedFileTest extends \PHPUnit_Framework_TestCase
+{
+    protected $cleanup;
+
+    public function setUp()
+    {
+        $this->cleanup = [];
+    }
+
+    public function tearDown()
+    {
+        foreach ($this->cleanup as $file) {
+            if (is_scalar($file) && file_exists($file)) {
+                unlink($file);
+            }
+        }
+    }
+
+    public function invalidStreams()
+    {
+        return [
+            'null'         => [null],
+            'true'         => [true],
+            'false'        => [false],
+            'int'          => [1],
+            'float'        => [1.1],
+            'array'        => [['filename']],
+            'object'       => [(object) ['filename']],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidStreams
+     */
+    public function testRaisesExceptionOnInvalidStreamOrFile($streamOrFile)
+    {
+        $this->setExpectedException('InvalidArgumentException');
+
+        new UploadedFile($streamOrFile, 0, UPLOAD_ERR_OK);
+    }
+
+    public function invalidSizes()
+    {
+        return [
+            'null'   => [null],
+            'float'  => [1.1],
+            'array'  => [[1]],
+            'object' => [(object) [1]],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidSizes
+     */
+    public function testRaisesExceptionOnInvalidSize($size)
+    {
+        $this->setExpectedException('InvalidArgumentException', 'size');
+
+        new UploadedFile(fopen('php://temp', 'wb+'), $size, UPLOAD_ERR_OK);
+    }
+
+    public function invalidErrorStatuses()
+    {
+        return [
+            'null'     => [null],
+            'true'     => [true],
+            'false'    => [false],
+            'float'    => [1.1],
+            'string'   => ['1'],
+            'array'    => [[1]],
+            'object'   => [(object) [1]],
+            'negative' => [-1],
+            'too-big'  => [9],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidErrorStatuses
+     */
+    public function testRaisesExceptionOnInvalidErrorStatus($status)
+    {
+        $this->setExpectedException('InvalidArgumentException', 'status');
+
+        new UploadedFile(fopen('php://temp', 'wb+'), 0, $status);
+    }
+
+    public function invalidFilenamesAndMediaTypes()
+    {
+        return [
+            'true'   => [true],
+            'false'  => [false],
+            'int'    => [1],
+            'float'  => [1.1],
+            'array'  => [['string']],
+            'object' => [(object) ['string']],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidFilenamesAndMediaTypes
+     */
+    public function testRaisesExceptionOnInvalidClientFilename($filename)
+    {
+        $this->setExpectedException('InvalidArgumentException', 'filename');
+
+        new UploadedFile(fopen('php://temp', 'wb+'), 0, UPLOAD_ERR_OK, $filename);
+    }
+
+    /**
+     * @dataProvider invalidFilenamesAndMediaTypes
+     */
+    public function testRaisesExceptionOnInvalidClientMediaType($mediaType)
+    {
+        $this->setExpectedException('InvalidArgumentException', 'media type');
+
+        new UploadedFile(fopen('php://temp', 'wb+'), 0, UPLOAD_ERR_OK, 'foobar.baz', $mediaType);
+    }
+
+    public function testGetStreamReturnsOriginalStreamObject()
+    {
+        $stream = new Stream(fopen('php://temp', 'r'));
+        $upload = new UploadedFile($stream, 0, UPLOAD_ERR_OK);
+
+        $this->assertSame($stream, $upload->getStream());
+    }
+
+    public function testGetStreamReturnsWrappedPhpStream()
+    {
+        $stream = fopen('php://temp', 'wb+');
+        $upload = new UploadedFile($stream, 0, UPLOAD_ERR_OK);
+        $uploadStream = $upload->getStream()->detach();
+
+        $this->assertSame($stream, $uploadStream);
+    }
+
+    public function testGetStreamReturnsStreamForFile()
+    {
+        $this->cleanup[] = $stream = tempnam(sys_get_temp_dir(), 'stream_file');
+        $upload = new UploadedFile($stream, 0, UPLOAD_ERR_OK);
+        $uploadStream = $upload->getStream();
+        $r = new ReflectionProperty($uploadStream, 'filename');
+        $r->setAccessible(true);
+
+        $this->assertSame($stream, $r->getValue($uploadStream));
+    }
+
+    public function testSuccessful()
+    {
+        $stream = \GuzzleHttp\Psr7\stream_for('Foo bar!');
+        $upload = new UploadedFile($stream, $stream->getSize(), UPLOAD_ERR_OK, 'filename.txt', 'text/plain');
+
+        $this->assertEquals($stream->getSize(), $upload->getSize());
+        $this->assertEquals('filename.txt', $upload->getClientFilename());
+        $this->assertEquals('text/plain', $upload->getClientMediaType());
+
+        $this->cleanup[] = $to = tempnam(sys_get_temp_dir(), 'successful');
+        $upload->moveTo($to);
+        $this->assertFileExists($to);
+        $this->assertEquals($stream->__toString(), file_get_contents($to));
+    }
+
+    public function invalidMovePaths()
+    {
+        return [
+            'null'   => [null],
+            'true'   => [true],
+            'false'  => [false],
+            'int'    => [1],
+            'float'  => [1.1],
+            'empty'  => [''],
+            'array'  => [['filename']],
+            'object' => [(object) ['filename']],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidMovePaths
+     */
+    public function testMoveRaisesExceptionForInvalidPath($path)
+    {
+        $stream = \GuzzleHttp\Psr7\stream_for('Foo bar!');
+        $upload = new UploadedFile($stream, 0, UPLOAD_ERR_OK);
+
+        $this->cleanup[] = $path;
+
+        $this->setExpectedException('InvalidArgumentException', 'path');
+        $upload->moveTo($path);
+    }
+
+    public function testMoveCannotBeCalledMoreThanOnce()
+    {
+        $stream = \GuzzleHttp\Psr7\stream_for('Foo bar!');
+        $upload = new UploadedFile($stream, 0, UPLOAD_ERR_OK);
+
+        $this->cleanup[] = $to = tempnam(sys_get_temp_dir(), 'diac');
+        $upload->moveTo($to);
+        $this->assertTrue(file_exists($to));
+
+        $this->setExpectedException('RuntimeException', 'moved');
+        $upload->moveTo($to);
+    }
+
+    public function testCannotRetrieveStreamAfterMove()
+    {
+        $stream = \GuzzleHttp\Psr7\stream_for('Foo bar!');
+        $upload = new UploadedFile($stream, 0, UPLOAD_ERR_OK);
+
+        $this->cleanup[] = $to = tempnam(sys_get_temp_dir(), 'diac');
+        $upload->moveTo($to);
+        $this->assertFileExists($to);
+
+        $this->setExpectedException('RuntimeException', 'moved');
+        $upload->getStream();
+    }
+
+    public function nonOkErrorStatus()
+    {
+        return [
+            'UPLOAD_ERR_INI_SIZE'   => [ UPLOAD_ERR_INI_SIZE ],
+            'UPLOAD_ERR_FORM_SIZE'  => [ UPLOAD_ERR_FORM_SIZE ],
+            'UPLOAD_ERR_PARTIAL'    => [ UPLOAD_ERR_PARTIAL ],
+            'UPLOAD_ERR_NO_FILE'    => [ UPLOAD_ERR_NO_FILE ],
+            'UPLOAD_ERR_NO_TMP_DIR' => [ UPLOAD_ERR_NO_TMP_DIR ],
+            'UPLOAD_ERR_CANT_WRITE' => [ UPLOAD_ERR_CANT_WRITE ],
+            'UPLOAD_ERR_EXTENSION'  => [ UPLOAD_ERR_EXTENSION ],
+        ];
+    }
+
+    /**
+     * @dataProvider nonOkErrorStatus
+     */
+    public function testConstructorDoesNotRaiseExceptionForInvalidStreamWhenErrorStatusPresent($status)
+    {
+        $uploadedFile = new UploadedFile('not ok', 0, $status);
+        $this->assertSame($status, $uploadedFile->getError());
+    }
+
+    /**
+     * @dataProvider nonOkErrorStatus
+     */
+    public function testMoveToRaisesExceptionWhenErrorStatusPresent($status)
+    {
+        $uploadedFile = new UploadedFile('not ok', 0, $status);
+        $this->setExpectedException('RuntimeException', 'upload error');
+        $uploadedFile->moveTo(__DIR__ . '/' . uniqid());
+    }
+
+    /**
+     * @dataProvider nonOkErrorStatus
+     */
+    public function testGetStreamRaisesExceptionWhenErrorStatusPresent($status)
+    {
+        $uploadedFile = new UploadedFile('not ok', 0, $status);
+        $this->setExpectedException('RuntimeException', 'upload error');
+        $stream = $uploadedFile->getStream();
+    }
+
+    public function testMoveToCreatesStreamIfOnlyAFilenameWasProvided()
+    {
+        $this->cleanup[] = $from = tempnam(sys_get_temp_dir(), 'copy_from');
+        $this->cleanup[] = $to = tempnam(sys_get_temp_dir(), 'copy_to');
+
+        copy(__FILE__, $from);
+
+        $uploadedFile = new UploadedFile($from, 100, UPLOAD_ERR_OK, basename($from), 'text/plain');
+        $uploadedFile->moveTo($to);
+
+        $this->assertFileEquals(__FILE__, $to);
+    }
+}


### PR DESCRIPTION
This is an implementation of ServerRequest and UploadedFIle and closes https://github.com/guzzle/psr7/issues/13.

I realize there is already a PR for that (https://github.com/guzzle/psr7/pull/32) but it seams sort-of abandoned. I was waiting on that functionality as I need it in one of my projects, so seeing this PR stagnate I decided to reimplement it myself. 
It has almost full test coverage, the $\_FILES array conversion handles more cases, the moveTo method is according to spec and I try to use the already available functionality as much as possible

Merry Christmas :christmas_tree: :)