### PR TITLE
No longer reading maxLen all into memory when copying stream

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -371,26 +371,25 @@ function copy_to_stream(
     StreamInterface $dest,
     $maxLen = -1
 ) {
+    $bufferSize = 8192;
+
     if ($maxLen === -1) {
         while (!$source->eof()) {
-            if (!$dest->write($source->read(1048576))) {
+            if (!$dest->write($source->read($bufferSize))) {
                 break;
             }
         }
-        return;
-    }
-
-    $bufferSize = 8192;
-    $remaining = $maxLen;
-
-    while ($remaining > 0 && !$source->eof()) {
-        $buf = $source->read(min($bufferSize, $remaining));
-        $len = strlen($buf);
-        if (!$len) {
-            break;
+    } else {
+        $remaining = $maxLen;
+        while ($remaining > 0 && !$source->eof()) {
+            $buf = $source->read(min($bufferSize, $remaining));
+            $len = strlen($buf);
+            if (!$len) {
+                break;
+            }
+            $remaining -= $len;
+            $dest->write($buf);
         }
-        $remaining -= $len;
-        $dest->write($buf);
     }
 }
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -380,17 +380,17 @@ function copy_to_stream(
         return;
     }
 
-    $bytes = 0;
-    while (!$source->eof()) {
-        $buf = $source->read($maxLen - $bytes);
-        if (!($len = strlen($buf))) {
+    $bufferSize = 8192;
+    $remaining = $maxLen;
+
+    while ($remaining > 0 && !$source->eof()) {
+        $buf = $source->read(min($bufferSize, $remaining));
+        $len = strlen($buf);
+        if (!$len) {
             break;
         }
-        $bytes += $len;
+        $remaining -= $len;
         $dest->write($buf);
-        if ($bytes == $maxLen) {
-            break;
-        }
     }
 }
 


### PR DESCRIPTION
@Tobion 

By the way, I'm getting this test failure when running the tests locally on my PHP 7.0.3:

```
1) GuzzleHttp\Tests\Psr7\UriTest::testUriComponentsGetEncodedProperly with data set #1 ('/€?€#€', '/%E2%82%AC', '%E2%82%AC', '%E2%82%AC', '/%E2%82%AC?%E2%82%AC#%E2%82%AC')
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-/%E2%82%AC
+/%E2_%AC

/Users/dowling/projects/guzzle/psr7/tests/UriTest.php:473
```