### PR TITLE
Create a request with an array body type

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -111,6 +111,8 @@ function stream_for($resource = '', array $options = [])
 
     if (is_callable($resource)) {
         return new PumpStream($resource, $options);
+    } elseif (is_array($resource)) {
+        return stream_for(http_build_query($resource, '', '&'), $options);
     }
 
     throw new \InvalidArgumentException('Invalid resource type: ' . gettype($resource));

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -4,6 +4,7 @@ namespace GuzzleHttp\Tests\Psr7;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Uri;
+use Psr\Http\Message\StreamInterface;
 
 /**
  * @covers GuzzleHttp\Psr7\Request
@@ -191,5 +192,11 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $r = new Request('GET', 'http://foo.com:8124/bar');
         $r = $r->withUri(new Uri('http://foo.com:8125/bar'));
         $this->assertEquals('foo.com:8125', $r->getHeaderLine('host'));
+    }
+
+    public function testAssertArrayBody()
+    {
+        $r = new Request('GET', '/', [], ['foo' => 'bar']);
+        $this->assertInstanceOf(StreamInterface::class, $r->getBody());
     }
 }


### PR DESCRIPTION
The "$body" argument can be of type array when creating a new instance of GuzzleHttp\Psr7\Request