### PR TITLE
stream_for docblock: `$resource` accepts Iterator

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -69,8 +69,8 @@ function uri_for($uri)
  * - metadata: Array of custom metadata.
  * - size: Size of the stream.
  *
- * @param resource|string|null|int|float|bool|StreamInterface|callable $resource Entity body data
- * @param array                                                        $options  Additional options
+ * @param resource|string|null|int|float|bool|StreamInterface|callable|\Iterator $resource Entity body data
+ * @param array                                                                  $options  Additional options
  *
  * @return StreamInterface
  * @throws \InvalidArgumentException if the $resource arg is not valid.


### PR DESCRIPTION
As per function's code - `stream_for` accepts `Iterator`, which is not mentioned in acceptable types for `$resource`