### PR TITLE
Change minimal port number to 0 (unix socket)

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -628,9 +628,9 @@ class Uri implements UriInterface
         }
 
         $port = (int) $port;
-        if (1 > $port || 0xffff < $port) {
+        if (0 > $port || 0xffff < $port) {
             throw new \InvalidArgumentException(
-                sprintf('Invalid port: %d. Must be between 1 and 65535', $port)
+                sprintf('Invalid port: %d. Must be between 0 and 65535', $port)
             );
         }
 

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -117,7 +117,7 @@ class UriTest extends BaseTest
 
     /**
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Invalid port: 100000. Must be between 1 and 65535
+     * @expectedExceptionMessage Invalid port: 100000. Must be between 0 and 65535
      */
     public function testPortMustBeValid()
     {
@@ -126,11 +126,11 @@ class UriTest extends BaseTest
 
     /**
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Invalid port: 0. Must be between 1 and 65535
+     * @expectedExceptionMessage Invalid port: -1. Must be between 0 and 65535
      */
-    public function testWithPortCannotBeZero()
+    public function testWithPortCannotBeNegative()
     {
-        (new Uri())->withPort(0);
+        (new Uri())->withPort(-1);
     }
 
     /**


### PR DESCRIPTION
Listening on an unix socket reports port number 0, which is interpreted as an invalid argument.