### PR TITLE
Suppress warning for `Stream::read` method call

### DIFF
--- a/src/Stream.php
+++ b/src/Stream.php
@@ -208,7 +208,17 @@ class Stream implements StreamInterface
             throw new \RuntimeException('Cannot read from non-readable stream');
         }
 
-        return fread($this->stream, $length);
+        if (0 === $length) {
+            return '';
+        }
+
+        $string = $length > 0 ? fread($this->stream, $length) : false;
+
+        if (false === $string) {
+            throw new \RuntimeException('Unable to read from stream');
+        }
+
+        return $string;
     }
 
     public function write($string)

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -207,13 +207,15 @@ class Stream implements StreamInterface
         if (!$this->readable) {
             throw new \RuntimeException('Cannot read from non-readable stream');
         }
+        if ($length < 0) {
+            throw new \RuntimeException('Length parameter cannot be negative');
+        }
 
         if (0 === $length) {
             return '';
         }
 
-        $string = $length > 0 ? fread($this->stream, $length) : false;
-
+        $string = fread($this->stream, $length);
         if (false === $string) {
             throw new \RuntimeException('Unable to read from stream');
         }

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -9,6 +9,8 @@ use GuzzleHttp\Psr7\Stream;
  */
 class StreamTest extends \PHPUnit_Framework_TestCase
 {
+    public static $isFReadError = false;
+
     /**
      * @expectedException \InvalidArgumentException
      */
@@ -164,28 +166,58 @@ class StreamTest extends \PHPUnit_Framework_TestCase
         $r = fopen('php://temp', 'r');
         $stream = new Stream($r);
 
-        $this->assertEquals('', $stream->read(0));
+        $this->assertSame('', $stream->read(0));
 
         $stream->close();
     }
 
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Length parameter cannot be negative
+     */
     public function testStreamReadingWithNegativeLength()
     {
-        $r = fopen('php://temp', 'r');
+        $r      = fopen('php://temp', 'r');
         $stream = new Stream($r);
 
         try {
             $stream->read(-1);
-        } catch (\RuntimeException $e) {
-            $stream->close();
-            $this->assertEquals('Unable to read from stream', $e->getMessage());
-            return;
         } catch (\Exception $e) {
             $stream->close();
-            throw new \PHPUnit_Framework_Exception('Expect for RuntimeException');
+            throw $e;
         }
 
         $stream->close();
-        throw new \PHPUnit_Framework_Exception('Expect for Exception');
     }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Unable to read from stream
+     */
+    public function testStreamReadingFreadError()
+    {
+        self::$isFReadError = true;
+        $r                  = fopen('php://temp', 'r');
+        $stream             = new Stream($r);
+
+        try {
+            $stream->read(1);
+        } catch (\Exception $e) {
+            self::$isFReadError = false;
+            $stream->close();
+            throw $e;
+        }
+
+        self::$isFReadError = false;
+        $stream->close();
+    }
+}
+
+namespace GuzzleHttp\Psr7;
+
+use GuzzleHttp\Tests\Psr7\StreamTest;
+
+function fread($handle, $length)
+{
+    return StreamTest::$isFReadError ? false : \fread($handle, $length);
 }

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -177,7 +177,7 @@ class StreamTest extends \PHPUnit_Framework_TestCase
      */
     public function testStreamReadingWithNegativeLength()
     {
-        $r      = fopen('php://temp', 'r');
+        $r = fopen('php://temp', 'r');
         $stream = new Stream($r);
 
         try {
@@ -197,8 +197,8 @@ class StreamTest extends \PHPUnit_Framework_TestCase
     public function testStreamReadingFreadError()
     {
         self::$isFReadError = true;
-        $r                  = fopen('php://temp', 'r');
-        $stream             = new Stream($r);
+        $r = fopen('php://temp', 'r');
+        $stream = new Stream($r);
 
         try {
             $stream->read(1);

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -158,4 +158,34 @@ class StreamTest extends \PHPUnit_Framework_TestCase
         $s = new NoSeekStream($s);
         $this->assertEquals('foo', (string) $s);
     }
+
+    public function testStreamReadingWithZeroLength()
+    {
+        $r = fopen('php://temp', 'r');
+        $stream = new Stream($r);
+
+        $this->assertEquals('', $stream->read(0));
+
+        $stream->close();
+    }
+
+    public function testStreamReadingWithNegativeLength()
+    {
+        $r = fopen('php://temp', 'r');
+        $stream = new Stream($r);
+
+        try {
+            $stream->read(-1);
+        } catch (\RuntimeException $e) {
+            $stream->close();
+            $this->assertEquals('Unable to read from stream', $e->getMessage());
+            return;
+        } catch (\Exception $e) {
+            $stream->close();
+            throw new \PHPUnit_Framework_Exception('Expect for RuntimeException');
+        }
+
+        $stream->close();
+        throw new \PHPUnit_Framework_Exception('Expect for Exception');
+    }
 }


### PR DESCRIPTION
 - if `$length === 0` return empty string
 - if `$length < 0` throw `RuntimeException`
 - if `fread` return false throw RuntimeException

Add PHPUnit tests

Issue #119 