### PR TITLE
Fix AppendStream::detach to not close the resource and exception messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,15 @@
 language: php
 
-sudo: false
+php:
+  - 5.4
+  - 5.5
+  - 5.6
+  - 7.0
+  - 7.1
+  - hhvm
 
-matrix:
-  include:
-    - php: hhvm-3.19
-      sudo: required
-      dist: trusty
-      group: edge
-    - php: 5.4
-    - php: 5.5
-    - php: 5.6
-    - php: 7.0
-    - php: 7.1
-  fast_finish: true
+sudo: false
+dist: trusty
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,19 @@
 language: php
 
-php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
-  - hhvm
-
 sudo: false
+
+matrix:
+  include:
+    - php: hhvm-3.19
+      sudo: required
+      dist: trusty
+      group: edge
+    - php: 5.4
+    - php: 5.5
+    - php: 5.6
+    - php: 7.0
+    - php: 7.1
+  fast_finish: true
 
 cache:
   directories:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # CHANGELOG
 
-* Fix #145 Add response first-line to response string exception
+* Added response first-line to response string exception (fixes #145)
+* Fix `AppendStream::detach` to not close streams
+* Clarify exception message when stream is detached
+* Added a test for #129 behavior
 
 ## 1.4.2 - 2017-03-20
 

--- a/src/AppendStream.php
+++ b/src/AppendStream.php
@@ -16,7 +16,6 @@ class AppendStream implements StreamInterface
     private $seekable = true;
     private $current = 0;
     private $pos = 0;
-    private $detached = false;
 
     /**
      * @param StreamInterface[] $streams Streams to decorate. Each stream must
@@ -73,6 +72,7 @@ class AppendStream implements StreamInterface
     public function close()
     {
         $this->pos = $this->current = 0;
+        $this->seekable = true;
 
         foreach ($this->streams as $stream) {
             $stream->close();
@@ -82,14 +82,22 @@ class AppendStream implements StreamInterface
     }
 
     /**
-     * Detaches each attached stream
+     * Detaches each attached stream.
+     *
+     * Returns null as it's not clear which underlying stream resource to return.
      *
      * {@inheritdoc}
      */
     public function detach()
     {
-        $this->close();
-        $this->detached = true;
+        $this->pos = $this->current = 0;
+        $this->seekable = true;
+
+        foreach ($this->streams as $stream) {
+            $stream->detach();
+        }
+
+        $this->streams = [];
     }
 
     public function tell()

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -70,15 +70,6 @@ class Stream implements StreamInterface
         $this->uri = $this->getMetadata('uri');
     }
 
-    public function __get($name)
-    {
-        if ($name == 'stream') {
-            throw new \RuntimeException('The stream is detached');
-        }
-
-        throw new \BadMethodCallException('No value for ' . $name);
-    }
-
     /**
      * Closes the stream when the destructed
      */
@@ -99,6 +90,10 @@ class Stream implements StreamInterface
 
     public function getContents()
     {
+        if (!isset($this->stream)) {
+            throw new \RuntimeException('Stream is detached');
+        }
+
         $contents = stream_get_contents($this->stream);
 
         if ($contents === false) {
@@ -173,11 +168,19 @@ class Stream implements StreamInterface
 
     public function eof()
     {
-        return !$this->stream || feof($this->stream);
+        if (!isset($this->stream)) {
+            throw new \RuntimeException('Stream is detached');
+        }
+
+        return feof($this->stream);
     }
 
     public function tell()
     {
+        if (!isset($this->stream)) {
+            throw new \RuntimeException('Stream is detached');
+        }
+
         $result = ftell($this->stream);
 
         if ($result === false) {
@@ -194,9 +197,13 @@ class Stream implements StreamInterface
 
     public function seek($offset, $whence = SEEK_SET)
     {
+        if (!isset($this->stream)) {
+            throw new \RuntimeException('Stream is detached');
+        }
         if (!$this->seekable) {
             throw new \RuntimeException('Stream is not seekable');
-        } elseif (fseek($this->stream, $offset, $whence) === -1) {
+        }
+        if (fseek($this->stream, $offset, $whence) === -1) {
             throw new \RuntimeException('Unable to seek to stream position '
                 . $offset . ' with whence ' . var_export($whence, true));
         }
@@ -204,6 +211,9 @@ class Stream implements StreamInterface
 
     public function read($length)
     {
+        if (!isset($this->stream)) {
+            throw new \RuntimeException('Stream is detached');
+        }
         if (!$this->readable) {
             throw new \RuntimeException('Cannot read from non-readable stream');
         }
@@ -225,6 +235,9 @@ class Stream implements StreamInterface
 
     public function write($string)
     {
+        if (!isset($this->stream)) {
+            throw new \RuntimeException('Stream is detached');
+        }
         if (!$this->writable) {
             throw new \RuntimeException('Cannot write to a non-writable stream');
         }

--- a/tests/AppendStreamTest.php
+++ b/tests/AppendStreamTest.php
@@ -72,23 +72,59 @@ class AppendStreamTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('baz', $a->read(3));
     }
 
+    public function testDetachWithoutStreams()
+    {
+        $s = new AppendStream();
+        $s->detach();
+
+        $this->assertSame(0, $s->getSize());
+        $this->assertTrue($s->eof());
+        $this->assertTrue($s->isReadable());
+        $this->assertSame('', (string) $s);
+        $this->assertTrue($s->isSeekable());
+        $this->assertFalse($s->isWritable());
+    }
+
     public function testDetachesEachStream()
     {
-        $s1 = Psr7\stream_for('foo');
+        $handle = fopen('php://temp', 'r');
+
+        $s1 = Psr7\stream_for($handle);
         $s2 = Psr7\stream_for('bar');
         $a = new AppendStream([$s1, $s2]);
-        $this->assertSame('foobar', (string) $a);
+
         $a->detach();
-        $this->assertSame('', (string) $a);
+
         $this->assertSame(0, $a->getSize());
+        $this->assertTrue($a->eof());
+        $this->assertTrue($a->isReadable());
+        $this->assertSame('', (string) $a);
+        $this->assertTrue($a->isSeekable());
+        $this->assertFalse($a->isWritable());
+
+        $this->assertNull($s1->detach());
+        $this->assertTrue(is_resource($handle), 'resource is not closed when detaching');
+        fclose($handle);
     }
 
     public function testClosesEachStream()
     {
-        $s1 = Psr7\stream_for('foo');
-        $a = new AppendStream([$s1]);
+        $handle = fopen('php://temp', 'r');
+
+        $s1 = Psr7\stream_for($handle);
+        $s2 = Psr7\stream_for('bar');
+        $a = new AppendStream([$s1, $s2]);
+
         $a->close();
+
+        $this->assertSame(0, $a->getSize());
+        $this->assertTrue($a->eof());
+        $this->assertTrue($a->isReadable());
         $this->assertSame('', (string) $a);
+        $this->assertTrue($a->isSeekable());
+        $this->assertFalse($a->isWritable());
+
+        $this->assertFalse(is_resource($handle));
     }
 
     /**
@@ -169,12 +205,6 @@ class AppendStreamTest extends \PHPUnit_Framework_TestCase
         $a = new AppendStream([$s]);
         $this->assertFalse($a->eof());
         $this->assertSame('', (string) $a);
-    }
-
-    public function testCanDetach()
-    {
-        $s = new AppendStream();
-        $s->detach();
     }
 
     public function testReturnsEmptyMetadata()

--- a/tests/FnStreamTest.php
+++ b/tests/FnStreamTest.php
@@ -46,6 +46,7 @@ class FnStreamTest extends \PHPUnit_Framework_TestCase
     {
         $s = new FnStream([]);
         unset($s);
+        $this->assertTrue(true); // strict mode requires an assertion
     }
 
     public function testDecoratesStream()

--- a/tests/NoSeekStreamTest.php
+++ b/tests/NoSeekStreamTest.php
@@ -26,15 +26,13 @@ class NoSeekStreamTest extends \PHPUnit_Framework_TestCase
         $wrapped->seek(2);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Cannot write to a non-writable stream
-     */
-    public function testHandlesClose()
+    public function testToStringDoesNotSeek()
     {
-        $s = Psr7\stream_for('foo');
+        $s = \GuzzleHttp\Psr7\stream_for('foo');
+        $s->seek(1);
         $wrapped = new NoSeekStream($s);
+        $this->assertEquals('oo', (string) $wrapped);
+
         $wrapped->close();
-        $wrapped->write('foo');
     }
 }

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -61,6 +61,7 @@ class StreamTest extends \PHPUnit_Framework_TestCase
         $stream->seek(0);
         $this->assertEquals('data', $stream->getContents());
         $this->assertEquals('', $stream->getContents());
+        $stream->close();
     }
 
     public function testChecksEof()
@@ -68,8 +69,9 @@ class StreamTest extends \PHPUnit_Framework_TestCase
         $handle = fopen('php://temp', 'w+');
         fwrite($handle, 'data');
         $stream = new Stream($handle);
-        $this->assertFalse($stream->eof());
-        $stream->read(4);
+        $this->assertSame(4, $stream->tell(), 'Stream cursor already at the end');
+        $this->assertFalse($stream->eof(), 'Stream still not eof');
+        $this->assertSame('', $stream->read(1), 'Need to read one more byte to reach eof');
         $this->assertTrue($stream->eof());
         $stream->close();
     }
@@ -110,55 +112,58 @@ class StreamTest extends \PHPUnit_Framework_TestCase
         $stream->close();
     }
 
-    public function testCanDetachStream()
+    public function testDetachStreamAndClearProperties()
     {
-        $r = fopen('php://temp', 'w+');
-        $stream = new Stream($r);
-        $stream->write('foo');
-        $this->assertTrue($stream->isReadable());
-        $this->assertSame($r, $stream->detach());
-        $stream->detach();
+        $handle = fopen('php://temp', 'r');
+        $stream = new Stream($handle);
+        $this->assertSame($handle, $stream->detach());
+        $this->assertTrue(is_resource($handle), 'Stream is not closed');
+        $this->assertNull($stream->detach());
 
-        $this->assertFalse($stream->isReadable());
-        $this->assertFalse($stream->isWritable());
-        $this->assertFalse($stream->isSeekable());
+        $this->assertStreamStateAfterClosedOrDetached($stream);
 
-        $throws = function (callable $fn) use ($stream) {
-            try {
-                $fn($stream);
-                $this->fail();
-            } catch (\Exception $e) {}
-        };
-
-        $throws(function ($stream) { $stream->read(10); });
-        $throws(function ($stream) { $stream->write('bar'); });
-        $throws(function ($stream) { $stream->seek(10); });
-        $throws(function ($stream) { $stream->tell(); });
-        $throws(function ($stream) { $stream->eof(); });
-        $throws(function ($stream) { $stream->getSize(); });
-        $throws(function ($stream) { $stream->getContents(); });
-        $this->assertSame('', (string) $stream);
         $stream->close();
     }
 
-    public function testCloseClearProperties()
+    public function testCloseResourceAndClearProperties()
     {
-        $handle = fopen('php://temp', 'r+');
+        $handle = fopen('php://temp', 'r');
         $stream = new Stream($handle);
         $stream->close();
 
-        $this->assertFalse($stream->isSeekable());
-        $this->assertFalse($stream->isReadable());
-        $this->assertFalse($stream->isWritable());
-        $this->assertNull($stream->getSize());
-        $this->assertEmpty($stream->getMetadata());
+        $this->assertFalse(is_resource($handle));
+
+        $this->assertStreamStateAfterClosedOrDetached($stream);
     }
 
-    public function testDoesNotThrowInToString()
+    private function assertStreamStateAfterClosedOrDetached(Stream $stream)
     {
-        $s = \GuzzleHttp\Psr7\stream_for('foo');
-        $s = new NoSeekStream($s);
-        $this->assertEquals('foo', (string) $s);
+        $this->assertFalse($stream->isReadable());
+        $this->assertFalse($stream->isWritable());
+        $this->assertFalse($stream->isSeekable());
+        $this->assertNull($stream->getSize());
+        $this->assertSame([], $stream->getMetadata());
+        $this->assertNull($stream->getMetadata('foo'));
+
+        $throws = function (callable $fn) {
+            try {
+                $fn();
+            } catch (\Exception $e) {
+                $this->assertContains('Stream is detached', $e->getMessage());
+
+                return;
+            }
+
+            $this->fail('Exception should be thrown after the stream is detached.');
+        };
+
+        $throws(function () use ($stream) { $stream->read(10); });
+        $throws(function () use ($stream) { $stream->write('bar'); });
+        $throws(function () use ($stream) { $stream->seek(10); });
+        $throws(function () use ($stream) { $stream->tell(); });
+        $throws(function () use ($stream) { $stream->eof(); });
+        $throws(function () use ($stream) { $stream->getContents(); });
+        $this->assertSame('', (string) $stream);
     }
 
     public function testStreamReadingWithZeroLength()


### PR DESCRIPTION
- Fix AppendStream::detach to not close the resource
- Clarify exception message when stream is detached. Some methods said "Stream is detached", while other methods used a different error. E.g. Stream::write said "Cannot write to a non-writable stream" which is misleading when is stream is actually detached.
- added a test for #129 behavior
- fix hhvm travis