### PR TITLE
Remove message about partial implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # PSR-7 Message Implementation
 
-This repository contains a partial [PSR-7](http://www.php-fig.org/psr/psr-7/)
+This repository contains a full [PSR-7](http://www.php-fig.org/psr/psr-7/)
 message implementation, several stream decorators, and some helpful
-functionality like query string parsing.  Currently missing
-ServerRequestInterface and UploadedFileInterface; a pull request for these features is welcome.
+functionality like query string parsing.
 
 
 [![Build Status](https://travis-ci.org/guzzle/psr7.svg?branch=master)](https://travis-ci.org/guzzle/psr7)


### PR DESCRIPTION
This was added in 1.3 right? So bit confusing when reading the readme :)

Also, docs for those functions should still be added.