### PR TITLE
Fix modify_request function to respect ServerRequest with UploadedFiles

### DIFF
--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -68,9 +68,11 @@ class ServerRequest extends Request implements ServerRequestInterface
         array $headers = [],
         $body = null,
         $version = '1.1',
-        array $serverParams = []
+        array $serverParams = [],
+        array $uploadedFiles = []
     ) {
         $this->serverParams = $serverParams;
+        $this->uploadedFiles = $uploadedFiles;
 
         parent::__construct($method, $uri, $headers, $body, $version);
     }

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -68,11 +68,9 @@ class ServerRequest extends Request implements ServerRequestInterface
         array $headers = [],
         $body = null,
         $version = '1.1',
-        array $serverParams = [],
-        array $uploadedFiles = []
+        array $serverParams = []
     ) {
         $this->serverParams = $serverParams;
-        $this->uploadedFiles = $uploadedFiles;
 
         parent::__construct($method, $uri, $headers, $body, $version);
     }

--- a/src/functions.php
+++ b/src/functions.php
@@ -246,7 +246,8 @@ function modify_request(RequestInterface $request, array $changes)
             isset($changes['version'])
                 ? $changes['version']
                 : $request->getProtocolVersion(),
-            $request->getServerParams()
+            $request->getServerParams(),
+            $request->getUploadedFiles()
         );
     }
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -247,7 +247,12 @@ function modify_request(RequestInterface $request, array $changes)
                 ? $changes['version']
                 : $request->getProtocolVersion(),
             $request->getServerParams()
-        ))->withUploadedFiles($request->getUploadedFiles());
+        ))
+        ->withParsedBody($request->getParsedBody())
+        ->withQueryParams($request->getQueryParams())
+        ->withCookieParams($request->getCookieParams())
+        ->withUploadedFiles($request->getUploadedFiles());
+
     }
 
     return new Request(

--- a/src/functions.php
+++ b/src/functions.php
@@ -238,7 +238,7 @@ function modify_request(RequestInterface $request, array $changes)
     }
 
     if ($request instanceof ServerRequestInterface) {
-        return new ServerRequest(
+        return (new ServerRequest(
             isset($changes['method']) ? $changes['method'] : $request->getMethod(),
             $uri,
             $headers,
@@ -246,9 +246,8 @@ function modify_request(RequestInterface $request, array $changes)
             isset($changes['version'])
                 ? $changes['version']
                 : $request->getProtocolVersion(),
-            $request->getServerParams(),
-            $request->getUploadedFiles()
-        );
+            $request->getServerParams()
+        ))->withUploadedFiles($request->getUploadedFiles());
     }
 
     return new Request(

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -671,7 +671,9 @@ class FunctionsTest extends \PHPUnit_Framework_TestCase
         $modifiedRequest = Psr7\modify_request($request, ['set_headers' => ['foo' => 'bar']]);
 
         $this->assertCount(1, $modifiedRequest->getUploadedFiles());
-        $this->assertInstanceOf(Psr7\UploadedFile::class, $modifiedRequest->getUploadedFiles()[0]);
+
+        $files = $modifiedRequest->getUploadedFiles();
+        $this->assertInstanceOf('GuzzleHttp\Psr7\UploadedFile', $files[0]);
 
     }
 }

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -660,6 +660,20 @@ class FunctionsTest extends \PHPUnit_Framework_TestCase
         $r2 = Psr7\modify_request($r1, ['remove_headers' => ['non-existent']]);
         $this->assertTrue($r2 instanceof ServerRequestInterface);
     }
+
+    public function testModifyServerRequestWithUploadedFiles()
+    {
+        $request = new Psr7\ServerRequest('GET', 'http://example.com/bla');
+        $file = new Psr7\UploadedFile('Test', 100, \UPLOAD_ERR_OK);
+        $request = $request->withUploadedFiles([$file]);
+
+        /** @var Psr7\ServerRequest $modifiedRequest */
+        $modifiedRequest = Psr7\modify_request($request, ['set_headers' => ['foo' => 'bar']]);
+
+        $this->assertCount(1, $modifiedRequest->getUploadedFiles());
+        $this->assertInstanceOf(Psr7\UploadedFile::class, $modifiedRequest->getUploadedFiles()[0]);
+
+    }
 }
 
 class HasToString

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -676,6 +676,40 @@ class FunctionsTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('GuzzleHttp\Psr7\UploadedFile', $files[0]);
 
     }
+
+    public function testModifyServerRequestWithCookies()
+    {
+        $request = (new Psr7\ServerRequest('GET', 'http://example.com/bla'))
+            ->withCookieParams(['name' => 'value']);
+
+        /** @var Psr7\ServerRequest $modifiedRequest */
+        $modifiedRequest = Psr7\modify_request($request, ['set_headers' => ['foo' => 'bar']]);
+
+        $this->assertEquals(['name' => 'value'], $modifiedRequest->getCookieParams());
+    }
+
+
+    public function testModifyServerRequestParsedBody()
+    {
+        $request = (new Psr7\ServerRequest('GET', 'http://example.com/bla'))
+            ->withParsedBody(['name' => 'value']);
+
+        /** @var Psr7\ServerRequest $modifiedRequest */
+        $modifiedRequest = Psr7\modify_request($request, ['set_headers' => ['foo' => 'bar']]);
+
+        $this->assertEquals(['name' => 'value'], $modifiedRequest->getParsedBody());
+    }
+
+    public function testModifyServerRequestQueryParams()
+    {
+        $request = (new Psr7\ServerRequest('GET', 'http://example.com/bla'))
+            ->withQueryParams(['name' => 'value']);
+
+        /** @var Psr7\ServerRequest $modifiedRequest */
+        $modifiedRequest = Psr7\modify_request($request, ['set_headers' => ['foo' => 'bar']]);
+
+        $this->assertEquals(['name' => 'value'], $modifiedRequest->getQueryParams());
+    }
 }
 
 class HasToString


### PR DESCRIPTION
Trying to fix https://github.com/guzzle/psr7/issues/177. The `modify_request` function removes the `uploadedFile` array out of the `ServerRequest` because it returns `new ServerRequest` and `ServerRequest` object doesn't have `uploadedFile` array as an argument in the constructor.
