### PR TITLE
Rely on `@deprecated` annotation instead of triggering and immediately silencing a deprecation notice

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -265,12 +265,6 @@ class Uri implements UriInterface
      */
     public static function removeDotSegments($path)
     {
-        @trigger_error(
-            'GuzzleHttp\Psr7\Uri::removeDotSegments is deprecated since version 1.4. ' .
-            'Use GuzzleHttp\Psr7\UriResolver::removeDotSegments instead.',
-            E_USER_DEPRECATED
-        );
-
         return UriResolver::removeDotSegments($path);
     }
 
@@ -287,11 +281,6 @@ class Uri implements UriInterface
      */
     public static function resolve(UriInterface $base, $rel)
     {
-        @trigger_error(
-            'GuzzleHttp\Psr7\Uri::resolve is deprecated since version 1.4. Use GuzzleHttp\Psr7\UriResolver::resolve instead.',
-            E_USER_DEPRECATED
-        );
-
         if (!($rel instanceof UriInterface)) {
             $rel = new self($rel);
         }


### PR DESCRIPTION
There are two static methods in `GuzzleHttp\Psr7\Uri` that always trigger immediately silenced errors. This introduces a runtime performance penalty to communicate the same information as the already-present `@deprecated` annotation, which is used by IDEs and static analysis tools to notify developers at dev time that a deprecated method is being used.

I've received multiple reports of the silenced `trigger_error` call causing errors in production for users who define custom error handlers, e.g. https://github.com/aws/aws-sdk-php/issues/1198

/cc @mtdowling @Tobion 