### PR TITLE
bugfix in ServerRequest::getUriFromGlobals() method for url https://site.com/path?continue=https://site.com/widget?param=1

### DIFF
--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -210,7 +210,7 @@ class ServerRequest extends Request implements ServerRequestInterface
 
         $hasQuery = false;
         if (isset($_SERVER['REQUEST_URI'])) {
-            $requestUriParts = explode('?', $_SERVER['REQUEST_URI']);
+            $requestUriParts = explode('?', $_SERVER['REQUEST_URI'], 2);
             $uri = $uri->withPath($requestUriParts[0]);
             if (isset($requestUriParts[1])) {
                 $hasQuery = true;


### PR DESCRIPTION
Fixes #151