### PR TITLE
Handle gzip format with a FNAME header

### DIFF
--- a/src/InflateStream.php
+++ b/src/InflateStream.php
@@ -20,10 +20,35 @@ class InflateStream implements StreamInterface
 
     public function __construct(StreamInterface $stream)
     {
-        // Skip the first 10 bytes
-        $stream = new LimitStream($stream, -1, 10);
+        // read the first 10 bytes, ie. gzip header
+        $header = $stream->read(10);
+        $filename_header_length = $this->getLengthOfPossibleFilenameHeader($stream, $header);
+        // Skip the header, that is 10 + length of filename + 1 (nil) bytes
+        $stream = new LimitStream($stream, -1, 10 + $filename_header_length);
         $resource = StreamWrapper::getResource($stream);
         stream_filter_append($resource, 'zlib.inflate', STREAM_FILTER_READ);
         $this->stream = new Stream($resource);
+    }
+
+    /**
+     * @param StreamInterface $stream
+     * @param $header
+     * @return int
+     */
+    protected function getLengthOfPossibleFilenameHeader(StreamInterface $stream, $header)
+    {
+        $filename_header_length = 0;
+
+        if( substr(bin2hex($header), 6, 2) === '08' )
+        {
+            // we have a filename, read until nil
+            $filename_header_length = 1;
+            while( $stream->read(1) !== chr(0) )
+            {
+                $filename_header_length++;
+            }
+        }
+
+        return $filename_header_length;
     }
 }

--- a/src/InflateStream.php
+++ b/src/InflateStream.php
@@ -22,9 +22,9 @@ class InflateStream implements StreamInterface
     {
         // read the first 10 bytes, ie. gzip header
         $header = $stream->read(10);
-        $filename_header_length = $this->getLengthOfPossibleFilenameHeader($stream, $header);
+        $filenameHeaderLength = $this->getLengthOfPossibleFilenameHeader($stream, $header);
         // Skip the header, that is 10 + length of filename + 1 (nil) bytes
-        $stream = new LimitStream($stream, -1, 10 + $filename_header_length);
+        $stream = new LimitStream($stream, -1, 10 + $filenameHeaderLength);
         $resource = StreamWrapper::getResource($stream);
         stream_filter_append($resource, 'zlib.inflate', STREAM_FILTER_READ);
         $this->stream = new Stream($resource);
@@ -35,16 +35,14 @@ class InflateStream implements StreamInterface
      * @param $header
      * @return int
      */
-    protected function getLengthOfPossibleFilenameHeader(StreamInterface $stream, $header)
+    private function getLengthOfPossibleFilenameHeader(StreamInterface $stream, $header)
     {
         $filename_header_length = 0;
 
-        if( substr(bin2hex($header), 6, 2) === '08' )
-        {
+        if (substr(bin2hex($header), 6, 2) === '08') {
             // we have a filename, read until nil
             $filename_header_length = 1;
-            while( $stream->read(1) !== chr(0) )
-            {
+            while ($stream->read(1) !== chr(0)) {
                 $filename_header_length++;
             }
         }

--- a/tests/InflateStreamTest.php
+++ b/tests/InflateStreamTest.php
@@ -13,4 +13,27 @@ class InflateStreamtest extends \PHPUnit_Framework_TestCase
         $b = new InflateStream($a);
         $this->assertEquals('test', (string) $b);
     }
+
+    public function testInflatesStreamsWithFilename()
+    {
+        $content = $this->getGzipStringWithFilename('test');
+        $a = Psr7\stream_for($content);
+        $b = new InflateStream($a);
+        $this->assertEquals('test', (string) $b);
+    }
+
+    private function getGzipStringWithFilename($original_string)
+    {
+        $gzipped = bin2hex(gzencode($original_string));
+
+        $header = substr($gzipped, 0, 20);
+        // set FNAME flag
+        $header[6]=0;
+        $header[7]=8;
+        // make a dummy filename
+        $filename = "64756d6d7900";
+        $rest = substr($gzipped, 20);
+
+        return hex2bin($header . $filename . $rest);
+    }
 }


### PR DESCRIPTION
A gzip file can have the original filename in the header. This pull request makes the InflateStream handle those cases, too.