### PR TITLE
Add http as standard protocol

### DIFF
--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -187,17 +187,17 @@ class ServerRequest extends Request implements ServerRequestInterface
      */
     public static function getUriFromGlobals() {
         $uri = new Uri('');
-        $addProtocol = false;
+        $addSchema = false;
 
         if (isset($_SERVER['HTTP_HOST'])) {
             $uri = $uri->withHost($_SERVER['HTTP_HOST']);
-            $addProtocol = true;
+            $addSchema = true;
         } elseif (isset($_SERVER['SERVER_NAME'])) {
             $uri = $uri->withHost($_SERVER['SERVER_NAME']);
-            $addProtocol = true;
+            $addSchema = true;
         }
 
-        if ($addProtocol) {
+        if ($addSchema) {
             $uri = $uri->withScheme(isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on' ? 'https' : 'http');
         }
 

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -187,15 +187,18 @@ class ServerRequest extends Request implements ServerRequestInterface
      */
     public static function getUriFromGlobals() {
         $uri = new Uri('');
-
-        if (isset($_SERVER['HTTPS'])) {
-            $uri = $uri->withScheme($_SERVER['HTTPS'] == 'on' ? 'https' : 'http');
-        }
+        $addProtocol = false;
 
         if (isset($_SERVER['HTTP_HOST'])) {
             $uri = $uri->withHost($_SERVER['HTTP_HOST']);
+            $addProtocol = true;
         } elseif (isset($_SERVER['SERVER_NAME'])) {
             $uri = $uri->withHost($_SERVER['SERVER_NAME']);
+            $addProtocol = true;
+        }
+
+        if ($addProtocol) {
+            $uri = $uri->withScheme(isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on' ? 'https' : 'http');
         }
 
         if (isset($_SERVER['SERVER_PORT'])) {

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -292,7 +292,6 @@ class ServerRequestTest extends \PHPUnit_Framework_TestCase
             'HTTP_HOST' => 'www.blakesimpson.co.uk',
             'HTTP_REFERER' => 'http://previous.url.com',
             'HTTP_USER_AGENT' => 'Mozilla/5.0 (Windows; U; Windows NT 6.0; en-GB; rv:1.9.2.6) Gecko/20100625 Firefox/3.6.6 ( .NET CLR 3.5.30729)',
-            'HTTPS' => '1',
             'REMOTE_ADDR' => '193.60.168.69',
             'REMOTE_HOST' => 'Client server\'s host name',
             'REMOTE_PORT' => '5390',
@@ -312,6 +311,10 @@ class ServerRequestTest extends \PHPUnit_Framework_TestCase
             'Secure request' => [
                 'https://www.blakesimpson.co.uk/blog/article.php?id=10&user=foo',
                 array_merge($server, ['HTTPS' => 'on', 'SERVER_PORT' => '443']),
+            ],
+            'No HTTPS param' => [
+                'http://www.blakesimpson.co.uk/blog/article.php?id=10&user=foo',
+                $server
             ],
             'HTTP_HOST missing' => [
                 'http://www.blakesimpson.co.uk/blog/article.php?id=10&user=foo',

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -312,9 +312,9 @@ class ServerRequestTest extends \PHPUnit_Framework_TestCase
                 'https://www.blakesimpson.co.uk/blog/article.php?id=10&user=foo',
                 array_merge($server, ['HTTPS' => 'on', 'SERVER_PORT' => '443']),
             ],
-            'No HTTPS param' => [
+            'With HTTPS param = 1' => [
                 'http://www.blakesimpson.co.uk/blog/article.php?id=10&user=foo',
-                $server
+                array_merge($server, ['HTTPS' => '1']),
             ],
             'HTTP_HOST missing' => [
                 'http://www.blakesimpson.co.uk/blog/article.php?id=10&user=foo',


### PR DESCRIPTION
If $_SERVER['HTTPS'] is not defined then we should add 'http' as protocol. A URL without a "_scheme_:", it's not a generic URL, but a [protocol-relative link](https://tools.ietf.org/html/rfc1738#section-2.3)
