### PR TITLE
Add ByteCountingStream

### DIFF
--- a/src/ByteCountingStream.php
+++ b/src/ByteCountingStream.php
@@ -1,0 +1,58 @@
+<?php
+namespace GuzzleHttp\Psr7;
+
+use Psr\Http\Message\StreamInterface;
+
+/**
+ *  Stream decorator that counts the number of bytes read off of an underlying
+ *  read stream.
+ */
+class ByteCountingStream implements StreamInterface
+{
+    use StreamDecoratorTrait;
+
+    /** @var int Number of bytes allowed per read */
+    private $byteCount;
+
+    /**
+     * @param StreamInterface $stream Stream to wrap
+     * @param int             $bytes  Number of bytes per read
+     * @throws \InvalidArgumentException
+     */
+    public function __construct(StreamInterface $stream, $bytes)
+    {
+        $this->stream = $stream;
+
+        if ($bytes < 0) {
+            $msg = "Bytes per read should be non-negative value, got {$bytes}.";
+            throw new \InvalidArgumentException($msg);
+        }
+        $this->byteCount = $bytes;
+    }
+
+    /**
+     * Reads byteCount number of bytes per read unless
+     * there are not enough bytes to read from.
+     *
+     * @throws \RuntimeException
+     */
+    public function readBytes()
+    {
+        $remaining = $this->stream->getSize() - $this->stream->tell();
+        if ($remaining < $this->byteCount) {
+            $data = $this->stream->read($remaining);
+        } else {
+            $data = $this->stream->read($this->byteCount);
+        }
+
+        $error = $remaining < $this->byteCount ?
+            strlen($data) !== $remaining :
+            strlen($data) !== $this->byteCount;
+
+        if ($error) {
+            $msg = "Fail to read bytes from {$this->stream->tell()}";
+            throw new \RuntimeException($msg);
+        }
+        return $data;
+    }
+}

--- a/tests/ByteCountingStreamTest.php
+++ b/tests/ByteCountingStreamTest.php
@@ -1,0 +1,50 @@
+<?php
+namespace GuzzleHttp\Tests\Psr7;
+
+use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\ByteCountingStream;
+
+/**
+ * @covers GuzzleHttp\Psr7\ByteCountingStream
+ */
+class ByteCountingStreamTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Bytes per read should be non-negative value, got
+     */
+    public function testEnsureNonNegativeBytesCount()
+    {
+        new ByteCountingStream(Psr7\stream_for('testing'), -2);
+    }
+
+    public function testByteCountingReadWhenAvailable()
+    {
+        $testStream = new ByteCountingStream(Psr7\stream_for('testing'), 2);
+        $this->assertEquals(2, strlen($testStream->readBytes()));
+    }
+
+    public function testReadBytesUnderCount()
+    {
+        $lackOfBytes = new ByteCountingStream(Psr7\stream_for('foo'), 5);
+        $this->assertEquals('foo', $lackOfBytes->readBytes());
+        $lackOfBytes->close();
+
+        $endingBytes = new ByteCountingStream(Psr7\stream_for('foo bar'), 4);
+        $this->assertEquals('foo ', $endingBytes->readBytes());
+        $this->assertEquals('bar', $endingBytes->readBytes());
+        $endingBytes->close();
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage The stream is detached
+     */
+    public function testEnsureReadUnclosedStream()
+    {
+        $body = Psr7\stream_for("closed");
+        $closedStream = new ByteCountingStream($body, 2);
+        $body->close();
+        $closedStream->readBytes();
+    }
+}


### PR DESCRIPTION
A stream decorator that takes another readable stream and number of bytes per read ($byteCount). When performing `readBytes()`, only `byteCount` number of bytes are read unless there isn't enough bytes to read.

cc:\ @mtdowling 