### PR TITLE
Remove redundant class properties assignment

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -78,10 +78,10 @@ class Response implements ResponseInterface
     ];
 
     /** @var string */
-    private $reasonPhrase = '';
+    private $reasonPhrase;
 
     /** @var int */
-    private $statusCode = 200;
+    private $statusCode;
 
     /**
      * @param int                                  $status  Status code


### PR DESCRIPTION
`$statusCode` assignment can be safely removed as the constructor overrides it.
`$reasonPhrase` assignment can be safely removed as the constructor overrides it and function default parameter also overrides it.