### PR TITLE
Add Request::__toString

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Fix `AppendStream::detach` to not close streams
 * Clarify exception message when stream is detached
 * Added a test for #129 behavior
+* Added `Request::__toString` to return HTTP message representation of object
 
 ## 1.4.2 - 2017-03-20
 

--- a/src/Request.php
+++ b/src/Request.php
@@ -54,6 +54,25 @@ class Request implements RequestInterface
         }
     }
 
+    /**
+     * String representation of Request-object as HTTP message
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        if (!$this->hasHeader('Content-Length')) {
+            $message = $this->withAddedHeader(
+                'Content-Length',
+                $this->getBody()->getSize()
+            );
+        } else {
+            $message = $this;
+        }
+
+        return str($message);
+    }
+
     public function getRequestTarget()
     {
         if ($this->requestTarget !== null) {

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -192,4 +192,18 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $r = $r->withUri(new Uri('http://foo.com:8125/bar'));
         $this->assertEquals('foo.com:8125', $r->getHeaderLine('host'));
     }
+
+    public function testToString()
+    {
+        $r = new Request('POST', 'http://foo.com:8124/bar', ['Content-Length'=>0], '{"zoo":"baz"}');
+        $this->assertSame(
+            'POST /bar HTTP/1.1'."\r\n".'Host: foo.com:8124'."\r\n".'Content-Length: 0'."\r\n\r\n".'{"zoo":"baz"}',
+            sprintf("%s", $r)
+        );
+        $r = $r->withoutHeader('Content-Length');
+        $this->assertSame(
+            'POST /bar HTTP/1.1'."\r\n".'Host: foo.com:8124'."\r\n".'Content-Length: 13'."\r\n\r\n".'{"zoo":"baz"}',
+            sprintf("%s", $r)
+        );
+    }
 }


### PR DESCRIPTION
Allow Request object to be converted to string.
The representation is basically using the internal str(MessageInterface)
function and additionally makes sure the Content-Length header is set.
This allows directly writing the Request-object to a socket.