### PR TITLE
Remove use of late static binding against private members in Uri.

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -174,7 +174,7 @@ class Uri implements UriInterface
             $parts['fragment'] = $relParts['fragment'];
         }
 
-        return new self(static::createUriString(
+        return new self(self::createUriString(
             $parts['scheme'],
             $parts['authority'],
             $parts['path'],
@@ -528,7 +528,7 @@ class Uri implements UriInterface
             return false;
         }
 
-        return !isset(static::$schemes[$scheme]) || $port !== static::$schemes[$scheme];
+        return !isset(self::$schemes[$scheme]) || $port !== self::$schemes[$scheme];
     }
 
     /**

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -290,7 +290,7 @@ class UriTest extends \PHPUnit_Framework_TestCase
         //  should not use late static binding to access private static members.
         // If they do, this will fatal.
         $this->assertInstanceOf(
-            \GuzzleHttp\Tests\Psr7\ExtendingClassTest::class,
+            '\GuzzleHttp\Tests\Psr7\ExtendingClassTest',
             new ExtendingClassTest('http://h:9/')
         );
     }

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -278,4 +278,20 @@ class UriTest extends \PHPUnit_Framework_TestCase
         $input = 'urn://example:animal:ferret:nose';
         $uri = new Uri($input);
     }
+
+    public function testExtendingClassesInstantiates()
+    {
+        eval('
+            namespace GuzzleHttp\Tests\Psr7;
+            use \GuzzleHttp\Psr7\Uri;
+            class ExtendingClassTest extends Uri {}
+        ');
+        // The non-standard port triggers a cascade of private methods which
+        //  should not use late static binding to access private static members.
+        // If they do, this will fatal.
+        $this->assertInstanceOf(
+            \GuzzleHttp\Tests\Psr7\ExtendingClassTest::class,
+            new ExtendingClassTest('http://h:9/')
+        );
+    }
 }

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -281,11 +281,6 @@ class UriTest extends \PHPUnit_Framework_TestCase
 
     public function testExtendingClassesInstantiates()
     {
-        eval('
-            namespace GuzzleHttp\Tests\Psr7;
-            use \GuzzleHttp\Psr7\Uri;
-            class ExtendingClassTest extends Uri {}
-        ');
         // The non-standard port triggers a cascade of private methods which
         //  should not use late static binding to access private static members.
         // If they do, this will fatal.
@@ -294,4 +289,8 @@ class UriTest extends \PHPUnit_Framework_TestCase
             new ExtendingClassTest('http://h:9/')
         );
     }
+}
+
+class ExtendingClassTest extends \GuzzleHttp\Psr7\Uri
+{
 }


### PR DESCRIPTION
As much as it seems these implementations really don't want to be friendly to extension, this change stands on its own as being more accurate with regards to using the `static` keyword. That being, there is no reason to use the `static` keyword when referring to private members.

For the situation in which `Uri` is extended, there is a fatal that can occur when a non-standard port is provided due to the `static` keyword attempting to access the private property `$schemes` in `Uri::isNonStandardPort()`.

Stack trace:
> PHP  15. GuzzleHttp\Psr7\Uri->__construct() ...extension...
> PHP  16. GuzzleHttp\Psr7\Uri->applyParts() ...guzzlehttp/psr7/src/Uri.php:54
> PHP  17. GuzzleHttp\Psr7\Uri->filterPort() ...guzzlehttp/psr7/src/Uri.php:449
> PHP  18. GuzzleHttp\Psr7\Uri::isNonStandardPort() ...guzzlehttp/psr7/src/Uri.php:567

Reproduction script:
```php
<?php
require __DIR__ . '/vendor/autoload.php';
use \GuzzleHttp\Psr7\Uri;
class Foo extends Uri {}
new Foo('scheme://h:9/');
// PHP Fatal error:  Cannot access  property Foo::$schemes in ...src/Uri.php on line 531
```
In regards to extending `Uri`, is there a good reason everything is private? Private visibility is unnecessarily limiting, and if you really don't want folks extending these classes, just drop `final` on them too. That makes the intention very clear. If y'all are willing, I'd be glad to provide a PR that s/private/protected/ :)