### PR TITLE
Remove common BC break for relative path with authority and trigger deprecations instead

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -265,6 +265,12 @@ class Uri implements UriInterface
      */
     public static function removeDotSegments($path)
     {
+        @trigger_error(
+            'GuzzleHttp\Psr7\Uri::removeDotSegments is deprecated since version 1.4. ' .
+            'Use GuzzleHttp\Psr7\UriResolver::removeDotSegments instead.',
+            E_USER_DEPRECATED
+        );
+
         return UriResolver::removeDotSegments($path);
     }
 
@@ -281,6 +287,11 @@ class Uri implements UriInterface
      */
     public static function resolve(UriInterface $base, $rel)
     {
+        @trigger_error(
+            'GuzzleHttp\Psr7\Uri::resolve is deprecated since version 1.4. Use GuzzleHttp\Psr7\UriResolver::resolve instead.',
+            E_USER_DEPRECATED
+        );
+
         if (!($rel instanceof UriInterface)) {
             $rel = new self($rel);
         }
@@ -690,7 +701,13 @@ class Uri implements UriInterface
                 throw new \InvalidArgumentException('A relative URI must not have a path beginning with a segment containing a colon');
             }
         } elseif (isset($this->path[0]) && $this->path[0] !== '/') {
-            throw new \InvalidArgumentException('The path of a URI with an authority must start with a slash "/" or be empty');
+            @trigger_error(
+                'The path of a URI with an authority must start with a slash "/" or be empty. Automagically fixing the URI ' .
+                'by adding a leading slash to the path is deprecated since version 1.4 and will throw an exception instead.',
+                E_USER_DEPRECATED
+            );
+            $this->path = '/'. $this->path;
+            //throw new \InvalidArgumentException('The path of a URI with an authority must start with a slash "/" or be empty');
         }
     }
 }

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -569,14 +569,12 @@ class UriTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('foo', (string) $uri);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The path of a URI with an authority must start with a slash "/" or be empty
-     */
-    public function testRelativePathAndAuhorityIsInvalid()
+    public function testRelativePathAndAuhorityIsAutomagicallyFixed()
     {
         // concatenating a relative path with a host doesn't work: "//example.comfoo" would be wrong
-        (new Uri)->withPath('foo')->withHost('example.com');
+        $uri = (new Uri)->withPath('foo')->withHost('example.com');
+        $this->assertSame('/foo', $uri->getPath());
+        $this->assertSame('//example.com/foo', (string) $uri);
     }
 
     /**


### PR DESCRIPTION
Fixes #138 and will be released as 1.4.1