### PR TITLE
Fix BC with array as request body

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -49,7 +49,7 @@ class Request implements RequestInterface
             $this->updateHostFromUri();
         }
 
-        if ($body !== '' && $body !== null) {
+        if ($body !== '' && $body !== null && $body !== []) {
             $this->stream = stream_for($body);
         }
     }

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -44,6 +44,13 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Psr\Http\Message\StreamInterface', $r->getBody());
         $this->assertSame('', (string) $r->getBody());
     }
+    
+    public function testEmptyArrayBody()
+    {
+        $r = new Request('GET', '/', [], []);
+        $this->assertInstanceOf('Psr\Http\Message\StreamInterface', $r->getBody());
+        $this->assertSame('', (string) $r->getBody());
+    }
 
     public function testFalseyBody()
     {


### PR DESCRIPTION
refs #95 

The change from `if ($body)` to `if ($body !== '' && $body !== null) {` breaks BC if someone (like me) hands over an empty array as request body. This PR restores BC.

