### PR TITLE
Added a function in order to get the message body summary

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -806,6 +806,40 @@ function _parse_request_uri($path, array $headers)
     return $scheme . '://' . $host . '/' . ltrim($path, '/');
 }
 
+/**
+ * Get a short summary of the message body
+ *
+ * Will return `null` if the response is not printable.
+ *
+ * @param MessageInterface $message    The message to get the body summary
+ * @param int              $truncateAt The maximum allowed size of the summary
+ *
+ * @return null|string
+ */
+function get_message_body_summary(MessageInterface $message, $truncateAt = 120){
+    $body = $message->getBody();
+
+    if (!$body->isSeekable()) {
+        return null;
+    }
+
+    $size = $body->getSize();
+    $summary = $body->read($truncateAt);
+    $body->rewind();
+
+    if ($size > $truncateAt) {
+        $summary .= ' (truncated...)';
+    }
+
+    // Matches any printable character, including unicode characters:
+    // letters, marks, numbers, punctuation, spacing, and separators.
+    if (preg_match('/[^\pL\pM\pN\pP\pS\pZ\n\r\t]/', $summary)) {
+        return null;
+    }
+
+    return $summary;
+}
+
 /** @internal */
 function _caseless_remove($keys, array $data)
 {

--- a/src/functions.php
+++ b/src/functions.php
@@ -816,7 +816,8 @@ function _parse_request_uri($path, array $headers)
  *
  * @return null|string
  */
-function get_message_body_summary(MessageInterface $message, $truncateAt = 120){
+function get_message_body_summary(MessageInterface $message, $truncateAt = 120)
+{
     $body = $message->getBody();
 
     if (!$body->isSeekable()) {

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -638,6 +638,18 @@ class FunctionsTest extends \PHPUnit_Framework_TestCase
         $r2 = Psr7\modify_request($r1, ['remove_headers' => ['non-existent']]);
         $this->assertTrue($r2 instanceof ServerRequestInterface);
     }
+
+    public function testMessageBodySummaryWithSmallBody()
+    {
+        $message = new Psr7\Response(200, [], 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.');
+        $this->assertEquals('Lorem ipsum dolor sit amet, consectetur adipiscing elit.', Psr7\get_message_body_summary($message));
+    }
+
+    public function testMessageBodySummaryWithLargeBody()
+    {
+        $message = new Psr7\Response(200, [], 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.');
+        $this->assertEquals('Lorem ipsu (truncated...)', Psr7\get_message_body_summary($message, 10));
+    }
 }
 
 class HasToString


### PR DESCRIPTION
Basically I never understood why this function was added in RequestException class https://github.com/guzzle/guzzle/blob/master/src/Exception/RequestException.php#L123 and why only for the responses.

I thought that this is a helpful function that could be added in the functions file.
