### PR TITLE
Locale independent \parse_url() wrapper for UTF-8 strings

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -611,8 +611,8 @@ class Uri implements UriInterface
             throw new \InvalidArgumentException('Host must be a string');
         }
 
-        // strtolower() simply breaks internationalized domain names
-        return function_exists('mb_strtolower') ? mb_strtolower($host) : $host;
+        // strtolower() simply breaks internationalized domain names (depends on the locale selected)
+        return function_exists('mb_strtolower') ? mb_strtolower($host, 'UTF-8') : $host;
     }
 
     /**

--- a/src/functions.php
+++ b/src/functions.php
@@ -841,7 +841,7 @@ function _parse_request_uri($path, array $headers)
 }
 
 /**
- * Get a short summary of the message body
+ * Get a short summary of the message body.
  *
  * Will return `null` if the response is not printable.
  *

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -697,6 +697,12 @@ class UriTest extends BaseTest
         $uri = (new Uri)->withUserInfo('foo%40bar.com', 'pass%23word');
         $this->assertSame('foo%40bar.com:pass%23word', $uri->getUserInfo());
     }
+
+    public function testInternationalizedDomainName()
+    {
+        $uri = new Uri('https://яндекс.рф');
+        $this->assertSame('яндекс.рф', $uri->getHost());
+    }
 }
 
 class ExtendedUriTest extends Uri


### PR DESCRIPTION
Reopening #269 to the right branch