### PR TITLE
Bool return type not possible in readline()

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -431,7 +431,7 @@ function hash(
  * @param StreamInterface $stream    Stream to read from
  * @param int             $maxLength Maximum buffer length
  *
- * @return string|bool
+ * @return string
  */
 function readline(StreamInterface $stream, $maxLength = null)
 {

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -105,6 +105,16 @@ class FunctionsTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("45\n", Psr7\readline($s));
     }
 
+    public function testReadLinesEof()
+    {
+        // Should return empty string on EOF
+        $s = Psr7\stream_for("foo\nbar");
+        while (!$s->eof()) {
+            Psr7\readline($s);
+        }
+        $this->assertSame('', Psr7\readline($s));
+    }
+
     public function testReadsLineUntilFalseReturnedFromRead()
     {
         $s = $this->getMockBuilder('GuzzleHttp\Psr7\Stream')


### PR DESCRIPTION
readline() currently returns an empty string on EOF (rather than false).

Currently, comments suggest that the implementation works like fgets().

Incorrect usage :

```
while (($line = readline($stream, 2048)) !== false) {
    // Code loops forever
}
```

Correct usage:

```
// Read until the stream is closed
while (!$stream->eof()) {
    // Read a line from the stream
    $line = $stream->readLine();
}
```