### PR TITLE
__toString functions must catch also throwables

### DIFF
--- a/src/AppendStream.php
+++ b/src/AppendStream.php
@@ -36,7 +36,7 @@ class AppendStream implements StreamInterface
         try {
             $this->rewind();
             return $this->getContents();
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return '';
         }
     }

--- a/src/AppendStream.php
+++ b/src/AppendStream.php
@@ -37,6 +37,7 @@ class AppendStream implements StreamInterface
             $this->rewind();
             return $this->getContents();
         } catch (\Throwable $e) {
+            trigger_error(sprintf('%s::__toString exception: %s', self::class, (string) $e), E_USER_ERROR);
             return '';
         }
     }

--- a/src/FnStream.php
+++ b/src/FnStream.php
@@ -89,6 +89,7 @@ class FnStream implements StreamInterface
         try {
             return call_user_func($this->_fn___toString);
         } catch (\Throwable $e){
+            trigger_error(sprintf('%s::__toString exception: %s', self::class, (string) $e), E_USER_ERROR);
             return '';
         }
     }

--- a/src/FnStream.php
+++ b/src/FnStream.php
@@ -86,7 +86,11 @@ class FnStream implements StreamInterface
 
     public function __toString()
     {
-        return call_user_func($this->_fn___toString);
+        try {
+            return call_user_func($this->_fn___toString);
+        } catch (\Throwable $e){
+            return '';
+        }
     }
 
     public function close()

--- a/src/PumpStream.php
+++ b/src/PumpStream.php
@@ -56,6 +56,7 @@ class PumpStream implements StreamInterface
         try {
             return copy_to_string($this);
         } catch (\Throwable $e) {
+            trigger_error(sprintf('%s::__toString exception: %s', self::class, (string) $e), E_USER_ERROR);
             return '';
         }
     }

--- a/src/PumpStream.php
+++ b/src/PumpStream.php
@@ -55,7 +55,7 @@ class PumpStream implements StreamInterface
     {
         try {
             return copy_to_string($this);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return '';
         }
     }

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -86,7 +86,7 @@ class Stream implements StreamInterface
         try {
             $this->seek(0);
             return (string) stream_get_contents($this->stream);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return '';
         }
     }

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -87,6 +87,7 @@ class Stream implements StreamInterface
             $this->seek(0);
             return (string) stream_get_contents($this->stream);
         } catch (\Throwable $e) {
+            trigger_error(sprintf('%s::__toString exception: %s', self::class, (string) $e), E_USER_ERROR);
             return '';
         }
     }

--- a/src/StreamDecoratorTrait.php
+++ b/src/StreamDecoratorTrait.php
@@ -45,7 +45,7 @@ trait StreamDecoratorTrait
                 $this->seek(0);
             }
             return $this->getContents();
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             // Really, PHP? https://bugs.php.net/bug.php?id=53648
             trigger_error('StreamDecorator::__toString exception: '
                 . (string) $e, E_USER_ERROR);

--- a/src/StreamDecoratorTrait.php
+++ b/src/StreamDecoratorTrait.php
@@ -47,8 +47,7 @@ trait StreamDecoratorTrait
             return $this->getContents();
         } catch (\Throwable $e) {
             // Really, PHP? https://bugs.php.net/bug.php?id=53648
-            trigger_error('StreamDecorator::__toString exception: '
-                . (string) $e, E_USER_ERROR);
+            trigger_error('StreamDecorator::__toString exception: '.(string) $e, E_USER_ERROR);
             return '';
         }
     }

--- a/tests/AppendStreamTest.php
+++ b/tests/AppendStreamTest.php
@@ -208,7 +208,8 @@ class AppendStreamTest extends TestCase
             ->will($this->returnValue(false));
         $a = new AppendStream([$s]);
         $this->assertFalse($a->eof());
-        $this->assertSame('', (string) $a);
+        $this->expectException(\PHPUnit\Framework\Error\Error::class);
+        (string) $a;
     }
 
     public function testReturnsEmptyMetadata()

--- a/tests/AppendStreamTest.php
+++ b/tests/AppendStreamTest.php
@@ -208,8 +208,18 @@ class AppendStreamTest extends TestCase
             ->will($this->returnValue(false));
         $a = new AppendStream([$s]);
         $this->assertFalse($a->eof());
-        $this->expectException(\PHPUnit\Framework\Error\Error::class);
+
+        $errors = [];
+        set_error_handler(function (int $errorNumber, string $errorMessage) use (&$errors){
+            $errors[] = ['number' => $errorNumber, 'message' => $errorMessage];
+        });
         (string) $a;
+
+        restore_error_handler();
+
+        $this->assertCount(1, $errors);
+        $this->assertSame(E_USER_ERROR, $errors[0]['number']);
+        $this->assertStringStartsWith('GuzzleHttp\Psr7\AppendStream::__toString exception:', $errors[0]['message']);
     }
 
     public function testReturnsEmptyMetadata()

--- a/tests/FnStreamTest.php
+++ b/tests/FnStreamTest.php
@@ -110,7 +110,16 @@ class FnStreamTest extends TestCase
             },
         ]);
 
-        $this->expectException(\PHPUnit\Framework\Error\Error::class);
-        $a->__toString();
+        $errors = [];
+        set_error_handler(function (int $errorNumber, string $errorMessage) use (&$errors){
+            $errors[] = ['number' => $errorNumber, 'message' => $errorMessage];
+        });
+        (string) $a;
+
+        restore_error_handler();
+
+        $this->assertCount(1, $errors);
+        $this->assertSame(E_USER_ERROR, $errors[0]['number']);
+        $this->assertStringStartsWith('GuzzleHttp\Psr7\FnStream::__toString exception:', $errors[0]['message']);
     }
 }

--- a/tests/FnStreamTest.php
+++ b/tests/FnStreamTest.php
@@ -101,4 +101,16 @@ class FnStreamTest extends TestCase
         $this->expectExceptionMessage('FnStream should never be unserialized');
         unserialize($b);
     }
+
+    public function testThatConvertingStreamToStringWillTriggerErrorAndWillReturnEmptyString()
+    {
+        $a = new FnStream([
+            '__toString' => function () {
+                throw new \Exception();
+            },
+        ]);
+
+        $this->expectException(\PHPUnit\Framework\Error\Error::class);
+        $a->__toString();
+    }
 }

--- a/tests/PumpStreamTest.php
+++ b/tests/PumpStreamTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace GuzzleHttp\Tests\Psr7;
 
+use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\LimitStream;
 use GuzzleHttp\Psr7\PumpStream;
-use GuzzleHttp\Psr7;
 use PHPUnit\Framework\TestCase;
 
 class PumpStreamTest extends TestCase
@@ -72,5 +72,19 @@ class PumpStreamTest extends TestCase
             $this->assertFalse($p->write('aa'));
             $this->fail();
         } catch (\RuntimeException $e) {}
+    }
+
+    public function testThatConvertingStreamToStringWillTriggerErrorAndWillReturnEmptyString()
+    {
+        $p = Psr7\stream_for(function ($size) {
+            throw new \Exception();
+        });
+        $this->assertInstanceOf(PumpStream::class, $p);
+
+        try {
+            $p->__toString();
+        } catch (\Throwable $e) {
+            $this->assertInstanceOf(\Throwable::class, $e);
+        }
     }
 }

--- a/tests/PumpStreamTest.php
+++ b/tests/PumpStreamTest.php
@@ -81,10 +81,16 @@ class PumpStreamTest extends TestCase
         });
         $this->assertInstanceOf(PumpStream::class, $p);
 
-        try {
-            $p->__toString();
-        } catch (\Throwable $e) {
-            $this->assertInstanceOf(\Throwable::class, $e);
-        }
+        $errors = [];
+        set_error_handler(function (int $errorNumber, string $errorMessage) use (&$errors){
+            $errors[] = ['number' => $errorNumber, 'message' => $errorMessage];
+        });
+        (string) $p;
+
+        restore_error_handler();
+
+        $this->assertCount(1, $errors);
+        $this->assertSame(E_USER_ERROR, $errors[0]['number']);
+        $this->assertStringStartsWith('GuzzleHttp\Psr7\PumpStream::__toString exception:', $errors[0]['message']);
     }
 }


### PR DESCRIPTION
On `StreamDecoratorTrait` I saw a comment about this [bug](https://bugs.php.net/bug.php?id=53648)

I made a test and I saw that the same error is raised with throwables as well..

My test:

``` php
class MyClass
{
    public function __toString()
    {
        try {
            throw new Error('whatever');
        } catch (Exception $e) {
            return '';
        }
    }
}


$c = new MyClass();
(string)$c;
```

Result: `Method MyClass::__toString() must not throw an exception, caught Error: whatever .... ... ... `

**Important** not sure if `FnStream` should also have a `try..catch`. At the moment it does not.