### PR TITLE
Include '/u' flag on summary regex

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -893,7 +893,7 @@ function get_message_body_summary(MessageInterface $message, $truncateAt = 120)
 
     // Matches any printable character, including unicode characters:
     // letters, marks, numbers, punctuation, spacing, and separators.
-    if (preg_match('/[^\pL\pM\pN\pP\pS\pZ\n\r\t]/', $summary)) {
+    if (preg_match('/[^\pL\pM\pN\pP\pS\pZ\n\r\t]/u', $summary)) {
         return null;
     }
 

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -764,6 +764,12 @@ class FunctionsTest extends TestCase
         self::assertEquals('Lorem ipsu (truncated...)', Psr7\get_message_body_summary($message, 10));
     }
 
+    public function testMessageBodySummaryWithSpecialUTF8Characters()
+    {
+        $message = new Psr7\Response(200, [], '’é€௵ဪ‱');
+        self::assertEquals('’é€௵ဪ‱', Psr7\get_message_body_summary($message));
+    }
+
     public function testMessageBodySummaryWithEmptyBody()
     {
         $message = new Psr7\Response(200, [], '');


### PR DESCRIPTION
I've noticed that if a request throws an exception and if the response body includes the character `’`, the function `get_message_body_summary()` **will return null**.

The expected result should be the string including **the special character**.

This happens due to the regex used to match any printable character lacks of the `/u` flag.

For example, this returns `1`, forcing `get_message_body_summary()` to return `null`:
```
preg_match('/[^\pL\pM\pN\pP\pS\pZ\n\r\t]/', '’')
```

Other multibyte characters like ௵ and ဪ also trigger this issue.

Adding the `/u` flag solves this issue.