### PR TITLE
Allow ralouphie/getallheaders ^3.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.4.0",
         "psr/http-message": "~1.0",
-        "ralouphie/getallheaders": "^2.0.5"
+        "ralouphie/getallheaders": "^2.0.5 || ^3.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.8.36 || ^5.7.27 || ^6.5.8"


### PR DESCRIPTION
Allow "ralouphie/getallheaders": "^2.0.5 || ^3.0.0 in composer.json which drops PHP < 5.6 support

Also does some repo cleanup adding .gitattributes. Enables travis testing on PHP 7.0 and above

https://github.com/ralouphie/getallheaders/compare/2.0.5...3.0.0