### PR TITLE
[1.6] Document get_message_body_summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,6 +519,15 @@ Determines the mimetype of a file by looking at its extension.
 Maps a file extensions to a mimetype.
 
 
+## `function get_message_body_summary`
+
+`function get_message_body_summary(MessageInterface $message, $truncateAt = 120)`
+
+Get a short summary of the message body.
+
+Will return `null` if the response is not printable.
+
+
 # Additional URI Methods
 
 Aside from the standard `Psr\Http\Message\UriInterface` implementation in form of the `GuzzleHttp\Psr7\Uri` class,

--- a/src/functions.php
+++ b/src/functions.php
@@ -841,7 +841,7 @@ function _parse_request_uri($path, array $headers)
 }
 
 /**
- * Get a short summary of the message body
+ * Get a short summary of the message body.
  *
  * Will return `null` if the response is not printable.
  *


### PR DESCRIPTION
I noticed this function was added recently (ish), but was never documented, like the other functions.