### PR TITLE
Fix converting a non-seekable stream to a string for 1.x

### DIFF
--- a/src/Stream.php
+++ b/src/Stream.php
@@ -76,8 +76,10 @@ class Stream implements StreamInterface
     public function __toString()
     {
         try {
-            $this->seek(0);
-            return (string) stream_get_contents($this->stream);
+            if ($this->isSeekable()) {
+                $this->seek(0);
+            }
+            return $this->getContents();
         } catch (\Exception $e) {
             return '';
         }
@@ -193,7 +195,7 @@ class Stream implements StreamInterface
     public function seek($offset, $whence = SEEK_SET)
     {
         $whence = (int) $whence;
-        
+
         if (!isset($this->stream)) {
             throw new \RuntimeException('Stream is detached');
         }

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -67,6 +67,24 @@ class StreamTest extends BaseTest
         $stream->close();
     }
 
+    public function testConvertsToStringNonSeekableStream()
+    {
+        $handle = popen('echo foo', 'r');
+        $stream = new Stream($handle);
+        $this->assertFalse($stream->isSeekable());
+        $this->assertSame('foo', trim((string) $stream));
+    }
+
+    public function testConvertsToStringNonSeekablePartiallyReadStream()
+    {
+        $handle = popen('echo bar', 'r');
+        $stream = new Stream($handle);
+        $firstLetter = $stream->read(1);
+        $this->assertFalse($stream->isSeekable());
+        $this->assertSame('b', $firstLetter);
+        $this->assertSame('ar', trim((string) $stream));
+    }
+
     public function testGetsContents()
     {
         $handle = fopen('php://temp', 'w+');


### PR DESCRIPTION
#294 for 1.x