### PR TITLE
ignore array keys in header values for correct merging

### DIFF
--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -194,7 +194,7 @@ trait MessageTrait
             }
 
             return trim((string) $value, " \t");
-        }, $values);
+        }, array_values($values));
     }
 
     private function assertHeader($header)

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -299,6 +299,15 @@ class ResponseTest extends BaseTest
         }
     }
 
+    public function testWithAddedHeaderArrayValueAndKeys()
+    {
+        $message = (new Response())->withAddedHeader('list', ['foo' => 'one']);
+        $message = $message->withAddedHeader('list', ['foo' => 'two', 'bar' => 'three']);
+
+        $headerLine = $message->getHeaderLine('list');
+        $this->assertSame('one, two, three', $headerLine);
+    }
+
     /**
      * @dataProvider nonIntegerStatusCodeProvider
      * @param mixed $invalidValues


### PR DESCRIPTION
This PR for https://github.com/php-http/psr7-integration-tests/pull/10 + https://github.com/php-http/psr7-integration-tests/pull/43 should fix https://github.com/guzzle/psr7/issues/249