### PR TITLE
Allow inflation of deflate (zlib format) streams

### DIFF
--- a/src/InflateStream.php
+++ b/src/InflateStream.php
@@ -9,11 +9,11 @@ use Psr\Http\Message\StreamInterface;
 /**
  * Uses PHP's zlib.inflate filter to inflate deflate or gzipped content.
  *
- * This stream decorator skips the first 10 bytes of the given stream to remove
- * the gzip header, converts the provided stream to a PHP stream resource,
+ * This stream decorator converts the provided stream to a PHP stream resource,
  * then appends the zlib.inflate filter. The stream is then converted back
  * to a Guzzle stream resource to be used as a Guzzle stream.
  *
+ * @link http://tools.ietf.org/html/rfc1950
  * @link http://tools.ietf.org/html/rfc1952
  * @link http://php.net/manual/en/filters.compression.php
  */
@@ -23,28 +23,12 @@ class InflateStream implements StreamInterface
 
     public function __construct(StreamInterface $stream)
     {
-        // read the first 10 bytes, ie. gzip header
-        $header = $stream->read(10);
-        $filenameHeaderLength = $this->getLengthOfPossibleFilenameHeader($stream, $header);
-        // Skip the header, that is 10 + length of filename + 1 (nil) bytes
-        $stream = new LimitStream($stream, -1, 10 + $filenameHeaderLength);
         $resource = StreamWrapper::getResource($stream);
-        stream_filter_append($resource, 'zlib.inflate', STREAM_FILTER_READ);
+        // Specify window=15+32, so zlib will use header detection to both gzip (with header) and zlib data
+        // See http://www.zlib.net/manual.html#Advanced definition of inflateInit2
+        // "Add 32 to windowBits to enable zlib and gzip decoding with automatic header detection"
+        // Default window size is 15.
+        stream_filter_append($resource, 'zlib.inflate', STREAM_FILTER_READ, ['window' => 15 + 32]);
         $this->stream = $stream->isSeekable() ? new Stream($resource) : new NoSeekStream(new Stream($resource));
-    }
-
-    private function getLengthOfPossibleFilenameHeader(StreamInterface $stream, string $header): int
-    {
-        $filename_header_length = 0;
-
-        if (substr(bin2hex($header), 6, 2) === '08') {
-            // we have a filename, read until nil
-            $filename_header_length = 1;
-            while ($stream->read(1) !== chr(0)) {
-                $filename_header_length++;
-            }
-        }
-
-        return $filename_header_length;
     }
 }


### PR DESCRIPTION
I figured that `InflateStream` is only capable of inflating gzip format (10 bytes header + optional meta). However, [it is meant to be used for inflating deflate](https://github.com/guzzle/guzzle/blob/master/src/Handler/StreamHandler.php#L163) data (zlib format - 2 bytes header).

Since this is using zlib stream filter, it is possible to pass `window=15+32` as parameter and let zlib detect file header so it can consume both zlib (deflate) and gzip data.

As bonus point, previous implementation was skipping only filename if it's present, but compressed file may contain more optional metadata - variable length comment, extra fields, header crc16. If any of these were present, existing code chokes and outputs empty string.