### PR TITLE
Use assertSame instead of assertEquals

### DIFF
--- a/tests/BufferStreamTest.php
+++ b/tests/BufferStreamTest.php
@@ -23,12 +23,12 @@ class BufferStreamTest extends TestCase
     public function testRemovesReadDataFromBuffer(): void
     {
         $b = new BufferStream();
-        self::assertEquals(3, $b->write('foo'));
-        self::assertEquals(3, $b->getSize());
+        self::assertSame(3, $b->write('foo'));
+        self::assertSame(3, $b->getSize());
         self::assertFalse($b->eof());
-        self::assertEquals('foo', $b->read(10));
+        self::assertSame('foo', $b->read(10));
         self::assertTrue($b->eof());
-        self::assertEquals('', $b->read(10));
+        self::assertSame('', $b->read(10));
     }
 
     public function testCanCastToStringOrGetContents(): void
@@ -36,9 +36,9 @@ class BufferStreamTest extends TestCase
         $b = new BufferStream();
         $b->write('foo');
         $b->write('baz');
-        self::assertEquals('foo', $b->read(3));
+        self::assertSame('foo', $b->read(3));
         $b->write('bar');
-        self::assertEquals('bazbar', (string) $b);
+        self::assertSame('bazbar', (string) $b);
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Cannot determine the position of a BufferStream');
         $b->tell();
@@ -50,16 +50,16 @@ class BufferStreamTest extends TestCase
         $b->write('foo');
         $b->detach();
         self::assertTrue($b->eof());
-        self::assertEquals(3, $b->write('abc'));
-        self::assertEquals('abc', $b->read(10));
+        self::assertSame(3, $b->write('abc'));
+        self::assertSame('abc', $b->read(10));
     }
 
     public function testExceedingHighwaterMarkReturnsFalseButStillBuffers(): void
     {
         $b = new BufferStream(5);
-        self::assertEquals(3, $b->write('hi '));
+        self::assertSame(3, $b->write('hi '));
         self::assertSame(0, $b->write('hello'));
-        self::assertEquals('hi hello', (string) $b);
-        self::assertEquals(4, $b->write('test'));
+        self::assertSame('hi hello', (string) $b);
+        self::assertSame(4, $b->write('test'));
     }
 }

--- a/tests/CachingStreamTest.php
+++ b/tests/CachingStreamTest.php
@@ -35,15 +35,15 @@ class CachingStreamTest extends TestCase
     {
         $body = Psr7\stream_for('test');
         $caching = new CachingStream($body);
-        self::assertEquals(4, $caching->getSize());
+        self::assertSame(4, $caching->getSize());
     }
 
     public function testReadsUntilCachedToByte(): void
     {
         $this->body->seek(5);
-        self::assertEquals('n', $this->body->read(1));
+        self::assertSame('n', $this->body->read(1));
         $this->body->seek(0);
-        self::assertEquals('t', $this->body->read(1));
+        self::assertSame('t', $this->body->read(1));
     }
 
     public function testCanSeekNearEndWithSeekEnd(): void
@@ -51,9 +51,9 @@ class CachingStreamTest extends TestCase
         $baseStream = Psr7\stream_for(implode('', range('a', 'z')));
         $cached = new CachingStream($baseStream);
         $cached->seek(-1, SEEK_END);
-        self::assertEquals(25, $baseStream->tell());
-        self::assertEquals('z', $cached->read(1));
-        self::assertEquals(26, $cached->getSize());
+        self::assertSame(25, $baseStream->tell());
+        self::assertSame('z', $cached->read(1));
+        self::assertSame(26, $cached->getSize());
     }
 
     public function testCanSeekToEndWithSeekEnd(): void
@@ -61,9 +61,9 @@ class CachingStreamTest extends TestCase
         $baseStream = Psr7\stream_for(implode('', range('a', 'z')));
         $cached = new CachingStream($baseStream);
         $cached->seek(0, SEEK_END);
-        self::assertEquals(26, $baseStream->tell());
-        self::assertEquals('', $cached->read(1));
-        self::assertEquals(26, $cached->getSize());
+        self::assertSame(26, $baseStream->tell());
+        self::assertSame('', $cached->read(1));
+        self::assertSame(26, $cached->getSize());
     }
 
     public function testCanUseSeekEndWithUnknownSize(): void
@@ -76,7 +76,7 @@ class CachingStreamTest extends TestCase
         ]);
         $cached = new CachingStream($decorated);
         $cached->seek(-1, SEEK_END);
-        self::assertEquals('g', $cached->read(1));
+        self::assertSame('g', $cached->read(1));
     }
 
     public function testRewind(): void
@@ -120,12 +120,12 @@ class CachingStreamTest extends TestCase
 
         $this->body = new CachingStream($this->decorated);
 
-        self::assertEquals(0, $this->body->tell());
+        self::assertSame(0, $this->body->tell());
         $this->body->seek(4, SEEK_SET);
-        self::assertEquals(4, $this->body->tell());
+        self::assertSame(4, $this->body->tell());
 
         $this->body->seek(0);
-        self::assertEquals('test', $this->body->read(4));
+        self::assertSame('test', $this->body->read(4));
     }
 
     public function testWritesToBufferStream(): void
@@ -133,7 +133,7 @@ class CachingStreamTest extends TestCase
         $this->body->read(2);
         $this->body->write('hi');
         $this->body->seek(0);
-        self::assertEquals('tehiing', (string) $this->body);
+        self::assertSame('tehiing', (string) $this->body);
     }
 
     public function testSkipsOverwrittenBytes(): void
@@ -146,28 +146,28 @@ class CachingStreamTest extends TestCase
 
         $body = new CachingStream($decorated);
 
-        self::assertEquals("0000\n", Psr7\readline($body));
-        self::assertEquals("0001\n", Psr7\readline($body));
+        self::assertSame("0000\n", Psr7\readline($body));
+        self::assertSame("0001\n", Psr7\readline($body));
         // Write over part of the body yet to be read, so skip some bytes
-        self::assertEquals(5, $body->write("TEST\n"));
+        self::assertSame(5, $body->write("TEST\n"));
         // Read, which skips bytes, then reads
-        self::assertEquals("0003\n", Psr7\readline($body));
-        self::assertEquals("0004\n", Psr7\readline($body));
-        self::assertEquals("0005\n", Psr7\readline($body));
+        self::assertSame("0003\n", Psr7\readline($body));
+        self::assertSame("0004\n", Psr7\readline($body));
+        self::assertSame("0005\n", Psr7\readline($body));
 
         // Overwrite part of the cached body (so don't skip any bytes)
         $body->seek(5);
-        self::assertEquals(5, $body->write("ABCD\n"));
-        self::assertEquals("TEST\n", Psr7\readline($body));
-        self::assertEquals("0003\n", Psr7\readline($body));
-        self::assertEquals("0004\n", Psr7\readline($body));
-        self::assertEquals("0005\n", Psr7\readline($body));
-        self::assertEquals("0006\n", Psr7\readline($body));
-        self::assertEquals(5, $body->write("1234\n"));
+        self::assertSame(5, $body->write("ABCD\n"));
+        self::assertSame("TEST\n", Psr7\readline($body));
+        self::assertSame("0003\n", Psr7\readline($body));
+        self::assertSame("0004\n", Psr7\readline($body));
+        self::assertSame("0005\n", Psr7\readline($body));
+        self::assertSame("0006\n", Psr7\readline($body));
+        self::assertSame(5, $body->write("1234\n"));
 
         // Seek to 0 and ensure the overwritten bit is replaced
         $body->seek(0);
-        self::assertEquals("0000\nABCD\nTEST\n0003\n0004\n0005\n0006\n1234\n0008\n0009\n", $body->read(50));
+        self::assertSame("0000\nABCD\nTEST\n0003\n0004\n0005\n0006\n1234\n0008\n0009\n", $body->read(50));
 
         // Ensure that casting it to a string does not include the bit that was overwritten
         self::assertStringContainsString("0000\nABCD\nTEST\n0003\n0004\n0005\n0006\n1234\n0008\n0009\n", (string) $body);

--- a/tests/DroppingStreamTest.php
+++ b/tests/DroppingStreamTest.php
@@ -14,16 +14,16 @@ class DroppingStreamTest extends TestCase
     {
         $stream = new BufferStream();
         $drop = new DroppingStream($stream, 5);
-        self::assertEquals(3, $drop->write('hel'));
-        self::assertEquals(2, $drop->write('lo'));
-        self::assertEquals(5, $drop->getSize());
-        self::assertEquals('hello', $drop->read(5));
-        self::assertEquals(0, $drop->getSize());
+        self::assertSame(3, $drop->write('hel'));
+        self::assertSame(2, $drop->write('lo'));
+        self::assertSame(5, $drop->getSize());
+        self::assertSame('hello', $drop->read(5));
+        self::assertSame(0, $drop->getSize());
         $drop->write('12345678910');
-        self::assertEquals(5, $stream->getSize());
-        self::assertEquals(5, $drop->getSize());
-        self::assertEquals('12345', (string) $drop);
-        self::assertEquals(0, $drop->getSize());
+        self::assertSame(5, $stream->getSize());
+        self::assertSame(5, $drop->getSize());
+        self::assertSame('12345', (string) $drop);
+        self::assertSame(0, $drop->getSize());
         $drop->write('hello');
         self::assertSame(0, $drop->write('test'));
     }

--- a/tests/FnStreamTest.php
+++ b/tests/FnStreamTest.php
@@ -24,12 +24,12 @@ class FnStreamTest extends TestCase
     {
         $s = new FnStream([
             'read' => function ($len) {
-                $this->assertEquals(3, $len);
+                $this->assertSame(3, $len);
                 return 'foo';
             }
         ]);
 
-        self::assertEquals('foo', $s->read(3));
+        self::assertSame('foo', $s->read(3));
     }
 
     public function testCanCloseOnDestruct(): void
@@ -55,24 +55,24 @@ class FnStreamTest extends TestCase
     {
         $a = Psr7\stream_for('foo');
         $b = FnStream::decorate($a, []);
-        self::assertEquals(3, $b->getSize());
-        self::assertEquals($b->isWritable(), true);
-        self::assertEquals($b->isReadable(), true);
-        self::assertEquals($b->isSeekable(), true);
-        self::assertEquals($b->read(3), 'foo');
-        self::assertEquals($b->tell(), 3);
-        self::assertEquals($a->tell(), 3);
+        self::assertSame(3, $b->getSize());
+        self::assertSame($b->isWritable(), true);
+        self::assertSame($b->isReadable(), true);
+        self::assertSame($b->isSeekable(), true);
+        self::assertSame($b->read(3), 'foo');
+        self::assertSame($b->tell(), 3);
+        self::assertSame($a->tell(), 3);
         self::assertSame('', $a->read(1));
-        self::assertEquals($b->eof(), true);
-        self::assertEquals($a->eof(), true);
+        self::assertSame($b->eof(), true);
+        self::assertSame($a->eof(), true);
         $b->seek(0);
-        self::assertEquals('foo', (string) $b);
+        self::assertSame('foo', (string) $b);
         $b->seek(0);
-        self::assertEquals('foo', $b->getContents());
-        self::assertEquals($a->getMetadata(), $b->getMetadata());
+        self::assertSame('foo', $b->getContents());
+        self::assertSame($a->getMetadata(), $b->getMetadata());
         $b->seek(0, SEEK_END);
         $b->write('bar');
-        self::assertEquals('foobar', (string) $b);
+        self::assertSame('foobar', (string) $b);
         self::assertIsResource($b->detach());
         $b->close();
     }
@@ -87,7 +87,7 @@ class FnStreamTest extends TestCase
                 return $a->read($len);
             }
         ]);
-        self::assertEquals('foo', $b->read(3));
+        self::assertSame('foo', $b->read(3));
         self::assertTrue($called);
     }
 

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -91,10 +91,10 @@ class FunctionsTest extends TestCase
         $s2 = Psr7\stream_for('');
         Psr7\copy_to_stream($s1, $s2, 16394);
         $s2->seek(0);
-        self::assertEquals(16394, strlen($s2->getContents()));
-        self::assertEquals(8192, $sizes[0]);
-        self::assertEquals(8192, $sizes[1]);
-        self::assertEquals(10, $sizes[2]);
+        self::assertSame(16394, strlen($s2->getContents()));
+        self::assertSame(8192, $sizes[0]);
+        self::assertSame(8192, $sizes[1]);
+        self::assertSame(10, $sizes[2]);
     }
 
     public function testStopsCopyToSteamWhenReadFailsWithMaxLen(): void
@@ -107,7 +107,7 @@ class FunctionsTest extends TestCase
         ]);
         $s2 = Psr7\stream_for('');
         Psr7\copy_to_stream($s1, $s2, 10);
-        self::assertEquals('', (string)$s2);
+        self::assertSame('', (string)$s2);
     }
 
     public function testReadsLines(): void
@@ -121,8 +121,8 @@ class FunctionsTest extends TestCase
     public function testReadsLinesUpToMaxLength(): void
     {
         $s = Psr7\stream_for("12345\n");
-        self::assertEquals('123', Psr7\readline($s, 4));
-        self::assertEquals("45\n", Psr7\readline($s));
+        self::assertSame('123', Psr7\readline($s, 4));
+        self::assertSame("45\n", Psr7\readline($s));
     }
 
     public function testReadLinesEof(): void
@@ -152,13 +152,13 @@ class FunctionsTest extends TestCase
         $s->expects(self::exactly(2))
             ->method('eof')
             ->willReturn(false);
-        self::assertEquals('h', Psr7\readline($s));
+        self::assertSame('h', Psr7\readline($s));
     }
 
     public function testCalculatesHash(): void
     {
         $s = Psr7\stream_for('foobazbar');
-        self::assertEquals(md5('foobazbar'), Psr7\hash($s, 'md5'));
+        self::assertSame(md5('foobazbar'), Psr7\hash($s, 'md5'));
     }
 
     public function testCalculatesHashThrowsWhenSeekFails(): void
@@ -173,8 +173,8 @@ class FunctionsTest extends TestCase
     {
         $s = Psr7\stream_for('foobazbar');
         $s->seek(4);
-        self::assertEquals(md5('foobazbar'), Psr7\hash($s, 'md5'));
-        self::assertEquals(4, $s->tell());
+        self::assertSame(md5('foobazbar'), Psr7\hash($s, 'md5'));
+        self::assertSame(4, $s->tell());
     }
 
     public function testOpensFilesSuccessfully(): void
@@ -243,7 +243,7 @@ class FunctionsTest extends TestCase
     {
         $str = 'foo%20=bar';
         $data = Psr7\parse_query($str, false);
-        self::assertEquals(['foo%20' => 'bar'], $data);
+        self::assertSame(['foo%20' => 'bar'], $data);
     }
 
     /**
@@ -258,90 +258,90 @@ class FunctionsTest extends TestCase
     public function testEncodesWithRfc1738(): void
     {
         $str = Psr7\build_query(['foo bar' => 'baz+'], PHP_QUERY_RFC1738);
-        self::assertEquals('foo+bar=baz%2B', $str);
+        self::assertSame('foo+bar=baz%2B', $str);
     }
 
     public function testEncodesWithRfc3986(): void
     {
         $str = Psr7\build_query(['foo bar' => 'baz+'], PHP_QUERY_RFC3986);
-        self::assertEquals('foo%20bar=baz%2B', $str);
+        self::assertSame('foo%20bar=baz%2B', $str);
     }
 
     public function testDoesNotEncode(): void
     {
         $str = Psr7\build_query(['foo bar' => 'baz+'], false);
-        self::assertEquals('foo bar=baz+', $str);
+        self::assertSame('foo bar=baz+', $str);
     }
 
     public function testCanControlDecodingType(): void
     {
         $result = Psr7\parse_query('var=foo+bar', PHP_QUERY_RFC3986);
-        self::assertEquals('foo+bar', $result['var']);
+        self::assertSame('foo+bar', $result['var']);
         $result = Psr7\parse_query('var=foo+bar', PHP_QUERY_RFC1738);
-        self::assertEquals('foo bar', $result['var']);
+        self::assertSame('foo bar', $result['var']);
     }
 
     public function testParsesRequestMessages(): void
     {
         $req = "GET /abc HTTP/1.0\r\nHost: foo.com\r\nFoo: Bar\r\nBaz: Bam\r\nBaz: Qux\r\n\r\nTest";
         $request = Psr7\parse_request($req);
-        self::assertEquals('GET', $request->getMethod());
-        self::assertEquals('/abc', $request->getRequestTarget());
-        self::assertEquals('1.0', $request->getProtocolVersion());
-        self::assertEquals('foo.com', $request->getHeaderLine('Host'));
-        self::assertEquals('Bar', $request->getHeaderLine('Foo'));
-        self::assertEquals('Bam, Qux', $request->getHeaderLine('Baz'));
-        self::assertEquals('Test', (string)$request->getBody());
-        self::assertEquals('http://foo.com/abc', (string)$request->getUri());
+        self::assertSame('GET', $request->getMethod());
+        self::assertSame('/abc', $request->getRequestTarget());
+        self::assertSame('1.0', $request->getProtocolVersion());
+        self::assertSame('foo.com', $request->getHeaderLine('Host'));
+        self::assertSame('Bar', $request->getHeaderLine('Foo'));
+        self::assertSame('Bam, Qux', $request->getHeaderLine('Baz'));
+        self::assertSame('Test', (string)$request->getBody());
+        self::assertSame('http://foo.com/abc', (string)$request->getUri());
     }
 
     public function testParsesRequestMessagesWithHttpsScheme(): void
     {
         $req = "PUT /abc?baz=bar HTTP/1.1\r\nHost: foo.com:443\r\n\r\n";
         $request = Psr7\parse_request($req);
-        self::assertEquals('PUT', $request->getMethod());
-        self::assertEquals('/abc?baz=bar', $request->getRequestTarget());
-        self::assertEquals('1.1', $request->getProtocolVersion());
-        self::assertEquals('foo.com:443', $request->getHeaderLine('Host'));
-        self::assertEquals('', (string)$request->getBody());
-        self::assertEquals('https://foo.com/abc?baz=bar', (string)$request->getUri());
+        self::assertSame('PUT', $request->getMethod());
+        self::assertSame('/abc?baz=bar', $request->getRequestTarget());
+        self::assertSame('1.1', $request->getProtocolVersion());
+        self::assertSame('foo.com:443', $request->getHeaderLine('Host'));
+        self::assertSame('', (string)$request->getBody());
+        self::assertSame('https://foo.com/abc?baz=bar', (string)$request->getUri());
     }
 
     public function testParsesRequestMessagesWithUriWhenHostIsNotFirst(): void
     {
         $req = "PUT / HTTP/1.1\r\nFoo: Bar\r\nHost: foo.com\r\n\r\n";
         $request = Psr7\parse_request($req);
-        self::assertEquals('PUT', $request->getMethod());
-        self::assertEquals('/', $request->getRequestTarget());
-        self::assertEquals('http://foo.com/', (string)$request->getUri());
+        self::assertSame('PUT', $request->getMethod());
+        self::assertSame('/', $request->getRequestTarget());
+        self::assertSame('http://foo.com/', (string)$request->getUri());
     }
 
     public function testParsesRequestMessagesWithFullUri(): void
     {
         $req = "GET https://www.google.com:443/search?q=foobar HTTP/1.1\r\nHost: www.google.com\r\n\r\n";
         $request = Psr7\parse_request($req);
-        self::assertEquals('GET', $request->getMethod());
-        self::assertEquals('https://www.google.com:443/search?q=foobar', $request->getRequestTarget());
-        self::assertEquals('1.1', $request->getProtocolVersion());
-        self::assertEquals('www.google.com', $request->getHeaderLine('Host'));
-        self::assertEquals('', (string)$request->getBody());
-        self::assertEquals('https://www.google.com/search?q=foobar', (string)$request->getUri());
+        self::assertSame('GET', $request->getMethod());
+        self::assertSame('https://www.google.com:443/search?q=foobar', $request->getRequestTarget());
+        self::assertSame('1.1', $request->getProtocolVersion());
+        self::assertSame('www.google.com', $request->getHeaderLine('Host'));
+        self::assertSame('', (string)$request->getBody());
+        self::assertSame('https://www.google.com/search?q=foobar', (string)$request->getUri());
     }
 
     public function testParsesRequestMessagesWithCustomMethod(): void
     {
         $req = "GET_DATA / HTTP/1.1\r\nFoo: Bar\r\nHost: foo.com\r\n\r\n";
         $request = Psr7\parse_request($req);
-        self::assertEquals('GET_DATA', $request->getMethod());
+        self::assertSame('GET_DATA', $request->getMethod());
     }
 
     public function testParsesRequestMessagesWithFoldedHeadersOnHttp10(): void
     {
         $req = "PUT / HTTP/1.0\r\nFoo: Bar\r\n Bam\r\n\r\n";
         $request = Psr7\parse_request($req);
-        self::assertEquals('PUT', $request->getMethod());
-        self::assertEquals('/', $request->getRequestTarget());
-        self::assertEquals('Bar Bam', $request->getHeaderLine('Foo'));
+        self::assertSame('PUT', $request->getMethod());
+        self::assertSame('/', $request->getRequestTarget());
+        self::assertSame('Bar Bam', $request->getHeaderLine('Foo'));
     }
 
     public function testRequestParsingFailsWithFoldedHeadersOnHttp11(): void
@@ -355,10 +355,10 @@ class FunctionsTest extends TestCase
     {
         $req = "PUT / HTTP/1.0\nFoo: Bar\nBaz: Bam\n\n";
         $request = Psr7\parse_request($req);
-        self::assertEquals('PUT', $request->getMethod());
-        self::assertEquals('/', $request->getRequestTarget());
-        self::assertEquals('Bar', $request->getHeaderLine('Foo'));
-        self::assertEquals('Bam', $request->getHeaderLine('Baz'));
+        self::assertSame('PUT', $request->getMethod());
+        self::assertSame('/', $request->getRequestTarget());
+        self::assertSame('Bar', $request->getHeaderLine('Foo'));
+        self::assertSame('Bam', $request->getHeaderLine('Baz'));
     }
 
     public function testValidatesRequestMessages(): void
@@ -446,11 +446,11 @@ class FunctionsTest extends TestCase
     public function testDetermineMimetype(): void
     {
         self::assertNull(Psr7\mimetype_from_extension('not-a-real-extension'));
-        self::assertEquals(
+        self::assertSame(
             'application/json',
             Psr7\mimetype_from_extension('json')
         );
-        self::assertEquals(
+        self::assertSame(
             'image/jpeg',
             Psr7\mimetype_from_filename('/tmp/images/IMG034821.JPEG')
         );
@@ -476,7 +476,7 @@ class FunctionsTest extends TestCase
         $h = fopen(__FILE__, 'r');
         fseek($h, 10);
         $stream = Psr7\stream_for($h);
-        self::assertEquals(10, $stream->tell());
+        self::assertSame(10, $stream->tell());
         $stream->close();
     }
 
@@ -484,7 +484,7 @@ class FunctionsTest extends TestCase
     {
         $stream = Psr7\stream_for('foo');
         self::assertInstanceOf(Stream::class, $stream);
-        self::assertEquals('foo', $stream->getContents());
+        self::assertSame('foo', $stream->getContents());
         $stream->close();
     }
 
@@ -513,7 +513,7 @@ class FunctionsTest extends TestCase
         $r = new HasToString();
         $s = Psr7\stream_for($r);
         self::assertInstanceOf(Stream::class, $s);
-        self::assertEquals('foo', (string)$s);
+        self::assertSame('foo', (string)$s);
     }
 
     public function testCreatePassesThrough(): void
@@ -531,14 +531,14 @@ class FunctionsTest extends TestCase
     public function testReturnsCustomMetadata(): void
     {
         $s = Psr7\stream_for('foo', ['metadata' => ['hwm' => 3]]);
-        self::assertEquals(3, $s->getMetadata('hwm'));
+        self::assertSame(3, $s->getMetadata('hwm'));
         self::assertArrayHasKey('hwm', $s->getMetadata());
     }
 
     public function testCanSetSize(): void
     {
         $s = Psr7\stream_for('', ['size' => 10]);
-        self::assertEquals(10, $s->getSize());
+        self::assertSame(10, $s->getSize());
     }
 
     public function testCanCreateIteratorBasedStream(): void
@@ -546,15 +546,15 @@ class FunctionsTest extends TestCase
         $a = new \ArrayIterator(['foo', 'bar', '123']);
         $p = Psr7\stream_for($a);
         self::assertInstanceOf(Psr7\PumpStream::class, $p);
-        self::assertEquals('foo', $p->read(3));
+        self::assertSame('foo', $p->read(3));
         self::assertFalse($p->eof());
-        self::assertEquals('b', $p->read(1));
-        self::assertEquals('a', $p->read(1));
-        self::assertEquals('r12', $p->read(3));
+        self::assertSame('b', $p->read(1));
+        self::assertSame('a', $p->read(1));
+        self::assertSame('r12', $p->read(3));
         self::assertFalse($p->eof());
-        self::assertEquals('3', $p->getContents());
+        self::assertSame('3', $p->getContents());
         self::assertTrue($p->eof());
-        self::assertEquals(9, $p->tell());
+        self::assertSame(9, $p->tell());
     }
 
     public function testConvertsRequestsToStrings(): void
@@ -563,7 +563,7 @@ class FunctionsTest extends TestCase
             'Baz' => 'bar',
             'Qux' => 'ipsum',
         ], 'hello', '1.0');
-        self::assertEquals(
+        self::assertSame(
             "PUT /hi?123 HTTP/1.0\r\nHost: foo.com\r\nBaz: bar\r\nQux: ipsum\r\n\r\nhello",
             Psr7\str($request)
         );
@@ -575,7 +575,7 @@ class FunctionsTest extends TestCase
             'Baz' => 'bar',
             'Qux' => 'ipsum',
         ], 'hello', '1.0', 'FOO');
-        self::assertEquals(
+        self::assertSame(
             "HTTP/1.0 200 FOO\r\nBaz: bar\r\nQux: ipsum\r\n\r\nhello",
             Psr7\str($response)
         );
@@ -586,7 +586,7 @@ class FunctionsTest extends TestCase
         $response = new Psr7\Response(200, [
             'Set-Cookie' => ['bar','baz','qux']
         ], 'hello', '1.0', 'FOO');
-        self::assertEquals(
+        self::assertSame(
             "HTTP/1.0 200 FOO\r\nSet-Cookie: bar\r\nSet-Cookie: baz\r\nSet-Cookie: qux\r\n\r\nhello",
             Psr7\str($response)
         );
@@ -643,13 +643,13 @@ class FunctionsTest extends TestCase
      */
     public function testParseParams($header, $result): void
     {
-        self::assertEquals($result, Psr7\parse_header($header));
+        self::assertSame($result, Psr7\parse_header($header));
     }
 
     public function testParsesArrayHeaders(): void
     {
         $header = ['a, b', 'c', 'd, e'];
-        self::assertEquals(['a', 'b', 'c', 'd', 'e'], Psr7\normalize_header($header));
+        self::assertSame(['a', 'b', 'c', 'd', 'e'], Psr7\normalize_header($header));
     }
 
     public function testRewindsBody(): void
@@ -657,10 +657,10 @@ class FunctionsTest extends TestCase
         $body = Psr7\stream_for('abc');
         $res = new Psr7\Response(200, [], $body);
         Psr7\rewind_body($res);
-        self::assertEquals(0, $body->tell());
+        self::assertSame(0, $body->tell());
         $body->rewind();
         Psr7\rewind_body($res);
-        self::assertEquals(0, $body->tell());
+        self::assertSame(0, $body->tell());
     }
 
     public function testThrowsWhenBodyCannotBeRewound(): void
@@ -683,8 +683,8 @@ class FunctionsTest extends TestCase
         $r2 = Psr7\modify_request($r1, [
             'uri' => new Psr7\Uri('http://www.foo.com'),
         ]);
-        self::assertEquals('http://www.foo.com', (string)$r2->getUri());
-        self::assertEquals('www.foo.com', (string)$r2->getHeaderLine('host'));
+        self::assertSame('http://www.foo.com', (string)$r2->getUri());
+        self::assertSame('www.foo.com', (string)$r2->getHeaderLine('host'));
     }
 
     public function testCanModifyRequestWithUriAndPort(): void
@@ -693,16 +693,16 @@ class FunctionsTest extends TestCase
         $r2 = Psr7\modify_request($r1, [
             'uri' => new Psr7\Uri('http://www.foo.com:8000'),
         ]);
-        self::assertEquals('http://www.foo.com:8000', (string)$r2->getUri());
-        self::assertEquals('www.foo.com:8000', (string)$r2->getHeaderLine('host'));
+        self::assertSame('http://www.foo.com:8000', (string)$r2->getUri());
+        self::assertSame('www.foo.com:8000', (string)$r2->getHeaderLine('host'));
     }
 
     public function testCanModifyRequestWithCaseInsensitiveHeader(): void
     {
         $r1 = new Psr7\Request('GET', 'http://foo.com', ['User-Agent' => 'foo']);
         $r2 = Psr7\modify_request($r1, ['set_headers' => ['User-agent' => 'bar']]);
-        self::assertEquals('bar', $r2->getHeaderLine('User-Agent'));
-        self::assertEquals('bar', $r2->getHeaderLine('User-agent'));
+        self::assertSame('bar', $r2->getHeaderLine('User-Agent'));
+        self::assertSame('bar', $r2->getHeaderLine('User-agent'));
     }
 
     public function testReturnsAsIsWhenNoChanges(): void
@@ -721,7 +721,7 @@ class FunctionsTest extends TestCase
         $r1 = new Psr7\Request('GET', 'http://foo.com');
         $r2 = Psr7\modify_request($r1, ['set_headers' => ['foo' => 'bar']]);
         self::assertNotSame($r1, $r2);
-        self::assertEquals('bar', $r2->getHeaderLine('foo'));
+        self::assertSame('bar', $r2->getHeaderLine('foo'));
     }
 
     public function testRemovesHeadersFromMessage(): void
@@ -737,7 +737,7 @@ class FunctionsTest extends TestCase
         $r1 = new Psr7\Request('GET', 'http://foo.com');
         $r2 = Psr7\modify_request($r1, ['query' => 'foo=bar']);
         self::assertNotSame($r1, $r2);
-        self::assertEquals('foo=bar', $r2->getUri()->getQuery());
+        self::assertSame('foo=bar', $r2->getUri()->getQuery());
     }
 
     public function testModifyRequestKeepInstanceOfRequest(): void
@@ -754,19 +754,19 @@ class FunctionsTest extends TestCase
     public function testMessageBodySummaryWithSmallBody(): void
     {
         $message = new Psr7\Response(200, [], 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.');
-        self::assertEquals('Lorem ipsum dolor sit amet, consectetur adipiscing elit.', Psr7\get_message_body_summary($message));
+        self::assertSame('Lorem ipsum dolor sit amet, consectetur adipiscing elit.', Psr7\get_message_body_summary($message));
     }
 
     public function testMessageBodySummaryWithLargeBody(): void
     {
         $message = new Psr7\Response(200, [], 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.');
-        self::assertEquals('Lorem ipsu (truncated...)', Psr7\get_message_body_summary($message, 10));
+        self::assertSame('Lorem ipsu (truncated...)', Psr7\get_message_body_summary($message, 10));
     }
 
     public function testMessageBodySummaryWithSpecialUTF8Characters(): void
     {
         $message = new Psr7\Response(200, [], '’é€௵ဪ‱');
-        self::assertEquals('’é€௵ဪ‱', Psr7\get_message_body_summary($message));
+        self::assertSame('’é€௵ဪ‱', Psr7\get_message_body_summary($message));
     }
 
     public function testMessageBodySummaryWithEmptyBody(): void
@@ -803,7 +803,7 @@ class FunctionsTest extends TestCase
         /** @var Psr7\ServerRequest $modifiedRequest */
         $modifiedRequest = Psr7\modify_request($request, ['set_headers' => ['foo' => 'bar']]);
 
-        self::assertEquals(['name' => 'value'], $modifiedRequest->getCookieParams());
+        self::assertSame(['name' => 'value'], $modifiedRequest->getCookieParams());
     }
 
     public function testModifyServerRequestParsedBody(): void
@@ -814,7 +814,7 @@ class FunctionsTest extends TestCase
         /** @var Psr7\ServerRequest $modifiedRequest */
         $modifiedRequest = Psr7\modify_request($request, ['set_headers' => ['foo' => 'bar']]);
 
-        self::assertEquals(['name' => 'value'], $modifiedRequest->getParsedBody());
+        self::assertSame(['name' => 'value'], $modifiedRequest->getParsedBody());
     }
 
     public function testModifyServerRequestQueryParams(): void
@@ -825,7 +825,7 @@ class FunctionsTest extends TestCase
         /** @var Psr7\ServerRequest $modifiedRequest */
         $modifiedRequest = Psr7\modify_request($request, ['set_headers' => ['foo' => 'bar']]);
 
-        self::assertEquals(['name' => 'value'], $modifiedRequest->getQueryParams());
+        self::assertSame(['name' => 'value'], $modifiedRequest->getQueryParams());
     }
 }
 

--- a/tests/InflateStreamTest.php
+++ b/tests/InflateStreamTest.php
@@ -19,7 +19,7 @@ class InflateStreamTest extends TestCase
         $content = gzencode('test');
         $a = Psr7\stream_for($content);
         $b = new InflateStream($a);
-        self::assertEquals('test', (string) $b);
+        self::assertSame('test', (string) $b);
     }
 
     public function testInflatesStreamsRfc1952WithFilename(): void
@@ -27,7 +27,7 @@ class InflateStreamTest extends TestCase
         $content = $this->getGzipStringWithFilename('test');
         $a = Psr7\stream_for($content);
         $b = new InflateStream($a);
-        self::assertEquals('test', (string) $b);
+        self::assertSame('test', (string) $b);
     }
 
     public function testInflatesRfc1950Streams(): void
@@ -35,7 +35,7 @@ class InflateStreamTest extends TestCase
         $content = gzcompress('test');
         $a = Psr7\stream_for($content);
         $b = new InflateStream($a);
-        self::assertEquals('test', (string) $b);
+        self::assertSame('test', (string) $b);
     }
 
     public function testInflatesRfc1952StreamsWithExtraFlags(): void
@@ -62,7 +62,7 @@ class InflateStreamTest extends TestCase
 
         $a = Psr7\stream_for($header . $content);
         $b = new InflateStream($a);
-        self::assertEquals('test', (string) $b);
+        self::assertSame('test', (string) $b);
     }
 
     public function testInflatesStreamsPreserveSeekable(): void
@@ -72,12 +72,12 @@ class InflateStreamTest extends TestCase
 
         $seekableInflate = new InflateStream($seekable);
         self::assertTrue($seekableInflate->isSeekable());
-        self::assertEquals('test', (string) $seekableInflate);
+        self::assertSame('test', (string) $seekableInflate);
 
         $nonSeekable = new NoSeekStream(Psr7\stream_for($content));
         $nonSeekableInflate = new InflateStream($nonSeekable);
         self::assertFalse($nonSeekableInflate->isSeekable());
-        self::assertEquals('test', (string) $nonSeekableInflate);
+        self::assertSame('test', (string) $nonSeekableInflate);
     }
 
     private function getGzipStringWithFilename($original_string)

--- a/tests/LazyOpenStreamTest.php
+++ b/tests/LazyOpenStreamTest.php
@@ -41,16 +41,16 @@ class LazyOpenStreamTest extends TestCase
     {
         file_put_contents($this->fname, 'foo');
         $l = new LazyOpenStream($this->fname, 'r');
-        self::assertEquals('foo', $l->read(4));
+        self::assertSame('foo', $l->read(4));
         self::assertTrue($l->eof());
-        self::assertEquals(3, $l->tell());
+        self::assertSame(3, $l->tell());
         self::assertTrue($l->isReadable());
         self::assertTrue($l->isSeekable());
         self::assertFalse($l->isWritable());
         $l->seek(1);
-        self::assertEquals('oo', $l->getContents());
-        self::assertEquals('foo', (string) $l);
-        self::assertEquals(3, $l->getSize());
+        self::assertSame('oo', $l->getContents());
+        self::assertSame('foo', (string) $l);
+        self::assertSame(3, $l->getSize());
         self::assertIsArray($l->getMetadata());
         $l->close();
     }

--- a/tests/LimitStreamTest.php
+++ b/tests/LimitStreamTest.php
@@ -31,11 +31,11 @@ class LimitStreamTest extends TestCase
     public function testReturnsSubset(): void
     {
         $body = new LimitStream(Psr7\stream_for('foo'), -1, 1);
-        self::assertEquals('oo', (string) $body);
+        self::assertSame('oo', (string) $body);
         self::assertTrue($body->eof());
         $body->seek(0);
         self::assertFalse($body->eof());
-        self::assertEquals('oo', $body->read(100));
+        self::assertSame('oo', $body->read(100));
         self::assertSame('', $body->read(1));
         self::assertTrue($body->eof());
     }
@@ -44,47 +44,47 @@ class LimitStreamTest extends TestCase
     {
         $body = Psr7\stream_for('foo_baz_bar');
         $limited = new LimitStream($body, 3, 4);
-        self::assertEquals('baz', (string) $limited);
+        self::assertSame('baz', (string) $limited);
     }
 
     public function testReturnsSubsetOfEmptyBodyWhenCastToString(): void
     {
         $body = Psr7\stream_for('01234567891234');
         $limited = new LimitStream($body, 0, 10);
-        self::assertEquals('', (string) $limited);
+        self::assertSame('', (string) $limited);
     }
 
     public function testReturnsSpecificSubsetOBodyWhenCastToString(): void
     {
         $body = Psr7\stream_for('0123456789abcdef');
         $limited = new LimitStream($body, 3, 10);
-        self::assertEquals('abc', (string) $limited);
+        self::assertSame('abc', (string) $limited);
     }
 
     public function testSeeksWhenConstructed(): void
     {
-        self::assertEquals(0, $this->body->tell());
-        self::assertEquals(3, $this->decorated->tell());
+        self::assertSame(0, $this->body->tell());
+        self::assertSame(3, $this->decorated->tell());
     }
 
     public function testAllowsBoundedSeek(): void
     {
         $this->body->seek(100);
-        self::assertEquals(10, $this->body->tell());
-        self::assertEquals(13, $this->decorated->tell());
+        self::assertSame(10, $this->body->tell());
+        self::assertSame(13, $this->decorated->tell());
         $this->body->seek(0);
-        self::assertEquals(0, $this->body->tell());
-        self::assertEquals(3, $this->decorated->tell());
+        self::assertSame(0, $this->body->tell());
+        self::assertSame(3, $this->decorated->tell());
         try {
             $this->body->seek(-10);
             self::fail();
         } catch (\RuntimeException $e) {
         }
-        self::assertEquals(0, $this->body->tell());
-        self::assertEquals(3, $this->decorated->tell());
+        self::assertSame(0, $this->body->tell());
+        self::assertSame(3, $this->decorated->tell());
         $this->body->seek(5);
-        self::assertEquals(5, $this->body->tell());
-        self::assertEquals(8, $this->decorated->tell());
+        self::assertSame(5, $this->body->tell());
+        self::assertSame(8, $this->decorated->tell());
         // Fail
         try {
             $this->body->seek(1000, SEEK_END);
@@ -96,12 +96,12 @@ class LimitStreamTest extends TestCase
     public function testReadsOnlySubsetOfData(): void
     {
         $data = $this->body->read(100);
-        self::assertEquals(10, strlen($data));
+        self::assertSame(10, strlen($data));
         self::assertSame('', $this->body->read(1000));
 
         $this->body->setOffset(10);
         $newData = $this->body->read(100);
-        self::assertEquals(10, strlen($newData));
+        self::assertSame(10, strlen($newData));
         self::assertNotSame($data, $newData);
     }
 
@@ -121,7 +121,7 @@ class LimitStreamTest extends TestCase
         $a = Psr7\stream_for('foo_bar');
         $b = new NoSeekStream($a);
         $c = new LimitStream($b);
-        self::assertEquals('foo_bar', $c->getContents());
+        self::assertSame('foo_bar', $c->getContents());
     }
 
     public function testClaimsConsumedWhenReadLimitIsReached(): void
@@ -133,13 +133,13 @@ class LimitStreamTest extends TestCase
 
     public function testContentLengthIsBounded(): void
     {
-        self::assertEquals(10, $this->body->getSize());
+        self::assertSame(10, $this->body->getSize());
     }
 
     public function testGetContentsIsBasedOnSubset(): void
     {
         $body = new LimitStream(Psr7\stream_for('foobazbar'), 3, 3);
-        self::assertEquals('baz', $body->getContents());
+        self::assertSame('baz', $body->getContents());
     }
 
     public function testReturnsNullIfSizeCannotBeDetermined(): void
@@ -160,6 +160,6 @@ class LimitStreamTest extends TestCase
     {
         $a = Psr7\stream_for('foo_bar');
         $b = new LimitStream($a, -1, 4);
-        self::assertEquals(3, $b->getSize());
+        self::assertSame(3, $b->getSize());
     }
 }

--- a/tests/MultipartStreamTest.php
+++ b/tests/MultipartStreamTest.php
@@ -19,7 +19,7 @@ class MultipartStreamTest extends TestCase
     public function testCanProvideBoundary(): void
     {
         $b = new MultipartStream([], 'foo');
-        self::assertEquals('foo', $b->getBoundary());
+        self::assertSame('foo', $b->getBoundary());
     }
 
     public function testIsNotWritable(): void
@@ -60,7 +60,7 @@ class MultipartStreamTest extends TestCase
                 'contents' => 'bam'
             ]
         ], 'boundary');
-        self::assertEquals(
+        self::assertSame(
             "--boundary\r\nContent-Disposition: form-data; name=\"foo\"\r\nContent-Length: 3\r\n\r\n"
             . "bar\r\n--boundary\r\nContent-Disposition: form-data; name=\"baz\"\r\nContent-Length: 3"
             . "\r\n\r\nbam\r\n--boundary--\r\n",
@@ -88,7 +88,7 @@ class MultipartStreamTest extends TestCase
                 'contents' => (float) 1.1
             ]
         ], 'boundary');
-        self::assertEquals(
+        self::assertSame(
             "--boundary\r\nContent-Disposition: form-data; name=\"int\"\r\nContent-Length: 1\r\n\r\n"
             . "1\r\n--boundary\r\nContent-Disposition: form-data; name=\"bool\"\r\n\r\n\r\n--boundary"
             . "\r\nContent-Disposition: form-data; name=\"bool2\"\r\nContent-Length: 1\r\n\r\n"
@@ -156,7 +156,7 @@ bar
 
 EOT;
 
-        self::assertEquals($expected, str_replace("\r", '', $b));
+        self::assertSame($expected, str_replace("\r", '', $b));
     }
 
     public function testSerializesFilesWithCustomHeaders(): void
@@ -190,7 +190,7 @@ foo
 
 EOT;
 
-        self::assertEquals($expected, str_replace("\r", '', $b));
+        self::assertSame($expected, str_replace("\r", '', $b));
     }
 
     public function testSerializesFilesWithCustomHeadersAndMultipleValues(): void
@@ -241,6 +241,6 @@ baz
 
 EOT;
 
-        self::assertEquals($expected, str_replace("\r", '', $b));
+        self::assertSame($expected, str_replace("\r", '', $b));
     }
 }

--- a/tests/PumpStreamTest.php
+++ b/tests/PumpStreamTest.php
@@ -19,9 +19,9 @@ class PumpStreamTest extends TestCase
             'size'     => 100
         ]);
 
-        self::assertEquals('bar', $p->getMetadata('foo'));
-        self::assertEquals(['foo' => 'bar'], $p->getMetadata());
-        self::assertEquals(100, $p->getSize());
+        self::assertSame('bar', $p->getMetadata('foo'));
+        self::assertSame(['foo' => 'bar'], $p->getMetadata());
+        self::assertSame(100, $p->getSize());
     }
 
     public function testCanReadFromCallable(): void
@@ -29,10 +29,10 @@ class PumpStreamTest extends TestCase
         $p = Psr7\stream_for(function ($size) {
             return 'a';
         });
-        self::assertEquals('a', $p->read(1));
-        self::assertEquals(1, $p->tell());
-        self::assertEquals('aaaaa', $p->read(5));
-        self::assertEquals(6, $p->tell());
+        self::assertSame('a', $p->read(1));
+        self::assertSame(1, $p->tell());
+        self::assertSame('aaaaa', $p->read(5));
+        self::assertSame(6, $p->tell());
     }
 
     public function testStoresExcessDataInBuffer(): void
@@ -42,11 +42,11 @@ class PumpStreamTest extends TestCase
             $called[] = $size;
             return 'abcdef';
         });
-        self::assertEquals('a', $p->read(1));
-        self::assertEquals('b', $p->read(1));
-        self::assertEquals('cdef', $p->read(4));
-        self::assertEquals('abcdefabc', $p->read(9));
-        self::assertEquals([1, 9, 3], $called);
+        self::assertSame('a', $p->read(1));
+        self::assertSame('b', $p->read(1));
+        self::assertSame('cdef', $p->read(4));
+        self::assertSame('abcdefabc', $p->read(9));
+        self::assertSame([1, 9, 3], $called);
     }
 
     public function testInifiniteStreamWrappedInLimitStream(): void
@@ -55,7 +55,7 @@ class PumpStreamTest extends TestCase
             return 'a';
         });
         $s = new LimitStream($p, 5);
-        self::assertEquals('aaaaa', (string) $s);
+        self::assertSame('aaaaa', (string) $s);
     }
 
     public function testDescribesCapabilities(): void
@@ -66,10 +66,10 @@ class PumpStreamTest extends TestCase
         self::assertFalse($p->isSeekable());
         self::assertFalse($p->isWritable());
         self::assertNull($p->getSize());
-        self::assertEquals('', $p->getContents());
-        self::assertEquals('', (string) $p);
+        self::assertSame('', $p->getContents());
+        self::assertSame('', (string) $p);
         $p->close();
-        self::assertEquals('', $p->read(10));
+        self::assertSame('', $p->read(10));
         self::assertTrue($p->eof());
 
         try {

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -412,18 +412,18 @@ class ServerRequestTest extends TestCase
         $server = ServerRequest::fromGlobals();
 
         self::assertSame('POST', $server->getMethod());
-        self::assertEquals([
-            'Host' => ['www.example.org'],
+        self::assertSame([
             'Content-Type' => ['text/plain'],
+            'Host' => ['www.example.org'],
             'Accept' => ['text/html'],
             'Referrer' => ['https://example.com'],
             'User-Agent' => ['My User Agent'],
         ], $server->getHeaders());
         self::assertSame('', (string) $server->getBody());
         self::assertSame('1.1', $server->getProtocolVersion());
-        self::assertEquals($_COOKIE, $server->getCookieParams());
-        self::assertEquals($_POST, $server->getParsedBody());
-        self::assertEquals($_GET, $server->getQueryParams());
+        self::assertSame($_COOKIE, $server->getCookieParams());
+        self::assertSame($_POST, $server->getParsedBody());
+        self::assertSame($_GET, $server->getQueryParams());
 
         self::assertEquals(
             new Uri('https://www.example.org/blog/article.php?id=10&user=foo'),
@@ -529,7 +529,7 @@ class ServerRequestTest extends TestCase
 
         self::assertSame('value', $request2->getAttribute('name'));
         self::assertSame(['name' => 'value'], $request2->getAttributes());
-        self::assertEquals(['name' => 'value', 'other' => 'otherValue'], $request3->getAttributes());
+        self::assertSame(['name' => 'value', 'other' => 'otherValue'], $request3->getAttributes());
         self::assertSame(['name' => 'value'], $request4->getAttributes());
     }
 

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -412,9 +412,9 @@ class ServerRequestTest extends TestCase
         $server = ServerRequest::fromGlobals();
 
         self::assertSame('POST', $server->getMethod());
-        self::assertSame([
-            'Content-Type' => ['text/plain'],
+        self::assertEquals([
             'Host' => ['www.example.org'],
+            'Content-Type' => ['text/plain'],
             'Accept' => ['text/html'],
             'Referrer' => ['https://example.com'],
             'User-Agent' => ['My User Agent'],

--- a/tests/StreamDecoratorTraitTest.php
+++ b/tests/StreamDecoratorTraitTest.php
@@ -55,45 +55,45 @@ class StreamDecoratorTraitTest extends TestCase
 
     public function testToString(): void
     {
-        self::assertEquals('foo', (string) $this->b);
+        self::assertSame('foo', (string) $this->b);
     }
 
     public function testHasSize(): void
     {
-        self::assertEquals(3, $this->b->getSize());
+        self::assertSame(3, $this->b->getSize());
     }
 
     public function testReads(): void
     {
-        self::assertEquals('foo', $this->b->read(10));
+        self::assertSame('foo', $this->b->read(10));
     }
 
     public function testCheckMethods(): void
     {
-        self::assertEquals($this->a->isReadable(), $this->b->isReadable());
-        self::assertEquals($this->a->isWritable(), $this->b->isWritable());
-        self::assertEquals($this->a->isSeekable(), $this->b->isSeekable());
+        self::assertSame($this->a->isReadable(), $this->b->isReadable());
+        self::assertSame($this->a->isWritable(), $this->b->isWritable());
+        self::assertSame($this->a->isSeekable(), $this->b->isSeekable());
     }
 
     public function testSeeksAndTells(): void
     {
         $this->b->seek(1);
-        self::assertEquals(1, $this->a->tell());
-        self::assertEquals(1, $this->b->tell());
+        self::assertSame(1, $this->a->tell());
+        self::assertSame(1, $this->b->tell());
         $this->b->seek(0);
-        self::assertEquals(0, $this->a->tell());
-        self::assertEquals(0, $this->b->tell());
+        self::assertSame(0, $this->a->tell());
+        self::assertSame(0, $this->b->tell());
         $this->b->seek(0, SEEK_END);
-        self::assertEquals(3, $this->a->tell());
-        self::assertEquals(3, $this->b->tell());
+        self::assertSame(3, $this->a->tell());
+        self::assertSame(3, $this->b->tell());
     }
 
     public function testGetsContents(): void
     {
-        self::assertEquals('foo', $this->b->getContents());
-        self::assertEquals('', $this->b->getContents());
+        self::assertSame('foo', $this->b->getContents());
+        self::assertSame('', $this->b->getContents());
         $this->b->seek(1);
-        self::assertEquals('oo', $this->b->getContents());
+        self::assertSame('oo', $this->b->getContents());
     }
 
     public function testCloses(): void
@@ -118,7 +118,7 @@ class StreamDecoratorTraitTest extends TestCase
     {
         $this->b->seek(0, SEEK_END);
         $this->b->write('foo');
-        self::assertEquals('foofoo', (string) $this->a);
+        self::assertSame('foofoo', (string) $this->a);
     }
 
     public function testThrowsWithInvalidGetter(): void

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -91,10 +91,10 @@ class StreamTest extends TestCase
         $handle = fopen('php://temp', 'w+');
         fwrite($handle, 'data');
         $stream = new Stream($handle);
-        self::assertEquals('', $stream->getContents());
+        self::assertSame('', $stream->getContents());
         $stream->seek(0);
-        self::assertEquals('data', $stream->getContents());
-        self::assertEquals('', $stream->getContents());
+        self::assertSame('data', $stream->getContents());
+        self::assertSame('', $stream->getContents());
         $stream->close();
     }
 
@@ -115,21 +115,21 @@ class StreamTest extends TestCase
         $size = filesize(__FILE__);
         $handle = fopen(__FILE__, 'r');
         $stream = new Stream($handle);
-        self::assertEquals($size, $stream->getSize());
+        self::assertSame($size, $stream->getSize());
         // Load from cache
-        self::assertEquals($size, $stream->getSize());
+        self::assertSame($size, $stream->getSize());
         $stream->close();
     }
 
     public function testEnsuresSizeIsConsistent(): void
     {
         $h = fopen('php://temp', 'w+');
-        self::assertEquals(3, fwrite($h, 'foo'));
+        self::assertSame(3, fwrite($h, 'foo'));
         $stream = new Stream($h);
-        self::assertEquals(3, $stream->getSize());
-        self::assertEquals(4, $stream->write('test'));
-        self::assertEquals(7, $stream->getSize());
-        self::assertEquals(7, $stream->getSize());
+        self::assertSame(3, $stream->getSize());
+        self::assertSame(4, $stream->write('test'));
+        self::assertSame(7, $stream->getSize());
+        self::assertSame(7, $stream->getSize());
         $stream->close();
     }
 
@@ -137,11 +137,11 @@ class StreamTest extends TestCase
     {
         $handle = fopen('php://temp', 'w+');
         $stream = new Stream($handle);
-        self::assertEquals(0, $stream->tell());
+        self::assertSame(0, $stream->tell());
         $stream->write('foo');
-        self::assertEquals(3, $stream->tell());
+        self::assertSame(3, $stream->tell());
         $stream->seek(1);
-        self::assertEquals(1, $stream->tell());
+        self::assertSame(1, $stream->tell());
         self::assertSame(ftell($handle), $stream->tell());
         $stream->close();
     }

--- a/tests/StreamWrapperTest.php
+++ b/tests/StreamWrapperTest.php
@@ -28,20 +28,7 @@ class StreamWrapperTest extends TestCase
 
         $stBlksize  = defined('PHP_WINDOWS_VERSION_BUILD') ? -1 : 0;
 
-        self::assertEquals([
-            'dev'     => 0,
-            'ino'     => 0,
-            'mode'    => 33206,
-            'nlink'   => 0,
-            'uid'     => 0,
-            'gid'     => 0,
-            'rdev'    => 0,
-            'size'    => 6,
-            'atime'   => 0,
-            'mtime'   => 0,
-            'ctime'   => 0,
-            'blksize' => $stBlksize,
-            'blocks'  => $stBlksize,
+        self::assertSame([
             0         => 0,
             1         => 0,
             2         => 33206,
@@ -55,6 +42,19 @@ class StreamWrapperTest extends TestCase
             10        => 0,
             11        => $stBlksize,
             12        => $stBlksize,
+            'dev'     => 0,
+            'ino'     => 0,
+            'mode'    => 33206,
+            'nlink'   => 0,
+            'uid'     => 0,
+            'gid'     => 0,
+            'rdev'    => 0,
+            'size'    => 6,
+            'atime'   => 0,
+            'mtime'   => 0,
+            'ctime'   => 0,
+            'blksize' => $stBlksize,
+            'blocks'  => $stBlksize,
         ], fstat($handle));
 
         self::assertTrue(fclose($handle));
@@ -65,7 +65,7 @@ class StreamWrapperTest extends TestCase
     {
         $stream = Psr7\stream_for('foo');
 
-        self::assertEquals('foo', file_get_contents('guzzle://stream', false, StreamWrapper::createStreamContext($stream)));
+        self::assertSame('foo', file_get_contents('guzzle://stream', false, StreamWrapper::createStreamContext($stream)));
     }
 
     public function testStreamCast(): void
@@ -119,21 +119,8 @@ class StreamWrapperTest extends TestCase
 
         $stBlksize  = defined('PHP_WINDOWS_VERSION_BUILD') ? -1 : 0;
 
-        self::assertEquals(
+        self::assertSame(
             [
-                'dev'     => 0,
-                'ino'     => 0,
-                'mode'    => 0,
-                'nlink'   => 0,
-                'uid'     => 0,
-                'gid'     => 0,
-                'rdev'    => 0,
-                'size'    => 0,
-                'atime'   => 0,
-                'mtime'   => 0,
-                'ctime'   => 0,
-                'blksize' => $stBlksize,
-                'blocks'  => $stBlksize,
                 0         => 0,
                 1         => 0,
                 2         => 0,
@@ -147,6 +134,19 @@ class StreamWrapperTest extends TestCase
                 10        => 0,
                 11        => $stBlksize,
                 12        => $stBlksize,
+                'dev'     => 0,
+                'ino'     => 0,
+                'mode'    => 0,
+                'nlink'   => 0,
+                'uid'     => 0,
+                'gid'     => 0,
+                'rdev'    => 0,
+                'size'    => 0,
+                'atime'   => 0,
+                'mtime'   => 0,
+                'ctime'   => 0,
+                'blksize' => $stBlksize,
+                'blocks'  => $stBlksize,
             ],
             stat('guzzle://stream')
         );
@@ -165,7 +165,7 @@ class StreamWrapperTest extends TestCase
 
         self::assertTrue($reader->open('guzzle://stream'));
         self::assertTrue($reader->read());
-        self::assertEquals('foo', $reader->name);
+        self::assertSame('foo', $reader->name);
     }
 
     /**

--- a/tests/StreamWrapperTest.php
+++ b/tests/StreamWrapperTest.php
@@ -28,20 +28,7 @@ class StreamWrapperTest extends TestCase
 
         $stBlksize  = defined('PHP_WINDOWS_VERSION_BUILD') ? -1 : 0;
 
-        self::assertSame([
-            0         => 0,
-            1         => 0,
-            2         => 33206,
-            3         => 0,
-            4         => 0,
-            5         => 0,
-            6         => 0,
-            7         => 6,
-            8         => 0,
-            9         => 0,
-            10        => 0,
-            11        => $stBlksize,
-            12        => $stBlksize,
+        self::assertEquals([
             'dev'     => 0,
             'ino'     => 0,
             'mode'    => 33206,
@@ -55,6 +42,19 @@ class StreamWrapperTest extends TestCase
             'ctime'   => 0,
             'blksize' => $stBlksize,
             'blocks'  => $stBlksize,
+            0         => 0,
+            1         => 0,
+            2         => 33206,
+            3         => 0,
+            4         => 0,
+            5         => 0,
+            6         => 0,
+            7         => 6,
+            8         => 0,
+            9         => 0,
+            10        => 0,
+            11        => $stBlksize,
+            12        => $stBlksize,
         ], fstat($handle));
 
         self::assertTrue(fclose($handle));
@@ -119,21 +119,8 @@ class StreamWrapperTest extends TestCase
 
         $stBlksize  = defined('PHP_WINDOWS_VERSION_BUILD') ? -1 : 0;
 
-        self::assertSame(
+        self::assertEquals(
             [
-                0         => 0,
-                1         => 0,
-                2         => 0,
-                3         => 0,
-                4         => 0,
-                5         => 0,
-                6         => 0,
-                7         => 0,
-                8         => 0,
-                9         => 0,
-                10        => 0,
-                11        => $stBlksize,
-                12        => $stBlksize,
                 'dev'     => 0,
                 'ino'     => 0,
                 'mode'    => 0,
@@ -147,6 +134,19 @@ class StreamWrapperTest extends TestCase
                 'ctime'   => 0,
                 'blksize' => $stBlksize,
                 'blocks'  => $stBlksize,
+                0         => 0,
+                1         => 0,
+                2         => 0,
+                3         => 0,
+                4         => 0,
+                5         => 0,
+                6         => 0,
+                7         => 0,
+                8         => 0,
+                9         => 0,
+                10        => 0,
+                11        => $stBlksize,
+                12        => $stBlksize,
             ],
             stat('guzzle://stream')
         );

--- a/tests/UploadedFileTest.php
+++ b/tests/UploadedFileTest.php
@@ -86,14 +86,14 @@ class UploadedFileTest extends TestCase
         $stream = \GuzzleHttp\Psr7\stream_for('Foo bar!');
         $upload = new UploadedFile($stream, $stream->getSize(), UPLOAD_ERR_OK, 'filename.txt', 'text/plain');
 
-        self::assertEquals($stream->getSize(), $upload->getSize());
-        self::assertEquals('filename.txt', $upload->getClientFilename());
-        self::assertEquals('text/plain', $upload->getClientMediaType());
+        self::assertSame($stream->getSize(), $upload->getSize());
+        self::assertSame('filename.txt', $upload->getClientFilename());
+        self::assertSame('text/plain', $upload->getClientMediaType());
 
         $this->cleanup[] = $to = tempnam(sys_get_temp_dir(), 'successful');
         $upload->moveTo($to);
         self::assertFileExists($to);
-        self::assertEquals($stream->__toString(), file_get_contents($to));
+        self::assertSame($stream->__toString(), file_get_contents($to));
     }
 
     public function invalidMovePaths(): iterable


### PR DESCRIPTION
So the thing is that there are assertions happening between objects. Hence the rule of assertSame can not be enforced.

Let me know WDYT.