### PR TITLE
Use fgets() to read a single line of a stream

### DIFF
--- a/src/Stream.php
+++ b/src/Stream.php
@@ -211,6 +211,15 @@ class Stream implements StreamInterface
         return fread($this->stream, $length);
     }
 
+    public function readLine()
+    {   
+        if (!$this->readable) {
+            throw new \RuntimeException('Cannot read from non-readable stream');
+        }
+
+        return fgets($this->stream);
+    }
+
     public function write($string)
     {
         if (!$this->writable) {


### PR DESCRIPTION
It makes me sad that we are not using fgets() here somewhere. It is 10 times faster than Psr7\readline(). I know readLine() method is not a StreamInterface method...but there has to be a way to incorporate it somehow.