### PR TITLE
Fix InflateStream not preserving isSeekable.

### DIFF
--- a/src/InflateStream.php
+++ b/src/InflateStream.php
@@ -27,7 +27,7 @@ class InflateStream implements StreamInterface
         $stream = new LimitStream($stream, -1, 10 + $filenameHeaderLength);
         $resource = StreamWrapper::getResource($stream);
         stream_filter_append($resource, 'zlib.inflate', STREAM_FILTER_READ);
-        $this->stream = new Stream($resource);
+        $this->stream = $stream->isSeekable() ? new Stream($resource) : new NoSeekStream(new Stream($resource));
     }
 
     /**

--- a/tests/InflateStreamTest.php
+++ b/tests/InflateStreamTest.php
@@ -3,6 +3,7 @@ namespace GuzzleHttp\Tests\Psr7;
 
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\InflateStream;
+use GuzzleHttp\Psr7\NoSeekStream;
 
 class InflateStreamtest extends \PHPUnit_Framework_TestCase
 {
@@ -20,6 +21,16 @@ class InflateStreamtest extends \PHPUnit_Framework_TestCase
         $a = Psr7\stream_for($content);
         $b = new InflateStream($a);
         $this->assertEquals('test', (string) $b);
+    }
+
+    public function testInflatesStreamsPreserveSeekable()
+    {
+        $content = $this->getGzipStringWithFilename('test');
+        $seekable = Psr7\stream_for($content);
+        $nonSeekable = new NoSeekStream(Psr7\stream_for($content));
+
+        $this->assertTrue((new InflateStream($seekable))->isSeekable());
+        $this->assertFalse((new InflateStream($nonSeekable))->isSeekable());
     }
 
     private function getGzipStringWithFilename($original_string)


### PR DESCRIPTION
When a stream is wrapped with InflateStream is not preserving isSeekable flag, breaking some outer decorators.

I did a research on the topic and seems that PHP custom wrappers are always seekable.