### PR TITLE
Fixes global parsing and filling on ServerRequest

### DIFF
--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -190,6 +190,8 @@ class ServerRequest extends Request implements ServerRequestInterface
 
         if (isset($_SERVER['HTTPS'])) {
             $uri = $uri->withScheme($_SERVER['HTTPS'] == 'on' ? 'https' : 'http');
+        } else {
+            $uri = $uri->withScheme('http');
         }
 
         if (isset($_SERVER['HTTP_HOST'])) {

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -195,7 +195,7 @@ class ServerRequest extends Request implements ServerRequestInterface
         }
 
         if (isset($_SERVER['HTTP_HOST'])) {
-            $uri = $uri->withHost($_SERVER['HTTP_HOST']);
+            $uri = $uri->withHost(explode(':', $_SERVER['HTTP_HOST'])[0]);
         } elseif (isset($_SERVER['SERVER_NAME'])) {
             $uri = $uri->withHost($_SERVER['SERVER_NAME']);
         }

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -326,7 +326,7 @@ class ServerRequestTest extends \PHPUnit_Framework_TestCase
                 array_merge($server, ['SERVER_PORT' => '8324']),
             ],
             'Empty server variable' => [
-                '',
+                'http://localhost',
                 [],
             ],
         ];


### PR DESCRIPTION
Per the documentation of PHP, the `HTTP` key is set on `$_SERVER` when HTTPS is enabled.  The on/off paradigm is only applicable to certain SAPI environments.

Additionally, the `HTTP_HOST` value which comes from the `Host` header in HTTP will contain the port when a non-standard port is used, so that needs to be discarded otherwise the host is set to include the port so the additional port setting will result in something like `localhost:8080:8080` if you try to get the authority back out of it.