### PR TITLE
Added support for request methods that contain something other that just letters

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -449,7 +449,7 @@ function parse_request($message)
 {
     $data = _parse_message($message);
     $matches = [];
-    if (!preg_match('/^[a-zA-Z]+\s+([a-zA-Z]+:\/\/|\/).*/', $data['start-line'], $matches)) {
+    if (!preg_match('/^[\S]+\s+([a-zA-Z]+:\/\/|\/).*/', $data['start-line'], $matches)) {
         throw new \InvalidArgumentException('Invalid request string');
     }
     $parts = explode(' ', $data['start-line'], 3);

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -282,6 +282,13 @@ class FunctionsTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('https://www.google.com/search?q=foobar', (string) $request->getUri());
     }
 
+    public function testParsesRequestMessagesWithCustomMethod()
+    {
+        $req = "GET_DATA / HTTP/1.1\r\nFoo: Bar\r\nHost: foo.com\r\n\r\n";
+        $request = Psr7\parse_request($req);
+        $this->assertEquals('GET_DATA', $request->getMethod());
+    }
+
     /**
      * @expectedException \InvalidArgumentException
      */


### PR DESCRIPTION
I haven't found any particular limitation in spec that doesn't allow using `_` as an example in request method.
Browsers and web servers (Nginx and Apache2 at least) all work fine with such methods, so we need to support it here as well.