### PR TITLE
Revert "Include '/u' flag on summary regex + tests"

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -879,7 +879,7 @@ function get_message_body_summary(MessageInterface $message, $truncateAt = 120)
 
     // Matches any printable character, including unicode characters:
     // letters, marks, numbers, punctuation, spacing, and separators.
-    if (preg_match('/[^\pL\pM\pN\pP\pS\pZ\n\r\t]/u', $summary)) {
+    if (preg_match('/[^\pL\pM\pN\pP\pS\pZ\n\r\t]/', $summary)) {
         return null;
     }
 

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -782,12 +782,6 @@ class FunctionsTest extends BaseTest
         $this->assertEquals('Lorem ipsu (truncated...)', Psr7\get_message_body_summary($message, 10));
     }
 
-    public function testMessageBodySummaryWithSpecialUTF8Characters()
-    {
-        $message = new Psr7\Response(200, [], '’é€௵ဪ‱');
-        self::assertEquals('’é€௵ဪ‱', Psr7\get_message_body_summary($message));
-    }
-
     public function testMessageBodySummaryWithEmptyBody()
     {
         $message = new Psr7\Response(200, [], '');


### PR DESCRIPTION
This reverts commit ef793921f7b207313e3ebe9d7b74fa856c870092. This change is breaking, and breaks Guzzle's tests. I'd suggest we only keep this change for 2.0.0, and revert in the 1.x series. Note that ef793921f7b207313e3ebe9d7b74fa856c870092 is not yet included in any tagged release, so nobody can complain that reverting it is actually breaking in itself.