### PR TITLE
Fix error in PHP 7.3

### DIFF
--- a/src/Stream.php
+++ b/src/Stream.php
@@ -197,6 +197,8 @@ class Stream implements StreamInterface
 
     public function seek($offset, $whence = SEEK_SET)
     {
+        $whence = (int) $whence;
+        
         if (!isset($this->stream)) {
             throw new \RuntimeException('Stream is detached');
         }


### PR DESCRIPTION
Fix error:
```
Exception: fseek() expects parameter 3 to be int, unknown given in 

/var/www/project/vendor/guzzlehttp/psr7/src/Stream.php:206
```