### PR TITLE
Locale independent \parse_url() wrapper for UTF-8 strings

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -66,7 +66,7 @@ class Uri implements UriInterface
     {
         // weak type check to also accept null until we can add scalar type hints
         if ($uri != '') {
-            $parts = parse_url($uri);
+            $parts = _parse_url($uri);
             if ($parts === false) {
                 throw new \InvalidArgumentException("Unable to parse URI: $uri");
             }

--- a/src/functions.php
+++ b/src/functions.php
@@ -841,7 +841,7 @@ function _parse_request_uri($path, array $headers)
 }
 
 /**
- * Get a short summary of the message body
+ * Get a short summary of the message body.
  *
  * Will return `null` if the response is not printable.
  *
@@ -896,4 +896,39 @@ function _caseless_remove($keys, array $data)
     }
 
     return $result;
+}
+
+/**
+ * UTF-8 aware \parse_url() replacement.
+ *
+ * The internal function produces broken output for non ASCII domain names (IDN)
+ * when used with locales other than "C".
+ *
+ * On the other hand, cURL understands IDN correctly only when UTF-8 locale is
+ * configured ("C.UTF-8", "en_US.UTF-8", etc.).
+ *
+ * @see https://bugs.php.net/bug.php?id=52923
+ * @see https://www.php.net/manual/en/function.parse-url.php#114817
+ * @see https://curl.haxx.se/libcurl/c/CURLOPT_URL.html#ENCODING
+ *
+ * @return array|false
+ * @internal
+ */
+function _parse_url($url, $component = -1)
+{
+    $encodedUrl = preg_replace_callback(
+        '%[^:/@?&=#]+%usD',
+        function ($matches) {
+            return urlencode($matches[0]);
+        },
+        $url
+    );
+
+    $result = parse_url($encodedUrl, $component);
+
+    if ($result === false) {
+        return false;
+    }
+
+    return is_array($result) ? array_map('urldecode', $result) : urldecode($result);
 }


### PR DESCRIPTION
`\parse_url()` breaks UTF-8 domain names (IDN) when used with locales other than "C". This PR introduces a small wrapper around the internal function to make Guzzle locale independent (and those more usable when you work with IDNs).

P.S.

For 2.x branch [`leageu/uri-parser`](https://uri.thephpleague.com/parser/1.0/) worths a try, IMO. It's a pure PHP implementation that is compatible with `\parse_url() that works nicely with UTF-8 and is more compatible with the standard.