### PR TITLE
Hotfix (hardcode) for working on php 7.1

### DIFF
--- a/src/Stream.php
+++ b/src/Stream.php
@@ -24,11 +24,11 @@ class Stream implements StreamInterface
             'r' => true, 'w+' => true, 'r+' => true, 'x+' => true, 'c+' => true,
             'rb' => true, 'w+b' => true, 'r+b' => true, 'x+b' => true,
             'c+b' => true, 'rt' => true, 'w+t' => true, 'r+t' => true,
-            'x+t' => true, 'c+t' => true, 'a+' => true
+            'x+t' => true, 'c+t' => true, 'a+' => true, 'rb+' => true,
         ],
         'write' => [
             'w' => true, 'w+' => true, 'rw' => true, 'r+' => true, 'x+' => true,
-            'c+' => true, 'wb' => true, 'w+b' => true, 'r+b' => true,
+            'c+' => true, 'wb' => true, 'w+b' => true, 'r+b' => true, 'rb+' => true,
             'x+b' => true, 'c+b' => true, 'w+t' => true, 'r+t' => true,
             'x+t' => true, 'c+t' => true, 'a' => true, 'a+' => true
         ]

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -34,6 +34,21 @@ class StreamTest extends BaseTest
         $stream->close();
     }
 
+    public function testConstructorInitializesPropertiesWithRbPlus()
+    {
+        $handle = fopen('php://temp', 'rb+');
+        fwrite($handle, 'data');
+        $stream = new Stream($handle);
+        $this->assertTrue($stream->isReadable());
+        $this->assertTrue($stream->isWritable());
+        $this->assertTrue($stream->isSeekable());
+        $this->assertEquals('php://temp', $stream->getMetadata('uri'));
+        $this->assertInternalType('array', $stream->getMetadata());
+        $this->assertEquals(4, $stream->getSize());
+        $this->assertFalse($stream->eof());
+        $stream->close();
+    }
+
     public function testStreamClosesHandleOnDestruct()
     {
         $handle = fopen('php://temp', 'r');


### PR DESCRIPTION
> PHP 7.1 gives rb+. But in this array there is only r+b variant. This fix will help to make Flystem aws s3 woring on php 7.1.
> 
> Without this commit Stream says, that stream is not readable, when it gives rb+ (which means it is readable). There is no problem on older php versions.

See #205 #183 