### PR TITLE
Fix URI parts when '0' and assembly according to PSR-7

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -46,7 +46,7 @@ class Uri implements UriInterface
      */
     public function __construct($uri = '')
     {
-        if ($uri != null) {
+        if ($uri != '') {
             $parts = parse_url($uri);
             if ($parts === false) {
                 throw new \InvalidArgumentException("Unable to parse URI: $uri");
@@ -119,7 +119,7 @@ class Uri implements UriInterface
      */
     public static function resolve(UriInterface $base, $rel)
     {
-        if ($rel === null || $rel === '') {
+        if ($rel == '') {
             return $base;
         }
 
@@ -148,18 +148,18 @@ class Uri implements UriInterface
             'fragment'  => $base->getFragment()
         ];
 
-        if (!empty($relParts['authority'])) {
+        if ($relParts['authority'] != '') {
             $parts['authority'] = $relParts['authority'];
             $parts['path'] = self::removeDotSegments($relParts['path']);
             $parts['query'] = $relParts['query'];
             $parts['fragment'] = $relParts['fragment'];
-        } elseif (!empty($relParts['path'])) {
+        } elseif ($relParts['path'] != '') {
             if (substr($relParts['path'], 0, 1) == '/') {
                 $parts['path'] = self::removeDotSegments($relParts['path']);
                 $parts['query'] = $relParts['query'];
                 $parts['fragment'] = $relParts['fragment'];
             } else {
-                if (!empty($parts['authority']) && empty($parts['path'])) {
+                if ($parts['authority'] != '' && $parts['path'] == '') {
                     $mergedPath = '/';
                 } else {
                     $mergedPath = substr($parts['path'], 0, strrpos($parts['path'], '/') + 1);
@@ -168,9 +168,9 @@ class Uri implements UriInterface
                 $parts['query'] = $relParts['query'];
                 $parts['fragment'] = $relParts['fragment'];
             }
-        } elseif (!empty($relParts['query'])) {
+        } elseif ($relParts['query'] != '') {
             $parts['query'] = $relParts['query'];
-        } elseif ($relParts['fragment'] != null) {
+        } elseif ($relParts['fragment'] != '') {
             $parts['fragment'] = $relParts['fragment'];
         }
 
@@ -199,7 +199,7 @@ class Uri implements UriInterface
     public static function withoutQueryValue(UriInterface $uri, $key)
     {
         $current = $uri->getQuery();
-        if (!$current) {
+        if ($current == '') {
             return $uri;
         }
 
@@ -232,7 +232,7 @@ class Uri implements UriInterface
         $current = $uri->getQuery();
         $key = strtr($key, self::$replaceQuery);
 
-        if (!$current) {
+        if ($current == '') {
             $result = [];
         } else {
             $result = [];
@@ -273,12 +273,12 @@ class Uri implements UriInterface
 
     public function getAuthority()
     {
-        if (empty($this->host)) {
+        if ($this->host == '') {
             return '';
         }
 
         $authority = $this->host;
-        if (!empty($this->userInfo)) {
+        if ($this->userInfo != '') {
             $authority = $this->userInfo . '@' . $authority;
         }
 
@@ -306,7 +306,7 @@ class Uri implements UriInterface
 
     public function getPath()
     {
-        return $this->path == null ? '' : $this->path;
+        return $this->path;
     }
 
     public function getQuery()
@@ -336,7 +336,7 @@ class Uri implements UriInterface
     public function withUserInfo($user, $password = null)
     {
         $info = $user;
-        if ($password) {
+        if ($password != '') {
             $info .= ':' . $password;
         }
 
@@ -436,7 +436,7 @@ class Uri implements UriInterface
     /**
      * Apply parse_url parts to a URI.
      *
-     * @param $parts Array of parse_url parts to apply.
+     * @param array $parts Array of parse_url parts to apply.
      */
     private function applyParts(array $parts)
     {
@@ -445,7 +445,7 @@ class Uri implements UriInterface
             : '';
         $this->userInfo = isset($parts['user']) ? $parts['user'] : '';
         $this->host = isset($parts['host']) ? $parts['host'] : '';
-        $this->port = !empty($parts['port'])
+        $this->port = isset($parts['port'])
             ? $this->filterPort($this->scheme, $this->host, $parts['port'])
             : null;
         $this->path = isset($parts['path'])
@@ -476,34 +476,36 @@ class Uri implements UriInterface
     {
         $uri = '';
 
-        if (!empty($scheme)) {
+        if ($scheme != '') {
             $uri .= $scheme . ':';
         }
 
-        $hierPart = '';
-
-        if (!empty($authority)) {
-            if (!empty($scheme)) {
-                $hierPart .= '//';
-            }
-            $hierPart .= $authority;
+        if ($authority != '') {
+            $uri .= '//' . $authority;
         }
 
-        if ($path != null) {
-            // Add a leading slash if necessary.
-            if ($hierPart && substr($path, 0, 1) !== '/') {
-                $hierPart .= '/';
+        if ($path != '') {
+            if ($path[0] !== '/') {
+                if ($authority != '') {
+                    // If the path is rootless and an authority is present, the path MUST be prefixed by "/"
+                    $path = '/' . $path;
+                }
+            } elseif (isset($path[1]) && $path[1] === '/') {
+                if ($authority == '') {
+                    // If the path is starting with more than one "/" and no authority is present, the
+                    // starting slashes MUST be reduced to one.
+                    $path = '/' . ltrim($path, '/');
+                }
             }
-            $hierPart .= $path;
+
+            $uri .= $path;
         }
 
-        $uri .= $hierPart;
-
-        if ($query != null) {
+        if ($query != '') {
             $uri .= '?' . $query;
         }
 
-        if ($fragment != null) {
+        if ($fragment != '') {
             $uri .= '#' . $fragment;
         }
 
@@ -570,7 +572,7 @@ class Uri implements UriInterface
     /**
      * Filters the path of a URI
      *
-     * @param $path
+     * @param string $path
      *
      * @return string
      */
@@ -586,7 +588,7 @@ class Uri implements UriInterface
     /**
      * Filters the query string or fragment of a URI.
      *
-     * @param $str
+     * @param string $str
      *
      * @return string
      */

--- a/src/functions.php
+++ b/src/functions.php
@@ -446,7 +446,7 @@ function readline(StreamInterface $stream, $maxLength = null)
         }
         $buffer .= $byte;
         // Break when a new line is found or the max length - 1 is reached
-        if ($byte == PHP_EOL || ++$size == $maxLength - 1) {
+        if ($byte === "\n" || ++$size === $maxLength - 1) {
             break;
         }
     }

--- a/tests/StreamWrapperTest.php
+++ b/tests/StreamWrapperTest.php
@@ -21,6 +21,8 @@ class StreamWrapperTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('', fread($handle, 1));
         $this->assertTrue(feof($handle));
 
+        $stBlksize  = defined('PHP_WINDOWS_VERSION_BUILD') ? -1 : 0;
+
         // This fails on HHVM for some reason
         if (!defined('HHVM_VERSION')) {
             $this->assertEquals([
@@ -35,8 +37,8 @@ class StreamWrapperTest extends \PHPUnit_Framework_TestCase
                 'atime'   => 0,
                 'mtime'   => 0,
                 'ctime'   => 0,
-                'blksize' => 0,
-                'blocks'  => 0,
+                'blksize' => $stBlksize,
+                'blocks'  => $stBlksize,
                 0         => 0,
                 1         => 0,
                 2         => 33206,
@@ -48,8 +50,8 @@ class StreamWrapperTest extends \PHPUnit_Framework_TestCase
                 8         => 0,
                 9         => 0,
                 10        => 0,
-                11        => 0,
-                12        => 0,
+                11        => $stBlksize,
+                12        => $stBlksize,
             ], fstat($handle));
         }
 

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -315,10 +315,10 @@ class UriTest extends \PHPUnit_Framework_TestCase
 
     public function testPortCanBeRemoved()
     {
-        $uri = (new Uri('//example.com:8080'))->withPort(null);
+        $uri = (new Uri('http://example.com:8080'))->withPort(null);
 
         $this->assertNull($uri->getPort());
-        $this->assertSame('//example.com', (string) $uri);
+        $this->assertSame('http://example.com', (string) $uri);
     }
 
     public function testAuthorityWithUserInfoButWithoutHost()


### PR DESCRIPTION
1. All occurences of `empty($this->password)` or `if ($this-password)` are broken because it will not correctly work with `'0'` string which is regarded as empty in PHP
2. Fix `Uri::__toString` according to PSR-7/RFC-3986
3. Refactor port handling
4. Improve tests
5. fix tests under windows