### PR TITLE
Fix composer.json: add `ext-zlib` to `require-dev` section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "ralouphie/getallheaders": "^2.0.5 || ^3.0.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.8.36 || ^5.7.27 || ^6.5.8"
+        "phpunit/phpunit": "~4.8.36 || ^5.7.27 || ^6.5.8",
+        "ext-zlib": "*"
     },
     "provide": {
         "psr/http-message-implementation": "1.0"


### PR DESCRIPTION
It is necessary because `gzencode ()` is used in tests