### PR TITLE
Closes #189 - detect https in the wild

### DIFF
--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -188,7 +188,24 @@ class ServerRequest extends Request implements ServerRequestInterface
     public static function getUriFromGlobals() {
         $uri = new Uri('');
 
-        $uri = $uri->withScheme(!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off' ? 'https' : 'http');
+        $https_keys = [
+            'HTTP_X_FORWARDED_PROTO' => 'http',
+            'HTTP_X_FORWARDED_PROTOCOL' => 'http',
+            'HTTP_X_FORWARDED_SSL' => 'off',
+            'HTTP_FRONT_END_HTTPS' => 'off',
+            'HTTP_X_URL_SCHEME' => 'http',
+            'HTTPS' => 'off',
+        ];
+
+        $scheme = 'http';
+        foreach ($https_keys as $key => $value) {
+            if (isset($_SERVER[$key]) && $_SERVER[$key] != $value) {
+                $scheme = 'https';
+                break;
+            }
+        }
+
+        $uri = $uri->withScheme($scheme);
 
         $hasPort = false;
         if (isset($_SERVER['HTTP_HOST'])) {

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -189,7 +189,7 @@ class ServerRequest extends Request implements ServerRequestInterface
     {
         $uri = new Uri('');
 
-        $https_keys = [
+        $httpsKeys = [
             'HTTP_X_FORWARDED_PROTOCOL' => 'http',
             'HTTP_X_FORWARDED_PROTO'    => 'http',
             'HTTP_X_FORWARDED_SSL'      => 'off',
@@ -199,7 +199,7 @@ class ServerRequest extends Request implements ServerRequestInterface
         ];
 
         $scheme = 'http';
-        foreach ($https_keys as $key => $value) {
+        foreach ($httpsKeys as $key => $value) {
             if (isset($_SERVER[$key]) && $_SERVER[$key] != $value) {
                 $scheme = 'https';
                 break;

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -185,16 +185,17 @@ class ServerRequest extends Request implements ServerRequestInterface
      *
      * @return UriInterface
      */
-    public static function getUriFromGlobals() {
+    public static function getUriFromGlobals()
+    {
         $uri = new Uri('');
 
         $https_keys = [
-            'HTTP_X_FORWARDED_PROTO' => 'http',
             'HTTP_X_FORWARDED_PROTOCOL' => 'http',
-            'HTTP_X_FORWARDED_SSL' => 'off',
-            'HTTP_FRONT_END_HTTPS' => 'off',
-            'HTTP_X_URL_SCHEME' => 'http',
-            'HTTPS' => 'off',
+            'HTTP_X_FORWARDED_PROTO'    => 'http',
+            'HTTP_X_FORWARDED_SSL'      => 'off',
+            'HTTP_FRONT_END_HTTPS'      => 'off',
+            'HTTP_X_URL_SCHEME'         => 'http',
+            'HTTPS'                     => 'off',
         ];
 
         $scheme = 'http';

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -300,6 +300,34 @@ class ServerRequestTest extends \PHPUnit_Framework_TestCase
                 'https://www.example.org/blog/article.php?id=10&user=foo',
                 array_merge($server, ['HTTPS' => '1']),
             ],
+            'HTTPS request with x-forwarded-proto' => [
+                'https://www.example.org/blog/article.php?id=10&user=foo',
+                array_merge($server, ['HTTP_X_FORWARDED_PROTO' => 'https']),
+            ],
+            'HTTPS request with x-forwarded-protocol' => [
+                'https://www.example.org/blog/article.php?id=10&user=foo',
+                array_merge($server, ['HTTP_X_FORWARDED_PROTOCOL' => 'https']),
+            ],
+            'HTTPS request with x-forwarded-ssl' => [
+                'https://www.example.org/blog/article.php?id=10&user=foo',
+                array_merge($server, ['HTTP_X_FORWARDED_SSL' => 'on']),
+            ],
+            'HTTPS request with different x-forwarded-ssl value' => [
+                'https://www.example.org/blog/article.php?id=10&user=foo',
+                array_merge($server, ['HTTP_X_FORWARDED_SSL' => '1']),
+            ],
+            'HTTPS request with front-end-https' => [
+                'https://www.example.org/blog/article.php?id=10&user=foo',
+                array_merge($server, ['HTTP_FRONT_END_HTTPS' => 'on']),
+            ],
+            'HTTPS request with different front-end-https value' => [
+                'https://www.example.org/blog/article.php?id=10&user=foo',
+                array_merge($server, ['HTTP_FRONT_END_HTTPS' => '1']),
+            ],
+            'HTTPS request with x-url-scheme' => [
+                'https://www.example.org/blog/article.php?id=10&user=foo',
+                array_merge($server, ['HTTP_X_URL_SCHEME' => '1']),
+            ],
             'HTTP request' => [
                 'http://www.example.org/blog/article.php?id=10&user=foo',
                 array_merge($server, ['HTTPS' => 'off', 'SERVER_PORT' => '80']),

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -326,7 +326,7 @@ class ServerRequestTest extends \PHPUnit_Framework_TestCase
             ],
             'HTTPS request with x-url-scheme' => [
                 'https://www.example.org/blog/article.php?id=10&user=foo',
-                array_merge($server, ['HTTP_X_URL_SCHEME' => '1']),
+                array_merge($server, ['HTTP_X_URL_SCHEME' => 'https']),
             ],
             'HTTP request' => [
                 'http://www.example.org/blog/article.php?id=10&user=foo',


### PR DESCRIPTION
Https schemes set up by servers will vary. The $_SERVER ['HTTPS'] will not always be present, and each server implements a different key to inform PHP that the communication with the client was secure.

This pull request fixes this issue by checking for six different keys, including the most used ones by Nginx and IIS.

More information about different key schemes can be found here:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto