### PR TITLE
Set parameters without values correctly

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -133,11 +133,13 @@ function parse_header($header)
 
     foreach (normalize_header($header) as $val) {
         $part = [];
-        foreach (preg_split('/;(?=([^"]*"[^"]*")*[^"]*$)/', $val) as $kvp) {
+        foreach (preg_split('/;(?=([^"]*"[^"]*")*[^"]*$)/', $val) as $i => $kvp) {
             if (preg_match_all('/<[^>]+>|[^=]+/', $kvp, $matches)) {
                 $m = $matches[0];
                 if (isset($m[1])) {
                     $part[trim($m[0], $trimmed)] = trim($m[1], $trimmed);
+                } elseif($i > 0) {
+                    $part[trim($m[0], $trimmed)] = '';
                 } else {
                     $part[] = trim($m[0], $trimmed);
                 }

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -504,6 +504,12 @@ class FunctionsTest extends \PHPUnit_Framework_TestCase
                 $res1
             ),
             array(
+                'video/mpeg; xmpeg %s',
+                array(
+                    array('video/mpeg', 'xmpeg %s' => ''),
+                ),
+            ),
+            array(
                 'foo="baz"; bar=123, boo, test="123", foobar="foo;bar"',
                 array(
                     array('foo' => 'baz', 'bar' => '123'),


### PR DESCRIPTION
The doc block for `parse_header()` says that if a parameter doesn't have a value it will be set as the key with an empty string value. This currently doesn't happen, so `video/mpeg; xmpeg %s` currently results in `[0 => 'video/mpeg', 1 => 'xmpeg %s']` rather than the expected `[0 => 'video/mpeg', 'xmpeg %s' => '']`.
