### PR TITLE
Use parse_url to extract port from host (Support IPv6 local loopback)

### DIFF
--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -182,19 +182,12 @@ class ServerRequest extends Request implements ServerRequestInterface
 
     private static function extractPortFromHost($host)
     {
-        if (preg_match('/:(\d+)$/', $host, $matches) !== 1) {
-            return [$host, null];
-        }
+        $url = "http://{$host}";
+        $parts = parse_url($url);
+        $host = $parts['host'];
+        $port = isset($parts['port']) ? $parts['port'] : null;
 
-        list($match, $port) = $matches;
-
-        $host = mb_substr(
-            $host,
-            0,
-            mb_strlen($host) - mb_strlen($match)
-        );
-
-        return [$host, (int) $port];
+        return [$host, $port];
     }
 
     /**

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -324,6 +324,10 @@ class ServerRequestTest extends \PHPUnit_Framework_TestCase
                 'https://www.example.org:8324/blog/article.php?id=10&user=foo',
                 array_merge($server, ['HTTP_HOST' => 'www.example.org:8324']),
             ],
+            'IPv6 local loopback address' => [
+                'https://[::1]:8000/blog/article.php?id=10&user=foo',
+                array_merge($server, ['HTTP_HOST' => '[::1]:8000']),
+            ],
             'Different port with SERVER_PORT' => [
                 'https://www.example.org:8324/blog/article.php?id=10&user=foo',
                 array_merge($server, ['SERVER_PORT' => '8324']),


### PR DESCRIPTION
If the host is an IPv6 local loopback address then

`explode(':', '[::1]:8000')` will return

```
array(4) {
  [0]=>
  string(1) "["
  [1]=>
  string(0) ""
  [2]=>
  string(2) "1]"
  [3]=>
  string(4) "8000"
}
```

This results in an `InvalidArgumentException` because the port is not between 1 and 65535 (The code assumed that port is always at index `1`)

We can use a regex to match only on the last port of the host.

UPDATE: We'll use `parse_url` instead of a regex as suggested.

Closes #193 