### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "psr/http-message": "~1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0"
+        "phpunit/phpunit": "~4.8.35"
     },
     "provide": {
         "psr/http-message-implementation": "1.0"

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "psr/http-message": "~1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.8.35"
+        "phpunit/phpunit": "~4.8.36 || ^5.7.25 || ^6.4"
     },
     "provide": {
         "psr/http-message-implementation": "1.0"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
+<phpunit bootstrap="tests/bootstrap.php"
          colors="true">
   <testsuites>
     <testsuite>

--- a/tests/AppendStreamTest.php
+++ b/tests/AppendStreamTest.php
@@ -3,8 +3,9 @@ namespace GuzzleHttp\Tests\Psr7;
 
 use GuzzleHttp\Psr7\AppendStream;
 use GuzzleHttp\Psr7;
+use PHPUnit\Framework\TestCase;
 
-class AppendStreamTest extends \PHPUnit_Framework_TestCase
+class AppendStreamTest extends TestCase
 {
     /**
      * @expectedException \InvalidArgumentException

--- a/tests/BufferStreamTest.php
+++ b/tests/BufferStreamTest.php
@@ -2,8 +2,9 @@
 namespace GuzzleHttp\Tests\Psr7;
 
 use GuzzleHttp\Psr7\BufferStream;
+use PHPUnit\Framework\TestCase;
 
-class BufferStreamTest extends \PHPUnit_Framework_TestCase
+class BufferStreamTest extends TestCase
 {
     public function testHasMetadata()
     {

--- a/tests/CachingStreamTest.php
+++ b/tests/CachingStreamTest.php
@@ -4,11 +4,12 @@ namespace GuzzleHttp\Tests\Psr7;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\CachingStream;
 use GuzzleHttp\Psr7\Stream;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers GuzzleHttp\Psr7\CachingStream
  */
-class CachingStreamTest extends \PHPUnit_Framework_TestCase
+class CachingStreamTest extends TestCase
 {
     /** @var CachingStream */
     private $body;

--- a/tests/DroppingStreamTest.php
+++ b/tests/DroppingStreamTest.php
@@ -3,8 +3,9 @@ namespace GuzzleHttp\Tests\Psr7;
 
 use GuzzleHttp\Psr7\BufferStream;
 use GuzzleHttp\Psr7\DroppingStream;
+use PHPUnit\Framework\TestCase;
 
-class DroppingStreamTest extends \PHPUnit_Framework_TestCase
+class DroppingStreamTest extends TestCase
 {
     public function testBeginsDroppingWhenSizeExceeded()
     {

--- a/tests/FnStreamTest.php
+++ b/tests/FnStreamTest.php
@@ -90,11 +90,14 @@ class FnStreamTest extends TestCase
         $this->assertTrue($called);
     }
 
+    /**
+     * @expectedException LogicException
+     * @expectedExceptionMessage FnStream should never be unserialized
+     */
     public function testDoNotAllowUnserialization()
     {
         $a = new FnStream([]);
         $b = serialize($a);
-        $this->setExpectedException('\LogicException', 'FnStream should never be unserialized');
         unserialize($b);
     }
 }

--- a/tests/FnStreamTest.php
+++ b/tests/FnStreamTest.php
@@ -3,11 +3,12 @@ namespace GuzzleHttp\Tests\Psr7;
 
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\FnStream;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers GuzzleHttp\Psr7\FnStream
  */
-class FnStreamTest extends \PHPUnit_Framework_TestCase
+class FnStreamTest extends TestCase
 {
     /**
      * @expectedException \BadMethodCallException

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -5,8 +5,9 @@ use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\FnStream;
 use GuzzleHttp\Psr7\NoSeekStream;
 use Psr\Http\Message\ServerRequestInterface;
+use PHPUnit\Framework\TestCase;
 
-class FunctionsTest extends \PHPUnit_Framework_TestCase
+class FunctionsTest extends TestCase
 {
     public function testCopiesToString()
     {

--- a/tests/InflateStreamTest.php
+++ b/tests/InflateStreamTest.php
@@ -3,8 +3,9 @@ namespace GuzzleHttp\Tests\Psr7;
 
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\InflateStream;
+use PHPUnit\Framework\TestCase;
 
-class InflateStreamtest extends \PHPUnit_Framework_TestCase
+class InflateStreamtest extends TestCase
 {
     public function testInflatesStreams()
     {

--- a/tests/LazyOpenStreamTest.php
+++ b/tests/LazyOpenStreamTest.php
@@ -2,8 +2,9 @@
 namespace GuzzleHttp\Tests\Psr7;
 
 use GuzzleHttp\Psr7\LazyOpenStream;
+use PHPUnit\Framework\TestCase;
 
-class LazyOpenStreamTest extends \PHPUnit_Framework_TestCase
+class LazyOpenStreamTest extends TestCase
 {
     private $fname;
 

--- a/tests/LimitStreamTest.php
+++ b/tests/LimitStreamTest.php
@@ -6,11 +6,12 @@ use GuzzleHttp\Psr7\FnStream;
 use GuzzleHttp\Psr7\Stream;
 use GuzzleHttp\Psr7\LimitStream;
 use GuzzleHttp\Psr7\NoSeekStream;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers GuzzleHttp\Psr7\LimitStream
  */
-class LimitStreamTest extends \PHPUnit_Framework_TestCase
+class LimitStreamTest extends TestCase
 {
     /** @var LimitStream */
     private $body;

--- a/tests/MultipartStreamTest.php
+++ b/tests/MultipartStreamTest.php
@@ -3,8 +3,9 @@ namespace GuzzleHttp\Tests;
 
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\MultipartStream;
+use PHPUnit\Framework\TestCase;
 
-class MultipartStreamTest extends \PHPUnit_Framework_TestCase
+class MultipartStreamTest extends TestCase
 {
     public function testCreatesDefaultBoundary()
     {

--- a/tests/NoSeekStreamTest.php
+++ b/tests/NoSeekStreamTest.php
@@ -3,12 +3,13 @@ namespace GuzzleHttp\Tests\Psr7;
 
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\NoSeekStream;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers GuzzleHttp\Psr7\NoSeekStream
  * @covers GuzzleHttp\Psr7\StreamDecoratorTrait
  */
-class NoSeekStreamTest extends \PHPUnit_Framework_TestCase
+class NoSeekStreamTest extends TestCase
 {
     /**
      * @expectedException \RuntimeException

--- a/tests/PumpStreamTest.php
+++ b/tests/PumpStreamTest.php
@@ -4,8 +4,9 @@ namespace GuzzleHttp\Tests\Psr7;
 use GuzzleHttp\Psr7\LimitStream;
 use GuzzleHttp\Psr7\PumpStream;
 use GuzzleHttp\Psr7;
+use PHPUnit\Framework\TestCase;
 
-class PumpStreamTest extends \PHPUnit_Framework_TestCase
+class PumpStreamTest extends TestCase
 {
     public function testHasMetadataAndSize()
     {

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -4,11 +4,12 @@ namespace GuzzleHttp\Tests\Psr7;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Uri;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers GuzzleHttp\Psr7\Request
  */
-class RequestTest extends \PHPUnit_Framework_TestCase
+class RequestTest extends TestCase
 {
     public function testRequestUriMayBeString()
     {

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -3,12 +3,13 @@ namespace GuzzleHttp\Tests\Psr7;
 
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers GuzzleHttp\Psr7\MessageTrait
  * @covers GuzzleHttp\Psr7\Response
  */
-class ResponseTest extends \PHPUnit_Framework_TestCase
+class ResponseTest extends TestCase
 {
     public function testDefaultConstructor()
     {

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -4,11 +4,12 @@ namespace GuzzleHttp\Tests\Psr7;
 use GuzzleHttp\Psr7\ServerRequest;
 use GuzzleHttp\Psr7\UploadedFile;
 use GuzzleHttp\Psr7\Uri;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers GuzzleHttp\Psr7\ServerRequest
  */
-class ServerRequestTest extends \PHPUnit_Framework_TestCase
+class ServerRequestTest extends TestCase
 {
     public function dataNormalizeFiles()
     {

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -265,10 +265,12 @@ class ServerRequestTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Invalid value in files specification
+     */
     public function testNormalizeFilesRaisesException()
     {
-        $this->setExpectedException('InvalidArgumentException', 'Invalid value in files specification');
-
         ServerRequest::normalizeFiles(['test' => 'something']);
     }
 

--- a/tests/StreamDecoratorTraitTest.php
+++ b/tests/StreamDecoratorTraitTest.php
@@ -4,6 +4,7 @@ namespace GuzzleHttp\Tests\Psr7;
 use Psr\Http\Message\StreamInterface;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\StreamDecoratorTrait;
+use PHPUnit\Framework\TestCase;
 
 class Str implements StreamInterface
 {
@@ -13,7 +14,7 @@ class Str implements StreamInterface
 /**
  * @covers GuzzleHttp\Psr7\StreamDecoratorTrait
  */
-class StreamDecoratorTraitTest extends \PHPUnit_Framework_TestCase
+class StreamDecoratorTraitTest extends TestCase
 {
     /** @var StreamInterface */
     private $a;

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -3,11 +3,12 @@ namespace GuzzleHttp\Tests\Psr7;
 
 use GuzzleHttp\Psr7\NoSeekStream;
 use GuzzleHttp\Psr7\Stream;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers GuzzleHttp\Psr7\Stream
  */
-class StreamTest extends \PHPUnit_Framework_TestCase
+class StreamTest extends TestCase
 {
     public static $isFReadError = false;
 

--- a/tests/StreamWrapperTest.php
+++ b/tests/StreamWrapperTest.php
@@ -78,7 +78,7 @@ class StreamWrapperTest extends TestCase
     }
 
     /**
-     * @expectedException \PHPUnit_Framework_Error_Warning
+     * @expectedException PHPUnit\Framework\Error\Warning
      */
     public function testReturnsFalseWhenStreamDoesNotExist()
     {

--- a/tests/StreamWrapperTest.php
+++ b/tests/StreamWrapperTest.php
@@ -3,11 +3,12 @@ namespace GuzzleHttp\Tests\Psr7;
 
 use GuzzleHttp\Psr7\StreamWrapper;
 use GuzzleHttp\Psr7;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers GuzzleHttp\Psr7\StreamWrapper
  */
-class StreamWrapperTest extends \PHPUnit_Framework_TestCase
+class StreamWrapperTest extends TestCase
 {
     public function testResource()
     {

--- a/tests/UploadedFileTest.php
+++ b/tests/UploadedFileTest.php
@@ -41,12 +41,11 @@ class UploadedFileTest extends TestCase
     }
 
     /**
+     * @expectedException InvalidArgumentException
      * @dataProvider invalidStreams
      */
     public function testRaisesExceptionOnInvalidStreamOrFile($streamOrFile)
     {
-        $this->setExpectedException('InvalidArgumentException');
-
         new UploadedFile($streamOrFile, 0, UPLOAD_ERR_OK);
     }
 
@@ -61,12 +60,12 @@ class UploadedFileTest extends TestCase
     }
 
     /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage size
      * @dataProvider invalidSizes
      */
     public function testRaisesExceptionOnInvalidSize($size)
     {
-        $this->setExpectedException('InvalidArgumentException', 'size');
-
         new UploadedFile(fopen('php://temp', 'wb+'), $size, UPLOAD_ERR_OK);
     }
 
@@ -86,12 +85,12 @@ class UploadedFileTest extends TestCase
     }
 
     /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage status
      * @dataProvider invalidErrorStatuses
      */
     public function testRaisesExceptionOnInvalidErrorStatus($status)
     {
-        $this->setExpectedException('InvalidArgumentException', 'status');
-
         new UploadedFile(fopen('php://temp', 'wb+'), 0, $status);
     }
 
@@ -108,22 +107,22 @@ class UploadedFileTest extends TestCase
     }
 
     /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage filename
      * @dataProvider invalidFilenamesAndMediaTypes
      */
     public function testRaisesExceptionOnInvalidClientFilename($filename)
     {
-        $this->setExpectedException('InvalidArgumentException', 'filename');
-
         new UploadedFile(fopen('php://temp', 'wb+'), 0, UPLOAD_ERR_OK, $filename);
     }
 
     /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage media type
      * @dataProvider invalidFilenamesAndMediaTypes
      */
     public function testRaisesExceptionOnInvalidClientMediaType($mediaType)
     {
-        $this->setExpectedException('InvalidArgumentException', 'media type');
-
         new UploadedFile(fopen('php://temp', 'wb+'), 0, UPLOAD_ERR_OK, 'foobar.baz', $mediaType);
     }
 
@@ -185,6 +184,8 @@ class UploadedFileTest extends TestCase
     }
 
     /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage path
      * @dataProvider invalidMovePaths
      */
     public function testMoveRaisesExceptionForInvalidPath($path)
@@ -194,10 +195,13 @@ class UploadedFileTest extends TestCase
 
         $this->cleanup[] = $path;
 
-        $this->setExpectedException('InvalidArgumentException', 'path');
         $upload->moveTo($path);
     }
 
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage moved
+     */
     public function testMoveCannotBeCalledMoreThanOnce()
     {
         $stream = \GuzzleHttp\Psr7\stream_for('Foo bar!');
@@ -207,10 +211,13 @@ class UploadedFileTest extends TestCase
         $upload->moveTo($to);
         $this->assertTrue(file_exists($to));
 
-        $this->setExpectedException('RuntimeException', 'moved');
         $upload->moveTo($to);
     }
 
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage moved
+     */
     public function testCannotRetrieveStreamAfterMove()
     {
         $stream = \GuzzleHttp\Psr7\stream_for('Foo bar!');
@@ -220,7 +227,6 @@ class UploadedFileTest extends TestCase
         $upload->moveTo($to);
         $this->assertFileExists($to);
 
-        $this->setExpectedException('RuntimeException', 'moved');
         $upload->getStream();
     }
 
@@ -247,22 +253,24 @@ class UploadedFileTest extends TestCase
     }
 
     /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage upload error
      * @dataProvider nonOkErrorStatus
      */
     public function testMoveToRaisesExceptionWhenErrorStatusPresent($status)
     {
         $uploadedFile = new UploadedFile('not ok', 0, $status);
-        $this->setExpectedException('RuntimeException', 'upload error');
         $uploadedFile->moveTo(__DIR__ . '/' . sha1(uniqid('', true)));
     }
 
     /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage upload error
      * @dataProvider nonOkErrorStatus
      */
     public function testGetStreamRaisesExceptionWhenErrorStatusPresent($status)
     {
         $uploadedFile = new UploadedFile('not ok', 0, $status);
-        $this->setExpectedException('RuntimeException', 'upload error');
         $uploadedFile->getStream();
     }
 

--- a/tests/UploadedFileTest.php
+++ b/tests/UploadedFileTest.php
@@ -4,11 +4,12 @@ namespace GuzzleHttp\Tests\Psr7;
 use ReflectionProperty;
 use GuzzleHttp\Psr7\Stream;
 use GuzzleHttp\Psr7\UploadedFile;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers GuzzleHttp\Psr7\UploadedFile
  */
-class UploadedFileTest extends \PHPUnit_Framework_TestCase
+class UploadedFileTest extends TestCase
 {
     private $cleanup;
 

--- a/tests/UriNormalizerTest.php
+++ b/tests/UriNormalizerTest.php
@@ -3,11 +3,12 @@ namespace GuzzleHttp\Tests\Psr7;
 
 use GuzzleHttp\Psr7\Uri;
 use GuzzleHttp\Psr7\UriNormalizer;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers GuzzleHttp\Psr7\UriNormalizer
  */
-class UriNormalizerTest extends \PHPUnit_Framework_TestCase
+class UriNormalizerTest extends TestCase
 {
     public function testCapitalizePercentEncoding()
     {

--- a/tests/UriNormalizerTest.php
+++ b/tests/UriNormalizerTest.php
@@ -83,7 +83,7 @@ class UriNormalizerTest extends TestCase
 
     public function testRemoveDefaultPort()
     {
-        $uri = $this->getMock('Psr\Http\Message\UriInterface');
+        $uri = $this->getMockBuilder('Psr\Http\Message\UriInterface')->getMock();
         $uri->expects($this->any())->method('getScheme')->will($this->returnValue('http'));
         $uri->expects($this->any())->method('getPort')->will($this->returnValue(80));
         $uri->expects($this->once())->method('withPort')->with(null)->will($this->returnValue(new Uri('http://example.org')));

--- a/tests/UriResoverTest.php
+++ b/tests/UriResoverTest.php
@@ -3,11 +3,12 @@ namespace GuzzleHttp\Tests\Psr7;
 
 use GuzzleHttp\Psr7\Uri;
 use GuzzleHttp\Psr7\UriResolver;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers GuzzleHttp\Psr7\UriResolver
  */
-class UriResolverTest extends \PHPUnit_Framework_TestCase
+class UriResolverTest extends TestCase
 {
     const RFC3986_BASE = 'http://a/b/c/d;p?q';
 

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -2,11 +2,12 @@
 namespace GuzzleHttp\Tests\Psr7;
 
 use GuzzleHttp\Psr7\Uri;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers GuzzleHttp\Psr7\Uri
  */
-class UriTest extends \PHPUnit_Framework_TestCase
+class UriTest extends TestCase
 {
     public function testParsesProvidedUri()
     {

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -222,7 +222,7 @@ class UriTest extends TestCase
      */
     public function testIsDefaultPort($scheme, $port, $isDefaultPort)
     {
-        $uri = $this->getMock('Psr\Http\Message\UriInterface');
+        $uri = $this->getMockBuilder('Psr\Http\Message\UriInterface')->getMock();
         $uri->expects($this->any())->method('getScheme')->will($this->returnValue($scheme));
         $uri->expects($this->any())->method('getPort')->will($this->returnValue($port));
 
@@ -588,6 +588,9 @@ class UriTest extends TestCase
         (new Uri)->withPath('//foo');
     }
 
+    /**
+     * @expectedException InvalidArgumentException
+     */
     public function testPathStartingWithTwoSlashes()
     {
         $uri = new Uri('http://example.org//path-not-host.com');
@@ -595,7 +598,6 @@ class UriTest extends TestCase
 
         $uri = $uri->withScheme('');
         $this->assertSame('//example.org//path-not-host.com', (string) $uri); // This is still valid
-        $this->setExpectedException('\InvalidArgumentException');
         $uri->withHost(''); // Now it becomes invalid
     }
 
@@ -608,12 +610,14 @@ class UriTest extends TestCase
         (new Uri)->withPath('mailto:foo');
     }
 
+    /**
+     * @expectedException InvalidArgumentException
+     */
     public function testRelativeUriWithPathHavingColonSegment()
     {
         $uri = (new Uri('urn:/mailto:foo'))->withScheme('');
         $this->assertSame('/mailto:foo', $uri->getPath());
 
-        $this->setExpectedException('\InvalidArgumentException');
         (new Uri('urn:mailto:foo'))->withScheme('');
     }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,7 @@
+<?php
+
+require_once './vendor/autoload.php';
+
+if (!class_exists('PHPUnit\Framework\Error\Warning')) {
+  class_alias('PHPUnit_Framework_Error_Warning', 'PHPUnit\Framework\Error\Warning');
+}


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`~4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this namespace.