### PR TITLE
Fix http_host with port issue

### DIFF
--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -193,13 +193,21 @@ class ServerRequest extends Request implements ServerRequestInterface
         }
 
         if (isset($_SERVER['HTTP_HOST'])) {
-            $uri = $uri->withHost($_SERVER['HTTP_HOST']);
+            $host = explode(':', $_SERVER['HTTP_HOST'])[0];
+            $has_port = isset(explode(':', $_SERVER['HTTP_HOST'])[1]);
+            $port = null;
+            if ($has_port) {
+                $port = explode(':', $_SERVER['HTTP_HOST'])[1];
+            }
+            $uri = $uri->withHost($host);
+            if (!is_null($port)) {
+                $uri = $uri->withPort($port);
+            }
         } elseif (isset($_SERVER['SERVER_NAME'])) {
             $uri = $uri->withHost($_SERVER['SERVER_NAME']);
-        }
-
-        if (isset($_SERVER['SERVER_PORT'])) {
-            $uri = $uri->withPort($_SERVER['SERVER_PORT']);
+            if (isset($_SERVER['SERVER_PORT'])) {
+                $uri = $uri->withPort($_SERVER['SERVER_PORT']);
+            }
         }
 
         if (isset($_SERVER['REQUEST_URI'])) {

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -323,7 +323,11 @@ class ServerRequestTest extends \PHPUnit_Framework_TestCase
             ],
             'Different port' => [
                 'http://www.blakesimpson.co.uk:8324/blog/article.php?id=10&user=foo',
-                array_merge($server, ['SERVER_PORT' => '8324']),
+                array_merge($server, ['HTTP_HOST' => 'www.blakesimpson.co.uk:8324', 'SERVER_PORT' => '8324']),
+            ],
+            'HTTP_HOST missing different port' => [
+                'http://www.blakesimpson.co.uk:8324/blog/article.php?id=10&user=foo',
+                array_merge($server, ['HTTP_HOST' => null, 'SERVER_PORT' => '8324']),
             ],
             'Empty server variable' => [
                 '',


### PR DESCRIPTION
The issue:

When building the ServerRequest fromGlobals(), the uri's host sometimes contains the port, which causes the uri to look like https://www.example.com:8000:8000/path...

For example, if you visit a website from your localhost on a non-standard port (e.g. localhost:8000 for example), and try to build the ServerRequest, when you get the uri, you get //localhost:8000:8000/path.

Here is a minimal script reproducing the issue:

``` php
<?php

require __DIR__.'/../vendor/autoload.php';

use GuzzleHttp\Psr7\ServerRequest;

//This is the $_SERVER params I get by calling the uri localhost:8000/guzzleuritest.php
$_SERVER['HTTPS'] = null;
$_SERVER['HTTP_HOST'] = 'localhost:8000';
$_SERVER['SERVER_NAME'] = 'localhost';
$_SERVER['SERVER_PORT'] = 8000;
$_REQUEST_URI = '/guzzleuritest.php';
$_SERVER['QUERY_STRING'] = null;

$serverRequest = ServerRequest::fromGlobals();
echo ((string)$serverRequest->getUri());
```

The reason this happens is that the HTTP_HOST superglobal gets his contents from the Host: header, which, by the specs, may contain the port number, especially if non-standard.
http://tools.ietf.org/html/rfc7230#section-5.4

This pull request fixes this issue and updates the test to take this into consideration.
