### PR TITLE
Changed error-handling of try_fopen()

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1111,11 +1111,6 @@ parameters:
 			path: src/functions.php
 
 		-
-			message: "#^Function GuzzleHttp\\\\Psr7\\\\try_fopen\\(\\) should return resource but returns resource\\|false\\.$#"
-			count: 1
-			path: src/functions.php
-
-		-
 			message: "#^Function GuzzleHttp\\\\Psr7\\\\copy_to_stream\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: src/functions.php

--- a/src/functions.php
+++ b/src/functions.php
@@ -307,22 +307,16 @@ function rewind_body(MessageInterface $message)
  */
 function try_fopen($filename, $mode)
 {
-    $ex = null;
-    set_error_handler(function (int $errno, string $errstr) use ($filename, $mode, &$ex) {
-        $ex = new \RuntimeException(sprintf(
+    $handle = @fopen($filename, $mode);
+
+    if ($handle === false) {
+        $lastError = error_get_last();
+        throw new \RuntimeException(sprintf(
             'Unable to open %s using mode %s: %s',
             $filename,
             $mode,
-            $errstr
+            $lastError !== null ? $lastError['message'] : 'Unknown error'
         ));
-    });
-
-    $handle = fopen($filename, $mode);
-    restore_error_handler();
-
-    if ($ex) {
-        /** @var $ex \RuntimeException */
-        throw $ex;
     }
 
     return $handle;


### PR DESCRIPTION
Using `set_error_handler()`/`restore_error_handler()` is not always stable - especially when calling it from inside a PHP error handler (e.g. [Sentry](https://github.com/getsentry/sentry-php) is using Guzzle for error-reporting - see https://github.com/getsentry/sentry-php/issues/976 for details).

The original problem is in the PHP core - mentioned in this PHP bug from 2012: https://bugs.php.net/bug.php?id=63206

As a workaround, I propose this pull-request, which avoids playing with the error handler, and instead silence the `fopen()`-call, check the return value and get the error-message via `error_get_last()`.

It is not 100% backwards compatible, as any custom error handler will now be called, even with the silenced ("@") mode. But I think this is better than destroying the error handler in some cases.

This would fix #318 