### PR TITLE
FnStream should never be unserialized

### DIFF
--- a/src/FnStream.php
+++ b/src/FnStream.php
@@ -53,6 +53,15 @@ class FnStream implements StreamInterface
     }
 
     /**
+     * An unserialize would allow the __destruct to run when the unserialized value goes out of scope.
+     * @throws \LogicException
+     */
+    public function __wakeup()
+    {
+        throw new \LogicException('FnStream should never be unserialized');
+    }
+
+    /**
      * Adds custom functionality to an underlying stream by intercepting
      * specific method calls.
      *

--- a/tests/FnStreamTest.php
+++ b/tests/FnStreamTest.php
@@ -88,4 +88,12 @@ class FnStreamTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $b->read(3));
         $this->assertTrue($called);
     }
+
+    public function testDoNotAllowUnserialization()
+    {
+        $this->setExpectedException('\LogicException');
+        $a = new FnStream([]);
+        $b = serialize($a);
+        unserialize($b);
+    }
 }

--- a/tests/FnStreamTest.php
+++ b/tests/FnStreamTest.php
@@ -91,9 +91,9 @@ class FnStreamTest extends \PHPUnit_Framework_TestCase
 
     public function testDoNotAllowUnserialization()
     {
-        $this->setExpectedException('\LogicException');
         $a = new FnStream([]);
         $b = serialize($a);
+        $this->setExpectedException('\LogicException', 'FnStream should never be unserialized');
         unserialize($b);
     }
 }


### PR DESCRIPTION
Given the fact that this is a very popular package, I would suggest to not allow an unserialization for FnStream.
A serialize of this type is pointless anyway as serialization of closures are not allowed.
The FnStream combined with an unserialize of a string inputted by a client could result in executing code via the destructor.
Of course people should be careful what they do with the unserialize function, but this pull request would at least limit the attack surface.
People have been using this do demonstrate CVE-2017-6920 (https://paper.seebug.org/334/)