### PR TITLE
Parse query expects int

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -516,7 +516,7 @@ function parse_response($message)
  * PHP style arrays into an associative array (e.g., foo[a]=1&foo[b]=2 will
  * be parsed into ['foo[a]' => '1', 'foo[b]' => '2']).
  *
- * @param string      $str         Query string to parse
+ * @param string   $str         Query string to parse
  * @param int|bool $urlEncoding How the query string is encoded
  *
  * @return array
@@ -533,9 +533,9 @@ function parse_query($str, $urlEncoding = true)
         $decoder = function ($value) {
             return rawurldecode(str_replace('+', ' ', $value));
         };
-    } elseif ($urlEncoding == PHP_QUERY_RFC3986) {
+    } elseif ($urlEncoding === PHP_QUERY_RFC3986) {
         $decoder = 'rawurldecode';
-    } elseif ($urlEncoding == PHP_QUERY_RFC1738) {
+    } elseif ($urlEncoding === PHP_QUERY_RFC1738) {
         $decoder = 'urldecode';
     } else {
         $decoder = function ($str) { return $str; };
@@ -565,10 +565,10 @@ function parse_query($str, $urlEncoding = true)
  * string. This function does not modify the provided keys when an array is
  * encountered (like http_build_query would).
  *
- * @param array     $params   Query string parameters.
+ * @param array    $params   Query string parameters.
  * @param int|bool $encoding Set to false to not encode, PHP_QUERY_RFC3986
- *                            to encode using RFC3986, or PHP_QUERY_RFC1738
- *                            to encode using RFC1738.
+ *                           to encode using RFC3986, or PHP_QUERY_RFC1738
+ *                           to encode using RFC1738.
  * @return string
  */
 function build_query(array $params, $encoding = PHP_QUERY_RFC3986)

--- a/src/functions.php
+++ b/src/functions.php
@@ -517,7 +517,7 @@ function parse_response($message)
  * be parsed into ['foo[a]' => '1', 'foo[b]' => '2']).
  *
  * @param string      $str         Query string to parse
- * @param bool|string $urlEncoding How the query string is encoded
+ * @param int|bool $urlEncoding How the query string is encoded
  *
  * @return array
  */
@@ -566,7 +566,7 @@ function parse_query($str, $urlEncoding = true)
  * encountered (like http_build_query would).
  *
  * @param array     $params   Query string parameters.
- * @param int|false $encoding Set to false to not encode, PHP_QUERY_RFC3986
+ * @param int|bool $encoding Set to false to not encode, PHP_QUERY_RFC3986
  *                            to encode using RFC3986, or PHP_QUERY_RFC1738
  *                            to encode using RFC1738.
  * @return string


### PR DESCRIPTION
Fix of phpstan/phpstan error: `Parameter #2 $urlEncoding of function GuzzleHttp\Psr7\parse_query expects bool|string, int given.`