### PR TITLE
ServerRequest::fromGlobals() - fix the fetching of request headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # CHANGELOG
 
+* Fix #147 ServerRequest::fromGlobals() - fix the fetching of request headers
 * Fix #145 Add response first-line to response string exception
 
 ## 1.4.2 - 2017-03-20
 
-* Reverted BC break to `Uri::resolve` and `Uri::removeDotSegments` by removing 
+* Reverted BC break to `Uri::resolve` and `Uri::removeDotSegments` by removing
   calls to `trigger_error` when deprecated methods are invoked.
 
 ## 1.4.1 - 2017-02-27

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -165,8 +165,18 @@ class ServerRequest extends Request implements ServerRequestInterface
      */
     public static function fromGlobals()
     {
+        if (function_exists('getallheaders')) {
+            $headers = getallheaders();
+        } else {
+            $headers = [];
+            foreach ($_SERVER as $name => $value) {
+                if (substr($name, 0, 5) == 'HTTP_') {
+                    $headers[str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', substr($name, 5)))))] = $value;
+                }
+            }
+        }
+
         $method = isset($_SERVER['REQUEST_METHOD']) ? $_SERVER['REQUEST_METHOD'] : 'GET';
-        $headers = function_exists('getallheaders') ? getallheaders() : [];
         $uri = self::getUriFromGlobals();
         $body = new LazyOpenStream('php://input', 'r+');
         $protocol = isset($_SERVER['SERVER_PROTOCOL']) ? str_replace('HTTP/', '', $_SERVER['SERVER_PROTOCOL']) : '1.1';


### PR DESCRIPTION
This pull request addresses the issue [SeverRequest::fromGlobals only works on Apache](https://github.com/guzzle/psr7/issues/126)
The solution is copied from a comment from the php manual - http://php.net/manual/en/function.getallheaders.php#84262