### PR TITLE
Fix subsequent reads from php://input in ServerRequest

### DIFF
--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -168,7 +168,7 @@ class ServerRequest extends Request implements ServerRequestInterface
         $method = isset($_SERVER['REQUEST_METHOD']) ? $_SERVER['REQUEST_METHOD'] : 'GET';
         $headers = getallheaders();
         $uri = self::getUriFromGlobals();
-        $body = new LazyOpenStream('php://input', 'r+');
+        $body = new CachingStream(new LazyOpenStream('php://input', 'r+'));
         $protocol = isset($_SERVER['SERVER_PROTOCOL']) ? str_replace('HTTP/', '', $_SERVER['SERVER_PROTOCOL']) : '1.1';
 
         $serverRequest = new ServerRequest($method, $uri, $headers, $body, $protocol, $_SERVER);


### PR DESCRIPTION
According to the PHP documentation reading from the same php://input
stream is not possible. Even reading from separate streams is
SAPI dependent.

http://php.net/manual/de/wrappers.php.php#wrappers.php.input

This change adds a CachingStream wrapping the default stream
when using ServerRequest::fromGlobals to allow subsequent
reads.

Fixes #186