### PR TITLE
Fix tests bootstraping

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once './vendor/autoload.php';
+require_once __DIR__ . '/../vendor/autoload.php';
 
 if (!class_exists('PHPUnit\Framework\Error\Warning')) {
     class_alias('PHPUnit_Framework_Error_Warning', 'PHPUnit\Framework\Error\Warning');


### PR DESCRIPTION
When I try to run a single file from my PHPStorm I get:

![image](https://user-images.githubusercontent.com/5675248/48980104-592ec780-f0cd-11e8-9170-52267a9d482d.png)


This fixes the issue @carusogabriel if he can check also... (was the one adding the file)