### PR TITLE
make special purpose classes final

### DIFF
--- a/src/AppendStream.php
+++ b/src/AppendStream.php
@@ -11,7 +11,7 @@ use Psr\Http\Message\StreamInterface;
  *
  * This is a read-only stream decorator.
  */
-class AppendStream implements StreamInterface
+final class AppendStream implements StreamInterface
 {
     /** @var StreamInterface[] Streams being decorated */
     private $streams = [];

--- a/src/BufferStream.php
+++ b/src/BufferStream.php
@@ -14,7 +14,7 @@ use Psr\Http\Message\StreamInterface;
  * what the configured high water mark of the stream is, or the maximum
  * preferred size of the buffer.
  */
-class BufferStream implements StreamInterface
+final class BufferStream implements StreamInterface
 {
     /** @var int */
     private $hwm;

--- a/src/CachingStream.php
+++ b/src/CachingStream.php
@@ -10,7 +10,7 @@ use Psr\Http\Message\StreamInterface;
  * Stream decorator that can cache previously read bytes from a sequentially
  * read stream.
  */
-class CachingStream implements StreamInterface
+final class CachingStream implements StreamInterface
 {
     use StreamDecoratorTrait;
 

--- a/src/DroppingStream.php
+++ b/src/DroppingStream.php
@@ -10,7 +10,7 @@ use Psr\Http\Message\StreamInterface;
  * Stream decorator that begins dropping data once the size of the underlying
  * stream becomes too full.
  */
-class DroppingStream implements StreamInterface
+final class DroppingStream implements StreamInterface
 {
     use StreamDecoratorTrait;
 

--- a/src/FnStream.php
+++ b/src/FnStream.php
@@ -12,7 +12,7 @@ use Psr\Http\Message\StreamInterface;
  * Allows for easy testing and extension of a provided stream without needing
  * to create a concrete class for a simple extension point.
  */
-class FnStream implements StreamInterface
+final class FnStream implements StreamInterface
 {
     private const SLOTS = [
         '__toString', 'close', 'detach', 'rewind',

--- a/src/InflateStream.php
+++ b/src/InflateStream.php
@@ -17,7 +17,7 @@ use Psr\Http\Message\StreamInterface;
  * @link http://tools.ietf.org/html/rfc1952
  * @link http://php.net/manual/en/filters.compression.php
  */
-class InflateStream implements StreamInterface
+final class InflateStream implements StreamInterface
 {
     use StreamDecoratorTrait;
 

--- a/src/LazyOpenStream.php
+++ b/src/LazyOpenStream.php
@@ -10,7 +10,7 @@ use Psr\Http\Message\StreamInterface;
  * Lazily reads or writes to a file that is opened only after an IO operation
  * take place on the stream.
  */
-class LazyOpenStream implements StreamInterface
+final class LazyOpenStream implements StreamInterface
 {
     use StreamDecoratorTrait;
 

--- a/src/LimitStream.php
+++ b/src/LimitStream.php
@@ -9,7 +9,7 @@ use Psr\Http\Message\StreamInterface;
 /**
  * Decorator used to return only a subset of a stream
  */
-class LimitStream implements StreamInterface
+final class LimitStream implements StreamInterface
 {
     use StreamDecoratorTrait;
 

--- a/src/MultipartStream.php
+++ b/src/MultipartStream.php
@@ -10,7 +10,7 @@ use Psr\Http\Message\StreamInterface;
  * Stream that when read returns bytes for a streaming multipart or
  * multipart/form-data stream.
  */
-class MultipartStream implements StreamInterface
+final class MultipartStream implements StreamInterface
 {
     use StreamDecoratorTrait;
 

--- a/src/NoSeekStream.php
+++ b/src/NoSeekStream.php
@@ -9,7 +9,7 @@ use Psr\Http\Message\StreamInterface;
 /**
  * Stream decorator that prevents a stream from being seeked
  */
-class NoSeekStream implements StreamInterface
+final class NoSeekStream implements StreamInterface
 {
     use StreamDecoratorTrait;
 

--- a/src/PumpStream.php
+++ b/src/PumpStream.php
@@ -16,7 +16,7 @@ use Psr\Http\Message\StreamInterface;
  * the read() function of the PumpStream. The provided callable MUST return
  * false when there is no more data to read.
  */
-class PumpStream implements StreamInterface
+final class PumpStream implements StreamInterface
 {
     /** @var callable|null */
     private $source;

--- a/src/StreamWrapper.php
+++ b/src/StreamWrapper.php
@@ -11,7 +11,7 @@ use Psr\Http\Message\StreamInterface;
  *
  * @see https://www.php.net/streamwrapper
  */
-class StreamWrapper
+final class StreamWrapper
 {
     /** @var resource */
     public $context;


### PR DESCRIPTION
the generic classes like request, response, uri, stream are not final as there seem to be use-cases to extend them

fixes #286