### PR TITLE
Hotfix (hardcode) for working on php 7.1

### DIFF
--- a/src/Stream.php
+++ b/src/Stream.php
@@ -24,7 +24,7 @@ class Stream implements StreamInterface
             'r' => true, 'w+' => true, 'r+' => true, 'x+' => true, 'c+' => true,
             'rb' => true, 'w+b' => true, 'r+b' => true, 'x+b' => true,
             'c+b' => true, 'rt' => true, 'w+t' => true, 'r+t' => true,
-            'x+t' => true, 'c+t' => true, 'a+' => true
+            'x+t' => true, 'c+t' => true, 'a+' => true, 'rb+' => true
         ],
         'write' => [
             'w' => true, 'w+' => true, 'rw' => true, 'r+' => true, 'x+' => true,


### PR DESCRIPTION
PHP 7.1 gives rb+. But in this array there is only r+b variant. This fix will help to make Flystem aws s3 woring on php 7.1.

Without this commit Stream says, that stream is not readable, when it gives rb+ (which means it is readable). There is no problem on older php versions.

Fixes
#183 