### PR TITLE
Fix parse response header status without description

### DIFF
--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -3,8 +3,6 @@ namespace GuzzleHttp\Psr7;
 
 use Psr\Http\Message\StreamInterface;
 
-require_once __DIR__.'/functions.php';
-
 /**
  * Trait implementing functionality common to requests and responses.
  */

--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -3,6 +3,8 @@ namespace GuzzleHttp\Psr7;
 
 use Psr\Http\Message\StreamInterface;
 
+require_once __DIR__.'/functions.php';
+
 /**
  * Trait implementing functionality common to requests and responses.
  */

--- a/src/functions.php
+++ b/src/functions.php
@@ -492,7 +492,7 @@ function parse_request($message)
 function parse_response($message)
 {
     $data = _parse_message($message);
-    if (!preg_match('/^HTTP\/.* [0-9]{3} .*/', $data['start-line'])) {
+    if (!preg_match('/^HTTP\/.* [0-9]{3}( .*|$)/', $data['start-line'])) {
         throw new \InvalidArgumentException('Invalid response string');
     }
     $parts = explode(' ', $data['start-line'], 3);

--- a/src/functions.php
+++ b/src/functions.php
@@ -8,8 +8,6 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
 
-require_once __DIR__.'/functions.php';
-
 /**
  * Returns the string representation of an HTTP message.
  *

--- a/src/functions.php
+++ b/src/functions.php
@@ -8,6 +8,8 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
 
+require_once __DIR__.'/functions.php';
+
 /**
  * Returns the string representation of an HTTP message.
  *


### PR DESCRIPTION
Fix parse response header in case something like this:
HTTP/1.1 404
Date: Mon, 20 Jun 2016 17:34:12 GMT
Content-Type: text/html
Content-Length: 193
Connection: close
Server: IdeaWebServer/v0.80
