### PR TITLE
Fix the return typehint in docblock of stream_for function

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -72,7 +72,7 @@ function uri_for($uri)
  * @param resource|string|null|int|float|bool|StreamInterface|callable $resource Entity body data
  * @param array                                                        $options  Additional options
  *
- * @return Stream
+ * @return StreamInterface
  * @throws \InvalidArgumentException if the $resource arg is not valid.
  */
 function stream_for($resource = '', array $options = [])


### PR DESCRIPTION
Since you are returning two type of stream (PumpStream and Stream) you should either have as docblock the `StreamInterface` or `Stream|PumpStream`