### PR TITLE
Fix trim headers values

### DIFF
--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -177,7 +177,7 @@ trait MessageTrait
     private function trimHeaderValues(array $values)
     {
         return array_map(function ($value) {
-            return trim($value, " \t");
+            return trim(strval($value), " \t");
         }, $values);
     }
 }


### PR DESCRIPTION
Fix Type error: trim() expects parameter 1 to be string, integer given" at /vendor/nyholm/psr7/src/MessageTrait.php line 216