### PR TITLE
Accept null and bool header values again

### DIFF
--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -186,9 +186,9 @@ trait MessageTrait
     private function trimHeaderValues(array $values)
     {
         return array_map(function ($value) {
-            if (!is_string($value) && !is_numeric($value)) {
+            if (!is_scalar($value) && null !== $value) {
                 throw new \InvalidArgumentException(sprintf(
-                    'Header value must be a string or numeric but %s provided.',
+                    'Header value must be scalar or null but %s provided.',
                     is_object($value) ? get_class($value) : gettype($value)
                 ));
             }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -263,8 +263,7 @@ class ResponseTest extends BaseTest
         return [
             ['foo', [], 'Header value can not be an empty array.'],
             ['', '', 'Header name can not be empty.'],
-            ['foo', false, 'Header value must be a string or numeric but boolean provided'],
-            ['foo', new \stdClass(),  'Header value must be a string or numeric but stdClass provided.'],
+            ['foo', new \stdClass(),  'Header value must be scalar or null but stdClass provided.'],
         ];
     }
 

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -263,7 +263,7 @@ class ResponseTest extends BaseTest
         return [
             ['foo', [], 'Header value can not be an empty array.'],
             ['', '', 'Header name can not be empty.'],
-            ['foo', new \stdClass(),  'Header value must be scalar or null but stdClass provided.'],
+            ['foo', new \stdClass(), 'Header value must be scalar or null but stdClass provided.'],
         ];
     }
 


### PR DESCRIPTION
This is not according to PSR-7 which says `@param string|string[] $value Header value(s).` but for BC and missing type declarations it makes sense.

Fixes #282