### PR TITLE
Add MIME type for WEBP image format

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -724,6 +724,7 @@ function mimetype_from_extension($extension)
         'txt' => 'text/plain',
         'wav' => 'audio/x-wav',
         'webm' => 'video/webm',
+        'webp' => 'image/webp',
         'wma' => 'audio/x-ms-wma',
         'wmv' => 'video/x-ms-wmv',
         'woff' => 'application/x-font-woff',


### PR DESCRIPTION
The WEBP image format does not yet have an official IANA MIME type definition.
However, the same can be said about video/webm which is adopted in a similar width as WEBP.

Apache web server, python web server and many more has adopted the MIME type image/webp for the WEBP image format, so it is only logical to assume its validity at the same level as WEBM video.