### PR TITLE
Make getContents return full stream contents

### DIFF
--- a/src/Stream.php
+++ b/src/Stream.php
@@ -87,7 +87,7 @@ class Stream implements StreamInterface
             throw new \RuntimeException('Stream is detached');
         }
 
-        $contents = stream_get_contents($this->stream);
+        $contents = stream_get_contents($this->stream, -1, 0);
 
         if ($contents === false) {
             throw new \RuntimeException('Unable to read stream contents');


### PR DESCRIPTION
* _Previous functionality_: getContents() returned remaining contents of stream (only that which had not been previously read)
* _New functionality_: getContents() returns the full stream, always

This PR is just a suggestion, it came about after I (wrongly) assumed that `getContents()` was idempotent. Currently it is not, since the act of reading the stream moves the pointer to the end and so subsequent calls to `getContents()`return an empty string.

PHP docs for [stream_get_contents](https://www.php.net/manual/en/function.stream-get-contents.php).

Related:
* https://github.com/guzzle/guzzle/pull/1262
* https://github.com/guzzle/guzzle/issues/1582
* https://github.com/guzzle/guzzle/pull/1872