### PR TITLE
Fix support for reconsturcting localhost file scheme

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -471,7 +471,7 @@ class Uri implements UriInterface
             $uri .= $scheme . ':';
         }
 
-        if ($authority != '') {
+        if ($authority != '' || $scheme == 'file') {
             $uri .= '//' . $authority;
         }
 

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -471,7 +471,7 @@ class Uri implements UriInterface
             $uri .= $scheme . ':';
         }
 
-        if ($authority != '' || $scheme == 'file') {
+        if ($authority != '' || $scheme === 'file') {
             $uri .= '//' . $authority;
         }
 

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -472,6 +472,15 @@ class UriTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('https://localhost', (string) $uri);
     }
 
+    public function testFileSchemeWithEmptyHost()
+    {
+        $uri = (new Uri())->withScheme('file');
+
+        $this->assertSame('', $uri->getHost());
+        $this->assertSame('', $uri->getAuthority());
+        $this->assertSame('file://', (string) $uri);
+    }
+
     public function uriComponentsEncodingProvider()
     {
         $unreserved = 'a-zA-Z0-9.-_~!$&\'()*+,;=:@';

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -472,13 +472,13 @@ class UriTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('https://localhost', (string) $uri);
     }
 
-    public function testFileSchemeWithEmptyHost()
+    public function testFileSchemeWithEmptyHostReconstruction()
     {
-        $uri = (new Uri())->withScheme('file');
+        $uri = new Uri('file:///tmp/filename.ext');
 
         $this->assertSame('', $uri->getHost());
         $this->assertSame('', $uri->getAuthority());
-        $this->assertSame('file://', (string) $uri);
+        $this->assertSame('file:///tmp/filename.ext', (string) $uri);
     }
 
     public function uriComponentsEncodingProvider()


### PR DESCRIPTION
Trying to test an html parser with local saved versions fails because the Uri re-constructs the `file` uri as `file:/home/...` instead of `file:///home/...`, which is necessary for php functions such as `fopen,` `file_get_contents` or `is_file`.
Using the scheme-less syntax, like `/home/...` might work for some, but it does not solve the issue when we are using a scheme.

So I added an exclusion when the file scheme is used, so we do add `//` even when authority is empty.