### PR TITLE
Implement StreamWrapper::url_stat()

### DIFF
--- a/src/StreamWrapper.php
+++ b/src/StreamWrapper.php
@@ -38,9 +38,21 @@ class StreamWrapper
                 . 'writable, or both.');
         }
 
-        return fopen('guzzle://stream', $mode, null, stream_context_create([
+        return fopen('guzzle://stream', $mode, null, self::createStreamContext($stream));
+    }
+
+    /**
+     * Creates a stream context that can be used to open a stream as a php stream resource.
+     *
+     * @param StreamInterface $stream
+     *
+     * @return resource
+     */
+    public static function createStreamContext(StreamInterface $stream)
+    {
+        return stream_context_create([
             'guzzle' => ['stream' => $stream]
-        ]));
+        ]);
     }
 
     /**
@@ -98,8 +110,10 @@ class StreamWrapper
     {
         static $modeMap = [
             'r'  => 33060,
+            'rb' => 33060,
             'r+' => 33206,
-            'w'  => 33188
+            'w'  => 33188,
+            'wb' => 33188
         ];
 
         return [
@@ -111,6 +125,25 @@ class StreamWrapper
             'gid'     => 0,
             'rdev'    => 0,
             'size'    => $this->stream->getSize() ?: 0,
+            'atime'   => 0,
+            'mtime'   => 0,
+            'ctime'   => 0,
+            'blksize' => 0,
+            'blocks'  => 0
+        ];
+    }
+
+    public function url_stat($path, $flags)
+    {
+        return [
+            'dev'     => 0,
+            'ino'     => 0,
+            'mode'    => 0,
+            'nlink'   => 0,
+            'uid'     => 0,
+            'gid'     => 0,
+            'rdev'    => 0,
+            'size'    => 0,
             'atime'   => 0,
             'mtime'   => 0,
             'ctime'   => 0,

--- a/tests/StreamWrapperTest.php
+++ b/tests/StreamWrapperTest.php
@@ -59,6 +59,13 @@ class StreamWrapperTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('foobar', (string) $stream);
     }
 
+    public function testStreamContext()
+    {
+        $stream = Psr7\stream_for('foo');
+
+        $this->assertEquals('foo', file_get_contents('guzzle://stream', false, StreamWrapper::createStreamContext($stream)));
+    }
+
     /**
      * @expectedException \InvalidArgumentException
      */
@@ -98,5 +105,86 @@ class StreamWrapperTest extends \PHPUnit_Framework_TestCase
         $r = StreamWrapper::getResource($stream);
         $this->assertInternalType('resource', $r);
         fclose($r);
+    }
+
+    public function testUrlStat()
+    {
+        StreamWrapper::register();
+
+        $this->assertEquals(
+            [
+                'dev'     => 0,
+                'ino'     => 0,
+                'mode'    => 0,
+                'nlink'   => 0,
+                'uid'     => 0,
+                'gid'     => 0,
+                'rdev'    => 0,
+                'size'    => 0,
+                'atime'   => 0,
+                'mtime'   => 0,
+                'ctime'   => 0,
+                'blksize' => 0,
+                'blocks'  => 0,
+                0         => 0,
+                1         => 0,
+                2         => 0,
+                3         => 0,
+                4         => 0,
+                5         => 0,
+                6         => 0,
+                7         => 0,
+                8         => 0,
+                9         => 0,
+                10        => 0,
+                11        => 0,
+                12        => 0,
+            ],
+            stat('guzzle://stream')
+        );
+    }
+
+    public function testXmlReaderWithStream()
+    {
+        if (!class_exists('XMLReader')) {
+            $this->markTestSkipped('XML Reader is not available.');
+        }
+        if (defined('HHVM_VERSION')) {
+            $this->markTestSkipped('This does not work on HHVM.');
+        }
+
+        $stream = Psr7\stream_for('<?xml version="1.0" encoding="utf-8"?><foo />');
+
+        StreamWrapper::register();
+        libxml_set_streams_context(StreamWrapper::createStreamContext($stream));
+        $reader = new \XMLReader();
+
+        $this->assertTrue($reader->open('guzzle://stream'));
+        $this->assertTrue($reader->read());
+        $this->assertEquals('foo', $reader->name);
+    }
+
+    public function testXmlWriterWithStream()
+    {
+        if (!class_exists('XMLWriter')) {
+            $this->markTestSkipped('XML Writer is not available.');
+        }
+        if (defined('HHVM_VERSION')) {
+            $this->markTestSkipped('This does not work on HHVM.');
+        }
+
+        $stream = Psr7\stream_for(fopen('php://memory', 'wb'));
+
+        StreamWrapper::register();
+        libxml_set_streams_context(StreamWrapper::createStreamContext($stream));
+        $writer = new \XMLWriter();
+
+        $this->assertTrue($writer->openURI('guzzle://stream'));
+        $this->assertTrue($writer->startDocument());
+        $this->assertTrue($writer->writeElement('foo'));
+        $this->assertTrue($writer->endDocument());
+
+        $stream->rewind();
+        $this->assertXmlStringEqualsXmlString('<?xml version="1.0"?><foo />', (string) $stream);
     }
 }


### PR DESCRIPTION
This PR implements the missing `StreamWrapper::url_stat()` method as documented [here](http://php.net/manual/en/streamwrapper.url-stat.php). In addition, it adds a helper method `createStreamContext()` to allow userland code to perform the `fopen` operation for a stream.

Motivation: Many php core functions and extensions are able to operate on php streams, but they demand a URI and a stream context. `StreamWrapper::getResource()` however gives me an open stream resource which is useless in that case.

One example is the `XMLReader` class, which I find very useful for processing a large HTTP response body containing XML. With the current state of guzzle/psr7, I would try to open an XML Reader like this:

```php
<?php

use GuzzleHttp\Psr7\StreamWrapper;

StreamWrapper::register();
libxml_set_streams_context(stream_context_create([
    'guzzle' => ['stream' => $stream]
]));

$reader = new \XMLReader();
$reader->open('guzzle://stream');
```

Unfortunately, this fails because `XMLReader::open()` internally performs a `stat('guzzle://stream')` which fails with a warning `stat(): GuzzleHttp\Psr7\StreamWrapper::url_stat is not implemented!`.

If I add the implementation, the XML reader is happy (although we're unable to provide any helpful information here).

The PR also contains two PHPUnit tests covering the use-cases of operating `XMLReader` and `XMLWriter` on PSR-7 streams. If those tests are too specific, please say so and I'll remove them from the PR.