### PR TITLE
Fix handling of encoding in Uri::with(out)QueryValue

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,7 +500,7 @@ an associative array (e.g., `foo[a]=1&foo[b]=2` will be parsed into
 
 Build a query string from an array of key value pairs.
 
-This function can use the return value of parseQuery() to build a query string.
+This function can use the return value of parse_query() to build a query string.
 This function does not modify the provided keys when an array is encountered
 (like http_build_query would).
 
@@ -551,8 +551,6 @@ Create a new URI with a specific query string value.
 Any existing query string values that exactly match the provided key are
 removed and replaced with the given key value pair.
 
-Note: this function will convert "=" to "%3D" and "&" to "%26".
-
 
 ## `GuzzleHttp\Psr7\Uri::withoutQueryValue`
 
@@ -562,8 +560,6 @@ Create a new URI with a specific query string value removed.
 
 Any existing query string values that exactly match the provided key are
 removed.
-
-Note: this function will convert "=" to "%3D" and "&" to "%26".
 
 
 ## `GuzzleHttp\Psr7\Uri::fromParts`

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ echo $stream; // 0123456789
 
 Compose stream implementations based on a hash of functions.
 
-Allows for easy testing and extension of a provided stream without needing 
+Allows for easy testing and extension of a provided stream without needing
 to create a concrete class for a simple extension point.
 
 ```php
@@ -526,7 +526,7 @@ The `GuzzleHttp\Psr7\Uri` class has several static methods to manipulate URIs.
 
 ## `GuzzleHttp\Psr7\Uri::removeDotSegments`
 
-`public static function removeDotSegments($path) -> UriInterface`
+`public static function removeDotSegments(string $path): string`
 
 Removes dot segments from a path and returns the new path.
 
@@ -535,7 +535,7 @@ See http://tools.ietf.org/html/rfc3986#section-5.2.4
 
 ## `GuzzleHttp\Psr7\Uri::resolve`
 
-`public static function resolve(UriInterface $base, $rel) -> UriInterface`
+`public static function resolve(UriInterface $base, $rel): UriInterface`
 
 Resolve a base URI with a relative URI and return a new URI.
 
@@ -544,7 +544,7 @@ See http://tools.ietf.org/html/rfc3986#section-5
 
 ## `GuzzleHttp\Psr7\Uri::withQueryValue`
 
-`public static function withQueryValue(UriInterface $uri, $key, $value) -> UriInterface`
+`public static function withQueryValue(UriInterface $uri, $key, $value): UriInterface`
 
 Create a new URI with a specific query string value.
 
@@ -556,7 +556,7 @@ Note: this function will convert "=" to "%3D" and "&" to "%26".
 
 ## `GuzzleHttp\Psr7\Uri::withoutQueryValue`
 
-`public static function withoutQueryValue(UriInterface $uri, $key, $value) -> UriInterface`
+`public static function withoutQueryValue(UriInterface $uri, $key): UriInterface`
 
 Create a new URI with a specific query string value removed.
 
@@ -568,6 +568,6 @@ Note: this function will convert "=" to "%3D" and "&" to "%26".
 
 ## `GuzzleHttp\Psr7\Uri::fromParts`
 
-`public static function fromParts(array $parts) -> UriInterface`
+`public static function fromParts(array $parts): UriInterface`
 
 Create a `GuzzleHttp\Psr7\Uri` object from a hash of `parse_url` parts.

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -178,10 +178,8 @@ class Uri implements UriInterface
      * Any existing query string values that exactly match the provided key are
      * removed.
      *
-     * Note: this function will convert "=" to "%3D" and "&" to "%26".
-     *
      * @param UriInterface $uri URI to use as a base.
-     * @param string       $key Query string key value pair to remove.
+     * @param string       $key Query string key to remove.
      *
      * @return UriInterface
      */
@@ -192,9 +190,10 @@ class Uri implements UriInterface
             return $uri;
         }
 
+        $decodedKey = rawurldecode($key);
         $result = [];
         foreach (explode('&', $current) as $part) {
-            if (explode('=', $part)[0] !== $key) {
+            if (rawurldecode(explode('=', $part)[0]) !== $decodedKey) {
                 $result[] = $part;
             };
         }
@@ -208,17 +207,22 @@ class Uri implements UriInterface
      * Any existing query string values that exactly match the provided key are
      * removed and replaced with the given key value pair.
      *
-     * Note: this function will convert "=" to "%3D" and "&" to "%26".
+     * A value of null will set the query string key without a value, e.g. "key"
+     * instead of "key=value".
      *
-     * @param UriInterface $uri URI to use as a base.
-     * @param string $key   Key to set.
-     * @param string $value Value to set.
+     * @param UriInterface $uri   URI to use as a base.
+     * @param string       $key   Key to set.
+     * @param string|null  $value Value to set
      *
      * @return UriInterface
      */
     public static function withQueryValue(UriInterface $uri, $key, $value)
     {
         $current = $uri->getQuery();
+        $decodedKey = rawurldecode($key);
+        // Query string separators ("=", "&") within the key or value need to be encoded
+        // (while preventing double-encoding) before setting the query string. All other
+        // chars that need percent-encoding will be encoded by withQuery().
         $key = strtr($key, self::$replaceQuery);
 
         if ($current == '') {
@@ -226,7 +230,7 @@ class Uri implements UriInterface
         } else {
             $result = [];
             foreach (explode('&', $current) as $part) {
-                if (explode('=', $part)[0] !== $key) {
+                if (rawurldecode(explode('=', $part)[0]) !== $decodedKey) {
                     $result[] = $part;
                 };
             }

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -191,12 +191,9 @@ class Uri implements UriInterface
         }
 
         $decodedKey = rawurldecode($key);
-        $result = [];
-        foreach (explode('&', $current) as $part) {
-            if (rawurldecode(explode('=', $part)[0]) !== $decodedKey) {
-                $result[] = $part;
-            };
-        }
+        $result = array_filter(explode('&', $current), function ($part) use ($decodedKey) {
+            return rawurldecode(explode('=', $part)[0]) !== $decodedKey;
+        });
 
         return $uri->withQuery(implode('&', $result));
     }
@@ -219,22 +216,20 @@ class Uri implements UriInterface
     public static function withQueryValue(UriInterface $uri, $key, $value)
     {
         $current = $uri->getQuery();
-        $decodedKey = rawurldecode($key);
-        // Query string separators ("=", "&") within the key or value need to be encoded
-        // (while preventing double-encoding) before setting the query string. All other
-        // chars that need percent-encoding will be encoded by withQuery().
-        $key = strtr($key, self::$replaceQuery);
 
         if ($current == '') {
             $result = [];
         } else {
-            $result = [];
-            foreach (explode('&', $current) as $part) {
-                if (rawurldecode(explode('=', $part)[0]) !== $decodedKey) {
-                    $result[] = $part;
-                };
-            }
+            $decodedKey = rawurldecode($key);
+            $result = array_filter(explode('&', $current), function ($part) use ($decodedKey) {
+                return rawurldecode(explode('=', $part)[0]) !== $decodedKey;
+            });
         }
+
+        // Query string separators ("=", "&") within the key or value need to be encoded
+        // (while preventing double-encoding) before setting the query string. All other
+        // chars that need percent-encoding will be encoded by withQuery().
+        $key = strtr($key, self::$replaceQuery);
 
         if ($value !== null) {
             $result[] = $key . '=' . strtr($value, self::$replaceQuery);

--- a/src/functions.php
+++ b/src/functions.php
@@ -559,7 +559,7 @@ function parse_query($str, $urlEncoding = true)
 /**
  * Build a query string from an array of key value pairs.
  *
- * This function can use the return value of parseQuery() to build a query
+ * This function can use the return value of parse_query() to build a query
  * string. This function does not modify the provided keys when an array is
  * encountered (like http_build_query would).
  *
@@ -577,9 +577,9 @@ function build_query(array $params, $encoding = PHP_QUERY_RFC3986)
 
     if ($encoding === false) {
         $encoder = function ($str) { return $str; };
-    } elseif ($encoding == PHP_QUERY_RFC3986) {
+    } elseif ($encoding === PHP_QUERY_RFC3986) {
         $encoder = 'rawurlencode';
-    } elseif ($encoding == PHP_QUERY_RFC1738) {
+    } elseif ($encoding === PHP_QUERY_RFC1738) {
         $encoder = 'urlencode';
     } else {
         throw new \InvalidArgumentException('Invalid type');

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -301,8 +301,31 @@ class UriTest extends \PHPUnit_Framework_TestCase
         $uri = Uri::withoutQueryValue($uri, 'e');
         $this->assertSame('a=b', $uri->getQuery());
         $uri = Uri::withoutQueryValue($uri, 'a');
-        $uri = Uri::withoutQueryValue($uri, 'a');
         $this->assertSame('', $uri->getQuery());
+    }
+
+    public function testWithQueryValueReplacesSameKeys()
+    {
+        $uri = new Uri();
+        $uri = Uri::withQueryValue($uri, 'a', 'b');
+        $uri = Uri::withQueryValue($uri, 'c', 'd');
+        $uri = Uri::withQueryValue($uri, 'a', 'e');
+        $this->assertSame('c=d&a=e', $uri->getQuery());
+    }
+
+    public function testWithoutQueryValueRemovesAllSameKeys()
+    {
+        $uri = (new Uri())->withQuery('a=b&c=d&a=e');
+        $uri = Uri::withoutQueryValue($uri, 'a');
+        $this->assertSame('c=d', $uri->getQuery());
+    }
+
+    public function testRemoveNonExistingQueryValue()
+    {
+        $uri = new Uri();
+        $uri = Uri::withQueryValue($uri, 'a', 'b');
+        $uri = Uri::withoutQueryValue($uri, 'c');
+        $this->assertSame('a=b', $uri->getQuery());
     }
 
     public function testSchemeIsNormalizedToLowercase()


### PR DESCRIPTION
This way you can pass they key/value both in encoded as well as decoded form to those methods.
This is consistent with `withPath`, `withQuery` etc.

Before it was handling a mix of it. It would encode the delimiters but not other chars. So it would not correctly identify existing query params to replace/remove. See tests.

Also fixes some docs in the readme.