### PR TITLE
additional test case for Uri resolving

### DIFF
--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -154,7 +154,7 @@ class UriTest extends \PHPUnit_Framework_TestCase
             [self::RFC3986_BASE, 'g;x=1/../y',    'http://a/b/c/y'],
             ['http://u@a/b/c/d;p?q', '.',         'http://u@a/b/c/'],
             ['http://u:p@a/b/c/d;p?q', '.',       'http://u:p@a/b/c/'],
-            //[self::RFC3986_BASE, 'http:g',        'http:g'],
+            ['http://a/b/c/d/', 'e',              'http://a/b/c/d/e'],
         ];
     }
 


### PR DESCRIPTION
This test case explains how to use library if you want to set 'base_url' with part of the path (e.g. http://foo.bar/api/) in the Client and append another part of the path (e.g. user/profile) in the Message thus to obtain request to full url (e.g. http://foo.bar/api/user/profile) with no replacements