### PR TITLE
CI and HHVM fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,39 @@
 language: php
 
-php:
-    - 5.6
-    - 7.0
-    - 7.1
-    - 7.2
-    - 7.3
-    - 7.4
-    - hhvm
-
 matrix:
-    # See https://travis-ci.community/t/php-5-4-and-5-5-archives-missing/3723
     include:
+        - php: hhvm-3.24
+          dist: trusty
         - php: 5.4
           dist: trusty
+          env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
+        - php: 5.4
+          dist: trusty
+        - php: 5.5.9
+          dist: trusty
+          env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
         - php: 5.5
           dist: trusty
+        - php: 5.6
+          dist: xenial
+        - php: 7.0
+          dist: xenial
+        - php: 7.1
+          dist: bionic
+        - php: 7.2
+          dist: bionic
+        - php: 7.3
+          dist: bionic
+        - php: 7.4
+          dist: bionic
     fast_finish: true
-    allow_failures:
-        - php: hhvm
 
-cache:
-    directories:
-        - vendor
-        - $HOME/.composer/cache
+before_install:
+    - if [[ "$TRAVIS_PHP_VERSION" != "hhvm-3.24" ]]; then echo "xdebug.overload_var_dump = 1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
+    - if [[ "$TRAVIS_PHP_VERSION" == "hhvm-3.24" ]]; then travis_retry composer require "phpunit/phpunit:^5.7.27" --dev --no-update -n; fi
 
 install:
-    - travis_retry composer install --no-interaction --prefer-dist
+    - travis_retry composer update --prefer-dist
 
-script: make test
+script:
+    - make test

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -69,6 +69,10 @@ class StreamTest extends BaseTest
 
     public function testConvertsToStringNonSeekableStream()
     {
+        if (defined('HHVM_VERSION')) {
+            $this->markTestSkipped('This does not work on HHVM.');
+        }
+
         $handle = popen('echo foo', 'r');
         $stream = new Stream($handle);
         $this->assertFalse($stream->isSeekable());
@@ -77,6 +81,10 @@ class StreamTest extends BaseTest
 
     public function testConvertsToStringNonSeekablePartiallyReadStream()
     {
+        if (defined('HHVM_VERSION')) {
+            $this->markTestSkipped('This does not work on HHVM.');
+        }
+
         $handle = popen('echo bar', 'r');
         $stream = new Stream($handle);
         $firstLetter = $stream->read(1);


### PR DESCRIPTION
This tests on the same versions as https://github.com/guzzle/promises/pull/110 (as well as 5.4), in particular, testing on HHVM 3 properly.