### PR TITLE
Added rewind to Stream::getContents();

### DIFF
--- a/src/Stream.php
+++ b/src/Stream.php
@@ -99,6 +99,8 @@ class Stream implements StreamInterface
 
     public function getContents()
     {
+        $this->rewind();
+        
         $contents = stream_get_contents($this->stream);
 
         if ($contents === false) {


### PR DESCRIPTION
Hello, I added rewind to Stream::getContents() because the idea of getContents to get all content, but if you write content to it will not be visible in getContents() because of pointer position.