### PR TITLE
Cache __toString() representation

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -72,7 +72,7 @@ class Uri implements UriInterface
     private $fragment = '';
 
     /** @var string|null String representation */
-    private $toString = null;
+    private $composedComponents;
 
     public function __construct(string $uri = '')
     {
@@ -87,8 +87,8 @@ class Uri implements UriInterface
 
     public function __toString()
     {
-        if ($this->toString === null) {
-            $this->toString = self::composeComponents(
+        if ($this->composedComponents === null) {
+            $this->composedComponents = self::composeComponents(
                 $this->scheme,
                 $this->getAuthority(),
                 $this->path,
@@ -97,7 +97,7 @@ class Uri implements UriInterface
             );
         }
 
-        return $this->toString;
+        return $this->composedComponents;
     }
 
     /**
@@ -409,7 +409,7 @@ class Uri implements UriInterface
 
         $new = clone $this;
         $new->scheme = $scheme;
-        $new->toString = null;
+        $new->composedComponents = null;
         $new->removeDefaultPort();
         $new->validateState();
 
@@ -429,7 +429,7 @@ class Uri implements UriInterface
 
         $new = clone $this;
         $new->userInfo = $info;
-        $new->toString = null;
+        $new->composedComponents = null;
         $new->validateState();
 
         return $new;
@@ -445,7 +445,7 @@ class Uri implements UriInterface
 
         $new = clone $this;
         $new->host = $host;
-        $new->toString = null;
+        $new->composedComponents = null;
         $new->validateState();
 
         return $new;
@@ -461,7 +461,7 @@ class Uri implements UriInterface
 
         $new = clone $this;
         $new->port = $port;
-        $new->toString = null;
+        $new->composedComponents = null;
         $new->removeDefaultPort();
         $new->validateState();
 
@@ -478,7 +478,7 @@ class Uri implements UriInterface
 
         $new = clone $this;
         $new->path = $path;
-        $new->toString = null;
+        $new->composedComponents = null;
         $new->validateState();
 
         return $new;
@@ -494,7 +494,7 @@ class Uri implements UriInterface
 
         $new = clone $this;
         $new->query = $query;
-        $new->toString = null;
+        $new->composedComponents = null;
 
         return $new;
     }
@@ -509,7 +509,7 @@ class Uri implements UriInterface
 
         $new = clone $this;
         $new->fragment = $fragment;
-        $new->toString = null;
+        $new->composedComponents = null;
 
         return $new;
     }

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -71,6 +71,9 @@ class Uri implements UriInterface
     /** @var string Uri fragment. */
     private $fragment = '';
 
+    /** @var string|null String representation */
+    private $toString = null;
+
     public function __construct(string $uri = '')
     {
         if ($uri !== '') {
@@ -84,13 +87,17 @@ class Uri implements UriInterface
 
     public function __toString()
     {
-        return self::composeComponents(
-            $this->scheme,
-            $this->getAuthority(),
-            $this->path,
-            $this->query,
-            $this->fragment
-        );
+        if ($this->toString === null) {
+            $this->toString = self::composeComponents(
+                $this->scheme,
+                $this->getAuthority(),
+                $this->path,
+                $this->query,
+                $this->fragment
+            );
+        }
+
+        return $this->toString;
     }
 
     /**
@@ -402,6 +409,7 @@ class Uri implements UriInterface
 
         $new = clone $this;
         $new->scheme = $scheme;
+        $new->toString = null;
         $new->removeDefaultPort();
         $new->validateState();
 
@@ -421,6 +429,7 @@ class Uri implements UriInterface
 
         $new = clone $this;
         $new->userInfo = $info;
+        $new->toString = null;
         $new->validateState();
 
         return $new;
@@ -436,6 +445,7 @@ class Uri implements UriInterface
 
         $new = clone $this;
         $new->host = $host;
+        $new->toString = null;
         $new->validateState();
 
         return $new;
@@ -451,6 +461,7 @@ class Uri implements UriInterface
 
         $new = clone $this;
         $new->port = $port;
+        $new->toString = null;
         $new->removeDefaultPort();
         $new->validateState();
 
@@ -467,6 +478,7 @@ class Uri implements UriInterface
 
         $new = clone $this;
         $new->path = $path;
+        $new->toString = null;
         $new->validateState();
 
         return $new;
@@ -482,6 +494,7 @@ class Uri implements UriInterface
 
         $new = clone $this;
         $new->query = $query;
+        $new->toString = null;
 
         return $new;
     }
@@ -496,6 +509,7 @@ class Uri implements UriInterface
 
         $new = clone $this;
         $new->fragment = $fragment;
+        $new->toString = null;
 
         return $new;
     }


### PR DESCRIPTION
Some libraries perform many implicit calls to `Uri::__toString()`, which heavily affect their performance.

For example, [in spatie/crawler](https://github.com/spatie/crawler/blob/67974a810f6a342c333c4e348fcfad7c1375ffde/src/CrawlQueue/CollectionCrawlQueue.php#L103-L117):

```php
protected function contains($collection, CrawlUrl $searchCrawlUrl): bool
{
    foreach ($collection as $crawlUrl) {
        if ((string) $crawlUrl->url === (string) $searchCrawlUrl->url) {
            return true;
        }
   }
   return false;
}
```

Of course, this specific example could be improved by moving the rightmost `(string)` conversion out of the loop; but the leftmost conversion is harder to optimize: every call to `contains()` will perform a `(string)` conversion on every element in the collection, making it harder to optimize without refactoring the whole class.

I was able to speed up the above library by an order of magnitude with a simple fix: **cache the `__toString()` output**.

This is perfectly safe, as PSR-7 requires that `Uri` objects are immutable.

I guess this improvement can speed-up a lot of other libraries, with very little effort. I hope this change can go upstream 👍 