### PR TITLE
Added 510 - Not Extended HTTP Response Phrase

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -73,6 +73,7 @@ class Response implements ResponseInterface
         506 => 'Variant Also Negotiates',
         507 => 'Insufficient Storage',
         508 => 'Loop Detected',
+        510 => 'Not Extended',
         511 => 'Network Authentication Required',
     ];
 


### PR DESCRIPTION
I added the 510 - Not Extended HTTP Response Phrase, as defined on the [RFC2774](https://tools.ietf.org/html/rfc2774#section-7).

Should it be merged? Maybe.

RFC2774 status is "Experimental" since February 2000, but I haven't found any conflict with other status codes. I'd say it'd be better to use it since some servers might respond with this status (I'm dealing with an API which does, and got quite confuse with an empty reason phrase on my logs).