### PR TITLE
added missing port to the Host when non-standard

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -209,6 +209,14 @@ function modify_request(RequestInterface $request, array $changes)
         // Remove the host header if one is on the URI
         if ($host = $changes['uri']->getHost()) {
             $changes['set_headers']['Host'] = $host;
+
+            if ($port = $changes['uri']->getPort()) {
+                $standardPorts = ['http' => 80, 'https' => 443];
+                $scheme = $changes['uri']->getScheme();
+                if (isset($standardPorts[$scheme]) && $port != $standardPorts[$scheme]) {
+                    $changes['set_headers']['Host'] .= ':'.$port;
+                }
+            }
         }
         $uri = $changes['uri'];
     }

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -546,6 +546,16 @@ class FunctionsTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('www.foo.com', (string) $r2->getHeaderLine('host'));
     }
 
+    public function testCanModifyRequestWithUriAndPort()
+    {
+        $r1 = new Psr7\Request('GET', 'http://foo.com:8000');
+        $r2 = Psr7\modify_request($r1, [
+            'uri' => new Psr7\Uri('http://www.foo.com:8000')
+        ]);
+        $this->assertEquals('http://www.foo.com:8000', (string) $r2->getUri());
+        $this->assertEquals('www.foo.com:8000', (string) $r2->getHeaderLine('host'));
+    }
+
     public function testCanModifyRequestWithCaseInsensitiveHeader()
     {
         $r1 = new Psr7\Request('GET', 'http://foo.com', ['User-Agent' => 'foo']);


### PR DESCRIPTION
The `Host` HTTP header must contain the HTTP port when it is not standard. Without this patch, Guzzle fails to follow redirect properly when the URI uses a non-standard port.
