### PR TITLE
~ make GuzzleHttp\Psr7\modify_request to produce the same subclasses of Request

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -245,8 +245,10 @@ function modify_request(RequestInterface $request, array $changes)
         $uri = $uri->withQuery($changes['query']);
     }
 
+    $class = get_class($request);
+
     if ($request instanceof ServerRequestInterface) {
-        return (new ServerRequest(
+        return (new $class(
             isset($changes['method']) ? $changes['method'] : $request->getMethod(),
             $uri,
             $headers,
@@ -262,7 +264,7 @@ function modify_request(RequestInterface $request, array $changes)
         ->withUploadedFiles($request->getUploadedFiles());
     }
 
-    return new Request(
+    return new $class(
         isset($changes['method']) ? $changes['method'] : $request->getMethod(),
         $uri,
         $headers,


### PR DESCRIPTION
Makes GuzzleHttp\Psr7\modify_request to produce requests of the same subclasses it have got from the input

Rationale:

When someone uses a subclass of `GuzzleHttp\Psr7\Request` such as `Graze\GuzzleHttp\JsonRpc\Message\Request` from `graze/guzzle-jsonrpc` he expects it to remain the same, for instance to check if an actual request in the middleware implements interface `Graze\GuzzleHttp\JsonRpc\Message\RequestInterface` .

But `GuzzleHttp\Psr7\modify_request` called from `GuzzleHttp\Client::applyOptions` will forcibly replace it with `GuzzleHttp\Psr7\Request`

It seem reasonable to make `modify_request` produce the same request subclass it have got from the input.
