### PR TITLE
[1.x] Run tests on PHP 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ matrix:
           dist: bionic
         - php: 7.4
           dist: bionic
+        - php: nightly
+          dist: bionic
     fast_finish: true
 
 before_install:
@@ -33,7 +35,8 @@ before_install:
     - if [[ "$TRAVIS_PHP_VERSION" == "hhvm-3.24" ]]; then travis_retry composer require "phpunit/phpunit:^5.7.27" --dev --no-update -n; fi
 
 install:
-    - travis_retry composer update --prefer-dist
+    - if [[ "$TRAVIS_PHP_VERSION" != "nightly" ]]; then travis_retry composer update --prefer-dist; fi
+    - if [[ "$TRAVIS_PHP_VERSION" == "nightly" ]]; then travis_retry composer update --prefer-dist --ignore-platform-reqs; fi
 
 script:
     - make test

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "ralouphie/getallheaders": "^2.0.5 || ^3.0.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.8.36 || ^5.7.27 || ^6.5.8",
+        "phpunit/phpunit": "~4.8.36 || ^5.7.27 || ^6.5.14 || ^7.5.20 || ^8.5.8 || ^9.3.10",
         "ext-zlib": "*"
     },
     "provide": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,18 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-    bootstrap="tests/bootstrap.php"
+    backupGlobals="true"
     colors="true"
+    beStrictAboutOutputDuringTests="true"
+    beStrictAboutTestsThatDoNotTestAnything="true"
+    bootstrap="vendor/autoload.php"
 >
   <testsuites>
-    <testsuite>
-      <directory>tests</directory>
+    <testsuite name="GuzzleHttp PSR7 Test Suite">
+      <directory>tests/</directory>
     </testsuite>
   </testsuites>
   <filter>
     <whitelist>
-      <directory suffix=".php">src</directory>
+      <directory suffix=".php">src/</directory>
     </whitelist>
   </filter>
 </phpunit>

--- a/tests/AppendStreamTest.php
+++ b/tests/AppendStreamTest.php
@@ -7,10 +7,6 @@ use GuzzleHttp\Psr7;
 
 class AppendStreamTest extends BaseTest
 {
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Each stream must be readable
-     */
     public function testValidatesStreamsAreReadable()
     {
         $a = new AppendStream();
@@ -20,23 +16,21 @@ class AppendStreamTest extends BaseTest
         $s->expects($this->once())
             ->method('isReadable')
             ->will($this->returnValue(false));
+
+        $this->expectExceptionGuzzle('InvalidArgumentException', 'Each stream must be readable');
+
         $a->addStream($s);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage The AppendStream can only seek with SEEK_SET
-     */
     public function testValidatesSeekType()
     {
         $a = new AppendStream();
+
+        $this->expectExceptionGuzzle('RuntimeException', 'The AppendStream can only seek with SEEK_SET');
+
         $a->seek(100, SEEK_CUR);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Unable to seek stream 0 of the AppendStream
-     */
     public function testTriesToRewindOnSeek()
     {
         $a = new AppendStream();
@@ -53,6 +47,9 @@ class AppendStreamTest extends BaseTest
             ->method('rewind')
             ->will($this->throwException(new \RuntimeException()));
         $a->addStream($s);
+
+        $this->expectExceptionGuzzle('RuntimeException', 'Unable to seek stream 0 of the AppendStream');
+
         $a->seek(10);
     }
 
@@ -104,7 +101,7 @@ class AppendStreamTest extends BaseTest
         $this->assertFalse($a->isWritable());
 
         $this->assertNull($s1->detach());
-        $this->assertInternalType('resource', $handle, 'resource is not closed when detaching');
+        $this->assertInternalTypeGuzzle('resource', $handle, 'resource is not closed when detaching');
         fclose($handle);
     }
 
@@ -128,16 +125,15 @@ class AppendStreamTest extends BaseTest
         $this->assertFalse(is_resource($handle));
     }
 
-    /**
-     * @expectedExceptionMessage Cannot write to an AppendStream
-     * @expectedException \RuntimeException
-     */
     public function testIsNotWritable()
     {
         $a = new AppendStream([Psr7\Utils::streamFor('foo')]);
         $this->assertFalse($a->isWritable());
         $this->assertTrue($a->isSeekable());
         $this->assertTrue($a->isReadable());
+
+        $this->expectExceptionGuzzle('RuntimeException', 'Cannot write to an AppendStream');
+
         $a->write('foo');
     }
 

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -7,19 +7,133 @@ use PHPUnit\Framework\TestCase;
 abstract class BaseTest extends TestCase
 {
     /**
-     * Make sure expectException always exists, even on PHPUnit 4
      * @param string      $exception
      * @param string|null $message
      */
-    public function expectException($exception, $message = null)
+    public function expectExceptionGuzzle($exception, $message = null)
     {
         if (method_exists($this, 'setExpectedException')) {
             $this->setExpectedException($exception, $message);
         } else {
-            parent::expectException($exception);
+            $this->expectException($exception);
             if (null !== $message) {
                 $this->expectExceptionMessage($message);
             }
+        }
+    }
+
+    public function expectWarningGuzzle()
+    {
+        if (method_exists($this, 'expectWarning')) {
+            $this->expectWarning();
+        } elseif (class_exists('PHPUnit\Framework\Error\Warning')) {
+            $this->expectExceptionGuzzle('PHPUnit\Framework\Error\Warning');
+        } else {
+            $this->expectExceptionGuzzle('PHPUnit_Framework_Error_Warning');
+        }
+    }
+
+    /**
+     * @param string $type
+     * @param mixed  $input
+     */
+    public function assertInternalTypeGuzzle($type, $input)
+    {
+        switch ($type) {
+            case 'array':
+                if (method_exists($this, 'assertIsArray')) {
+                    $this->assertIsArray($input);
+                } else {
+                    $this->assertInternalType('array', $input);
+                }
+                break;
+            case 'bool':
+            case 'boolean':
+                if (method_exists($this, 'assertIsBool')) {
+                    $this->assertIsBool($input);
+                } else {
+                    $this->assertInternalType('bool', $input);
+                }
+                break;
+            case 'double':
+            case 'float':
+            case 'real':
+                if (method_exists($this, 'assertIsFloat')) {
+                    $this->assertIsFloat($input);
+                } else {
+                    $this->assertInternalType('float', $input);
+                }
+                break;
+            case 'int':
+            case 'integer':
+                if (method_exists($this, 'assertIsInt')) {
+                    $this->assertIsInt($input);
+                } else {
+                    $this->assertInternalType('int', $input);
+                }
+                break;
+            case 'numeric':
+                if (method_exists($this, 'assertIsNumeric')) {
+                    $this->assertIsNumeric($input);
+                } else {
+                    $this->assertInternalType('numeric', $input);
+                }
+                break;
+            case 'object':
+                if (method_exists($this, 'assertIsObject')) {
+                    $this->assertIsObject($input);
+                } else {
+                    $this->assertInternalType('object', $input);
+                }
+                break;
+            case 'resource':
+                if (method_exists($this, 'assertIsResource')) {
+                    $this->assertIsResource($input);
+                } else {
+                    $this->assertInternalType('resource', $input);
+                }
+                break;
+            case 'string':
+                if (method_exists($this, 'assertIsString')) {
+                    $this->assertIsString($input);
+                } else {
+                    $this->assertInternalType('string', $input);
+                }
+                break;
+            case 'scalar':
+                if (method_exists($this, 'assertIsScalar')) {
+                    $this->assertIsScalar($input);
+                } else {
+                    $this->assertInternalType('scalar', $input);
+                }
+                break;
+            case 'callable':
+                if (method_exists($this, 'assertIsCallable')) {
+                    $this->assertIsCallable($input);
+                } else {
+                    $this->assertInternalType('callable', $input);
+                }
+                break;
+            case 'iterable':
+                if (method_exists($this, 'assertIsIterable')) {
+                    $this->assertIsIterable($input);
+                } else {
+                    $this->assertInternalType('iterable', $input);
+                }
+                break;
+        }
+    }
+
+    /**
+     * @param string $needle
+     * @param string $haystack
+     */
+    public function assertStringContainsStringGuzzle($needle, $haystack)
+    {
+        if (method_exists($this, 'assertStringContainsString')) {
+            $this->assertStringContainsString($needle, $haystack);
+        } else {
+            $this->assertContains($needle, $haystack);
         }
     }
 }

--- a/tests/BufferStreamTest.php
+++ b/tests/BufferStreamTest.php
@@ -28,10 +28,6 @@ class BufferStreamTest extends BaseTest
         $this->assertSame('', $b->read(10));
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Cannot determine the position of a BufferStream
-     */
     public function testCanCastToStringOrGetContents()
     {
         $b = new BufferStream();
@@ -40,6 +36,9 @@ class BufferStreamTest extends BaseTest
         $this->assertSame('foo', $b->read(3));
         $b->write('bar');
         $this->assertSame('bazbar', (string) $b);
+
+        $this->expectExceptionGuzzle('RuntimeException', 'Cannot determine the position of a BufferStream');
+
         $b->tell();
     }
 

--- a/tests/FnStreamTest.php
+++ b/tests/FnStreamTest.php
@@ -10,12 +10,10 @@ use GuzzleHttp\Psr7\FnStream;
  */
 class FnStreamTest extends BaseTest
 {
-    /**
-     * @expectedException \BadMethodCallException
-     * @expectedExceptionMessage seek() is not implemented in the FnStream
-     */
     public function testThrowsWhenNotImplemented()
     {
+        $this->expectExceptionGuzzle('BadMethodCallException', 'seek() is not implemented in the FnStream');
+
         (new FnStream([]))->seek(1);
     }
 
@@ -72,7 +70,7 @@ class FnStreamTest extends BaseTest
         $b->seek(0, SEEK_END);
         $b->write('bar');
         $this->assertSame('foobar', (string) $b);
-        $this->assertInternalType('resource', $b->detach());
+        $this->assertInternalTypeGuzzle('resource', $b->detach());
         $b->close();
     }
 
@@ -94,7 +92,7 @@ class FnStreamTest extends BaseTest
     {
         $a = new FnStream([]);
         $b = serialize($a);
-        $this->expectException('\LogicException', 'FnStream should never be unserialized');
+        $this->expectExceptionGuzzle('\LogicException', 'FnStream should never be unserialized');
         unserialize($b);
     }
 }

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace GuzzleHttp\Tests\Psr7;
+
+class Helpers
+{
+    /**
+     * @param object $object
+     * @param string $attributeName
+     */
+    public static function readObjectAttribute($object, $attributeName)
+    {
+        $reflector = new \ReflectionObject($object);
+
+        do {
+            try {
+                $attribute = $reflector->getProperty($attributeName);
+
+                if (!$attribute || $attribute->isPublic()) {
+                    return $object->$attributeName;
+                }
+
+                $attribute->setAccessible(true);
+
+                return $attribute->getValue($object);
+            } catch (\ReflectionException $e) {
+                // do nothing
+            }
+        } while ($reflector = $reflector->getParentClass());
+
+        throw new \Exception(
+            sprintf('Attribute "%s" not found in object.', $attributeName)
+        );
+    }
+}

--- a/tests/LazyOpenStreamTest.php
+++ b/tests/LazyOpenStreamTest.php
@@ -8,7 +8,10 @@ class LazyOpenStreamTest extends BaseTest
 {
     private $fname;
 
-    protected function setUp()
+    /**
+     * @before
+     */
+    public function setUpTest()
     {
         $this->fname = tempnam(sys_get_temp_dir(), 'tfile');
 
@@ -17,7 +20,10 @@ class LazyOpenStreamTest extends BaseTest
         }
     }
 
-    protected function tearDown()
+    /**
+     * @after
+     */
+    public function tearDownTest()
     {
         if (file_exists($this->fname)) {
             unlink($this->fname);
@@ -28,7 +34,7 @@ class LazyOpenStreamTest extends BaseTest
     {
         $l = new LazyOpenStream($this->fname, 'w+');
         $l->write('foo');
-        $this->assertInternalType('array', $l->getMetadata());
+        $this->assertInternalTypeGuzzle('array', $l->getMetadata());
         $this->assertFileExists($this->fname);
         $this->assertSame('foo', file_get_contents($this->fname));
         $this->assertSame('foo', (string) $l);
@@ -48,7 +54,7 @@ class LazyOpenStreamTest extends BaseTest
         $this->assertSame('oo', $l->getContents());
         $this->assertSame('foo', (string) $l);
         $this->assertSame(3, $l->getSize());
-        $this->assertInternalType('array', $l->getMetadata());
+        $this->assertInternalTypeGuzzle('array', $l->getMetadata());
         $l->close();
     }
 
@@ -57,7 +63,7 @@ class LazyOpenStreamTest extends BaseTest
         file_put_contents($this->fname, 'foo');
         $l = new LazyOpenStream($this->fname, 'r');
         $r = $l->detach();
-        $this->assertInternalType('resource', $r);
+        $this->assertInternalTypeGuzzle('resource', $r);
         fseek($r, 0);
         $this->assertSame('foo', stream_get_contents($r));
         fclose($r);

--- a/tests/LimitStreamTest.php
+++ b/tests/LimitStreamTest.php
@@ -19,7 +19,10 @@ class LimitStreamTest extends BaseTest
     /** @var Stream */
     private $decorated;
 
-    protected function setUp()
+    /**
+     * @before
+     */
+    public function setUpTest()
     {
         $this->decorated = Psr7\Utils::streamFor(fopen(__FILE__, 'r'));
         $this->body = new LimitStream($this->decorated, 10, 3);
@@ -100,16 +103,15 @@ class LimitStreamTest extends BaseTest
         $this->assertNotSame($data, $newData);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Could not seek to stream offset 2
-     */
     public function testThrowsWhenCurrentGreaterThanOffsetSeek()
     {
         $a = Psr7\Utils::streamFor('foo_bar');
         $b = new NoSeekStream($a);
         $c = new LimitStream($b);
         $a->getContents();
+
+        $this->expectExceptionGuzzle('RuntimeException', 'Could not seek to stream offset 2');
+
         $c->setOffset(2);
     }
 

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -53,9 +53,6 @@ class MessageTest extends BaseTest
         $this->assertSame(0, $body->tell());
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testThrowsWhenBodyCannotBeRewound()
     {
         $body = Psr7\Utils::streamFor('abc');
@@ -66,6 +63,9 @@ class MessageTest extends BaseTest
             },
         ]);
         $res = new Psr7\Response(200, [], $body);
+
+        $this->expectExceptionGuzzle('RuntimeException');
+
         Psr7\Message::rewindBody($res);
     }
 
@@ -132,12 +132,10 @@ class MessageTest extends BaseTest
         $this->assertSame('Bar Bam', $request->getHeaderLine('Foo'));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Invalid header syntax: Obsolete line folding
-     */
     public function testRequestParsingFailsWithFoldedHeadersOnHttp11()
     {
+        $this->expectExceptionGuzzle('InvalidArgumentException', 'Invalid header syntax: Obsolete line folding');
+
         Psr7\Message::parseResponse("GET_DATA / HTTP/1.1\r\nFoo: Bar\r\n Biz: Bam\r\n\r\n");
     }
 
@@ -151,11 +149,10 @@ class MessageTest extends BaseTest
         $this->assertSame('Bam', $request->getHeaderLine('Baz'));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testValidatesRequestMessages()
     {
+        $this->expectExceptionGuzzle('InvalidArgumentException');
+
         Psr7\Message::parseRequest("HTTP/1.1 200 OK\r\n\r\n");
     }
 
@@ -205,12 +202,10 @@ class MessageTest extends BaseTest
         $this->assertSame('Test', (string)$response->getBody());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Invalid header syntax: Obsolete line folding
-     */
     public function testResponseParsingFailsWithFoldedHeadersOnHttp11()
     {
+        $this->expectExceptionGuzzle('InvalidArgumentException', 'Invalid header syntax: Obsolete line folding');
+
         Psr7\Message::parseResponse("HTTP/1.1 200\r\nFoo: Bar\r\n Biz: Bam\r\nBaz: Qux\r\n\r\nTest");
     }
 
@@ -226,20 +221,17 @@ class MessageTest extends BaseTest
         $this->assertSame("Test\n\nOtherTest", (string)$response->getBody());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Invalid message: Missing header delimiter
-     */
     public function testResponseParsingFailsWithoutHeaderDelimiter()
     {
+        $this->expectExceptionGuzzle('InvalidArgumentException', 'Invalid message: Missing header delimiter');
+
         Psr7\Message::parseResponse("HTTP/1.0 200\r\nFoo: Bar\r\n Baz: Bam\r\nBaz: Qux\r\n");
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testValidatesResponseMessages()
     {
+        $this->expectExceptionGuzzle('InvalidArgumentException');
+
         Psr7\Message::parseResponse("GET / HTTP/1.1\r\n\r\n");
     }
 

--- a/tests/MultipartStreamTest.php
+++ b/tests/MultipartStreamTest.php
@@ -33,19 +33,17 @@ class MultipartStreamTest extends BaseTest
         $this->assertSame(strlen($boundary) + 6, $b->getSize());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testValidatesFilesArrayElement()
     {
+        $this->expectExceptionGuzzle('InvalidArgumentException');
+
         new MultipartStream([['foo' => 'bar']]);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testEnsuresFileHasName()
     {
+        $this->expectExceptionGuzzle('InvalidArgumentException');
+
         new MultipartStream([['contents' => 'bar']]);
     }
 

--- a/tests/NoSeekStreamTest.php
+++ b/tests/NoSeekStreamTest.php
@@ -11,10 +11,6 @@ use GuzzleHttp\Psr7\NoSeekStream;
  */
 class NoSeekStreamTest extends BaseTest
 {
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Cannot seek a NoSeekStream
-     */
     public function testCannotSeek()
     {
         $s = $this->getMockBuilder('Psr\Http\Message\StreamInterface')
@@ -24,6 +20,9 @@ class NoSeekStreamTest extends BaseTest
         $s->expects($this->never())->method('isSeekable');
         $wrapped = new NoSeekStream($s);
         $this->assertFalse($wrapped->isSeekable());
+
+        $this->expectExceptionGuzzle('RuntimeException', 'Cannot seek a NoSeekStream');
+
         $wrapped->seek(2);
     }
 

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -25,11 +25,10 @@ class RequestTest extends BaseTest
         $this->assertSame($uri, $r->getUri());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testValidateRequestUri()
     {
+        $this->expectExceptionGuzzle('InvalidArgumentException');
+
         new Request('GET', '///');
     }
 
@@ -97,7 +96,7 @@ class RequestTest extends BaseTest
      */
     public function testConstructWithInvalidMethods($method)
     {
-        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionGuzzle('InvalidArgumentException');
         new Request($method, '/');
     }
 
@@ -107,7 +106,7 @@ class RequestTest extends BaseTest
     public function testWithInvalidMethods($method)
     {
         $r = new Request('get', '/');
-        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionGuzzle('InvalidArgumentException');
         $r->withMethod($method);
     }
 
@@ -136,11 +135,10 @@ class RequestTest extends BaseTest
         $this->assertSame('/', $r1->getRequestTarget());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testRequestTargetDoesNotAllowSpaces()
     {
+        $this->expectExceptionGuzzle('InvalidArgumentException');
+
         $r1 = new Request('GET', '/');
         $r1->withRequestTarget('/foo bar');
     }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -255,7 +255,7 @@ class ResponseTest extends BaseTest
      */
     public function testConstructResponseInvalidHeader($header, $headerValue, $expectedMessage)
     {
-        $this->expectException('InvalidArgumentException', $expectedMessage);
+        $this->expectExceptionGuzzle('InvalidArgumentException', $expectedMessage);
         new Response(200, [$header => $headerValue]);
     }
 
@@ -274,7 +274,7 @@ class ResponseTest extends BaseTest
     public function testWithInvalidHeader($header, $headerValue, $expectedMessage)
     {
         $r = new Response();
-        $this->expectException('InvalidArgumentException', $expectedMessage);
+        $this->expectExceptionGuzzle('InvalidArgumentException', $expectedMessage);
         $r->withHeader($header, $headerValue);
     }
 
@@ -315,7 +315,7 @@ class ResponseTest extends BaseTest
      */
     public function testConstructResponseWithNonIntegerStatusCode($invalidValues)
     {
-        $this->expectException('InvalidArgumentException', 'Status code must be an integer value.');
+        $this->expectExceptionGuzzle('InvalidArgumentException', 'Status code must be an integer value.');
         new Response($invalidValues);
     }
 
@@ -326,7 +326,7 @@ class ResponseTest extends BaseTest
     public function testResponseChangeStatusCodeWithNonInteger($invalidValues)
     {
         $response = new Response();
-        $this->expectException('InvalidArgumentException', 'Status code must be an integer value.');
+        $this->expectExceptionGuzzle('InvalidArgumentException', 'Status code must be an integer value.');
         $response->withStatus($invalidValues);
     }
 
@@ -346,7 +346,7 @@ class ResponseTest extends BaseTest
      */
     public function testConstructResponseWithInvalidRangeStatusCode($invalidValues)
     {
-        $this->expectException('InvalidArgumentException', 'Status code must be an integer value between 1xx and 5xx.');
+        $this->expectExceptionGuzzle('InvalidArgumentException', 'Status code must be an integer value between 1xx and 5xx.');
         new Response($invalidValues);
     }
 
@@ -357,7 +357,7 @@ class ResponseTest extends BaseTest
     public function testResponseChangeStatusCodeWithWithInvalidRange($invalidValues)
     {
         $response = new Response();
-        $this->expectException('InvalidArgumentException', 'Status code must be an integer value between 1xx and 5xx.');
+        $this->expectExceptionGuzzle('InvalidArgumentException', 'Status code must be an integer value between 1xx and 5xx.');
         $response->withStatus($invalidValues);
     }
 

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -267,7 +267,7 @@ class ServerRequestTest extends BaseTest
 
     public function testNormalizeFilesRaisesException()
     {
-        $this->expectException('InvalidArgumentException', 'Invalid value in files specification');
+        $this->expectExceptionGuzzle('InvalidArgumentException', 'Invalid value in files specification');
         ServerRequest::normalizeFiles(['test' => 'something']);
     }
 

--- a/tests/StreamDecoratorTraitTest.php
+++ b/tests/StreamDecoratorTraitTest.php
@@ -23,7 +23,10 @@ class StreamDecoratorTraitTest extends BaseTest
     /** @var resource */
     private $c;
 
-    protected function setUp()
+    /**
+     * @before
+     */
+    public function setUpTest()
     {
         $this->c = fopen('php://temp', 'r+');
         fwrite($this->c, 'foo');
@@ -44,7 +47,7 @@ class StreamDecoratorTraitTest extends BaseTest
         set_error_handler(function ($errNo, $str) use (&$msg) { $msg = $str; });
         echo new Str($s);
         restore_error_handler();
-        $this->assertContains('foo', $msg);
+        $this->assertStringContainsStringGuzzle('foo', $msg);
     }
 
     public function testToString()
@@ -115,20 +118,19 @@ class StreamDecoratorTraitTest extends BaseTest
         $this->assertSame('foofoo', (string) $this->a);
     }
 
-    /**
-     * @expectedException \UnexpectedValueException
-     */
     public function testThrowsWithInvalidGetter()
     {
+        $this->expectExceptionGuzzle('UnexpectedValueException');
+
         $this->b->foo;
     }
 
-    /**
-     * @expectedException \BadMethodCallException
-     */
     public function testThrowsWhenGetterNotImplemented()
     {
         $s = new BadStream();
+
+        $this->expectExceptionGuzzle('BadMethodCallException');
+
         $s->stream;
     }
 }

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -12,11 +12,10 @@ class StreamTest extends BaseTest
 {
     public static $isFReadError = false;
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testConstructorThrowsExceptionOnInvalidArgument()
     {
+        $this->expectExceptionGuzzle('InvalidArgumentException');
+
         new Stream(true);
     }
 
@@ -29,7 +28,7 @@ class StreamTest extends BaseTest
         $this->assertTrue($stream->isWritable());
         $this->assertTrue($stream->isSeekable());
         $this->assertSame('php://temp', $stream->getMetadata('uri'));
-        $this->assertInternalType('array', $stream->getMetadata());
+        $this->assertInternalTypeGuzzle('array', $stream->getMetadata());
         $this->assertSame(4, $stream->getSize());
         $this->assertFalse($stream->eof());
         $stream->close();
@@ -44,7 +43,7 @@ class StreamTest extends BaseTest
         $this->assertTrue($stream->isWritable());
         $this->assertTrue($stream->isSeekable());
         $this->assertSame('php://temp', $stream->getMetadata('uri'));
-        $this->assertInternalType('array', $stream->getMetadata());
+        $this->assertInternalTypeGuzzle('array', $stream->getMetadata());
         $this->assertSame(4, $stream->getSize());
         $this->assertFalse($stream->eof());
         $stream->close();
@@ -159,7 +158,7 @@ class StreamTest extends BaseTest
         $handle = fopen('php://temp', 'r');
         $stream = new Stream($handle);
         $this->assertSame($handle, $stream->detach());
-        $this->assertInternalType('resource', $handle, 'Stream is not closed');
+        $this->assertInternalTypeGuzzle('resource', $handle, 'Stream is not closed');
         $this->assertNull($stream->detach());
 
         $this->assertStreamStateAfterClosedOrDetached($stream);
@@ -191,7 +190,7 @@ class StreamTest extends BaseTest
             try {
                 $fn();
             } catch (\Exception $e) {
-                $this->assertContains('Stream is detached', $e->getMessage());
+                $this->assertStringContainsStringGuzzle('Stream is detached', $e->getMessage());
 
                 return;
             }
@@ -218,14 +217,12 @@ class StreamTest extends BaseTest
         $stream->close();
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Length parameter cannot be negative
-     */
     public function testStreamReadingWithNegativeLength()
     {
         $r = fopen('php://temp', 'r');
         $stream = new Stream($r);
+
+        $this->expectExceptionGuzzle('RuntimeException', 'Length parameter cannot be negative');
 
         try {
             $stream->read(-1);
@@ -237,15 +234,13 @@ class StreamTest extends BaseTest
         $stream->close();
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Unable to read from stream
-     */
     public function testStreamReadingFreadError()
     {
         self::$isFReadError = true;
         $r = fopen('php://temp', 'r');
         $stream = new Stream($r);
+
+        $this->expectExceptionGuzzle('RuntimeException', 'Unable to read from stream');
 
         try {
             $stream->read(1);

--- a/tests/StreamWrapperTest.php
+++ b/tests/StreamWrapperTest.php
@@ -75,12 +75,9 @@ class StreamWrapperTest extends BaseTest
         ];
         $write = null;
         $except = null;
-        $this->assertInternalType('integer', stream_select($streams, $write, $except, 0));
+        $this->assertInternalTypeGuzzle('integer', stream_select($streams, $write, $except, 0));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testValidatesStream()
     {
         $stream = $this->getMockBuilder('Psr\Http\Message\StreamInterface')
@@ -92,14 +89,16 @@ class StreamWrapperTest extends BaseTest
         $stream->expects($this->once())
             ->method('isWritable')
             ->will($this->returnValue(false));
+
+        $this->expectExceptionGuzzle('InvalidArgumentException');
+
         StreamWrapper::getResource($stream);
     }
 
-    /**
-     * @expectedException \PHPUnit\Framework\Error\Warning
-     */
     public function testReturnsFalseWhenStreamDoesNotExist()
     {
+        $this->expectWarningGuzzle();
+
         fopen('guzzle://foo', 'r');
     }
 
@@ -115,7 +114,7 @@ class StreamWrapperTest extends BaseTest
             ->method('isWritable')
             ->will($this->returnValue(true));
         $r = StreamWrapper::getResource($stream);
-        $this->assertInternalType('resource', $r);
+        $this->assertInternalTypeGuzzle('resource', $r);
         fclose($r);
     }
 

--- a/tests/UploadedFileTest.php
+++ b/tests/UploadedFileTest.php
@@ -13,12 +13,18 @@ class UploadedFileTest extends BaseTest
 {
     private $cleanup;
 
-    protected function setUp()
+    /**
+     * @before
+     */
+    public function setUpTest()
     {
         $this->cleanup = [];
     }
 
-    protected function tearDown()
+    /**
+     * @after
+     */
+    public function tearDownTest()
     {
         foreach ($this->cleanup as $file) {
             if (is_scalar($file) && file_exists($file)) {
@@ -45,7 +51,7 @@ class UploadedFileTest extends BaseTest
      */
     public function testRaisesExceptionOnInvalidStreamOrFile($streamOrFile)
     {
-        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionGuzzle('InvalidArgumentException');
 
         new UploadedFile($streamOrFile, 0, UPLOAD_ERR_OK);
     }
@@ -65,7 +71,7 @@ class UploadedFileTest extends BaseTest
      */
     public function testRaisesExceptionOnInvalidSize($size)
     {
-        $this->expectException('InvalidArgumentException', 'size');
+        $this->expectExceptionGuzzle('InvalidArgumentException', 'size');
 
         new UploadedFile(fopen('php://temp', 'wb+'), $size, UPLOAD_ERR_OK);
     }
@@ -90,7 +96,7 @@ class UploadedFileTest extends BaseTest
      */
     public function testRaisesExceptionOnInvalidErrorStatus($status)
     {
-        $this->expectException('InvalidArgumentException', 'status');
+        $this->expectExceptionGuzzle('InvalidArgumentException', 'status');
 
         new UploadedFile(fopen('php://temp', 'wb+'), 0, $status);
     }
@@ -112,7 +118,7 @@ class UploadedFileTest extends BaseTest
      */
     public function testRaisesExceptionOnInvalidClientFilename($filename)
     {
-        $this->expectException('InvalidArgumentException', 'filename');
+        $this->expectExceptionGuzzle('InvalidArgumentException', 'filename');
 
         new UploadedFile(fopen('php://temp', 'wb+'), 0, UPLOAD_ERR_OK, $filename);
     }
@@ -122,7 +128,7 @@ class UploadedFileTest extends BaseTest
      */
     public function testRaisesExceptionOnInvalidClientMediaType($mediaType)
     {
-        $this->expectException('InvalidArgumentException', 'media type');
+        $this->expectExceptionGuzzle('InvalidArgumentException', 'media type');
 
         new UploadedFile(fopen('php://temp', 'wb+'), 0, UPLOAD_ERR_OK, 'foobar.baz', $mediaType);
     }
@@ -194,7 +200,7 @@ class UploadedFileTest extends BaseTest
 
         $this->cleanup[] = $path;
 
-        $this->expectException('InvalidArgumentException', 'path');
+        $this->expectExceptionGuzzle('InvalidArgumentException', 'path');
         $upload->moveTo($path);
     }
 
@@ -207,7 +213,7 @@ class UploadedFileTest extends BaseTest
         $upload->moveTo($to);
         $this->assertFileExists($to);
 
-        $this->expectException('RuntimeException', 'moved');
+        $this->expectExceptionGuzzle('RuntimeException', 'moved');
         $upload->moveTo($to);
     }
 
@@ -220,7 +226,7 @@ class UploadedFileTest extends BaseTest
         $upload->moveTo($to);
         $this->assertFileExists($to);
 
-        $this->expectException('RuntimeException', 'moved');
+        $this->expectExceptionGuzzle('RuntimeException', 'moved');
         $upload->getStream();
     }
 
@@ -252,7 +258,7 @@ class UploadedFileTest extends BaseTest
     public function testMoveToRaisesExceptionWhenErrorStatusPresent($status)
     {
         $uploadedFile = new UploadedFile('not ok', 0, $status);
-        $this->expectException('RuntimeException', 'upload error');
+        $this->expectExceptionGuzzle('RuntimeException', 'upload error');
         $uploadedFile->moveTo(__DIR__ . '/' . sha1(uniqid('', true)));
     }
 
@@ -262,7 +268,7 @@ class UploadedFileTest extends BaseTest
     public function testGetStreamRaisesExceptionWhenErrorStatusPresent($status)
     {
         $uploadedFile = new UploadedFile('not ok', 0, $status);
-        $this->expectException('RuntimeException', 'upload error');
+        $this->expectExceptionGuzzle('RuntimeException', 'upload error');
         $uploadedFile->getStream();
     }
 

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -96,12 +96,12 @@ class UriTest extends BaseTest
     }
 
     /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Unable to parse URI
      * @dataProvider getInvalidUris
      */
     public function testInvalidUrisThrowException($invalidUri)
     {
+        $this->expectExceptionGuzzle('InvalidArgumentException', 'Unable to parse URI');
+
         new Uri($invalidUri);
     }
 
@@ -116,70 +116,59 @@ class UriTest extends BaseTest
         ];
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Invalid port: 100000. Must be between 0 and 65535
-     */
     public function testPortMustBeValid()
     {
+        $this->expectExceptionGuzzle('InvalidArgumentException', 'Must be between 0 and 65535');
+
         (new Uri())->withPort(100000);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Invalid port: -1. Must be between 0 and 65535
-     */
     public function testWithPortCannotBeNegative()
     {
+        $this->expectExceptionGuzzle('InvalidArgumentException', 'Invalid port: -1. Must be between 0 and 65535');
+
         (new Uri())->withPort(-1);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Unable to parse URI
-     */
     public function testParseUriPortCannotBeZero()
     {
+        $this->expectExceptionGuzzle('InvalidArgumentException', 'Unable to parse URI');
+
         new Uri('//example.com:0');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testSchemeMustHaveCorrectType()
     {
+        $this->expectExceptionGuzzle('InvalidArgumentException');
+
         (new Uri())->withScheme([]);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testHostMustHaveCorrectType()
     {
+        $this->expectExceptionGuzzle('InvalidArgumentException');
+
         (new Uri())->withHost([]);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testPathMustHaveCorrectType()
     {
+        $this->expectExceptionGuzzle('InvalidArgumentException');
+
         (new Uri())->withPath([]);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testQueryMustHaveCorrectType()
     {
+        $this->expectExceptionGuzzle('InvalidArgumentException');
+
         (new Uri())->withQuery([]);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testFragmentMustHaveCorrectType()
     {
+        $this->expectExceptionGuzzle('InvalidArgumentException');
+
         (new Uri())->withFragment([]);
     }
 
@@ -611,12 +600,10 @@ class UriTest extends BaseTest
         $this->assertSame('//example.com/foo', (string) $uri);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The path of a URI without an authority must not start with two slashes "//"
-     */
     public function testPathStartingWithTwoSlashesAndNoAuthorityIsInvalid()
     {
+        $this->expectExceptionGuzzle('InvalidArgumentException', 'The path of a URI without an authority must not start with two slashes "//"');
+
         // URI "//foo" would be interpreted as network reference and thus change the original path to the host
         (new Uri)->withPath('//foo');
     }
@@ -628,16 +615,14 @@ class UriTest extends BaseTest
 
         $uri = $uri->withScheme('');
         $this->assertSame('//example.org//path-not-host.com', (string) $uri); // This is still valid
-        $this->expectException('\InvalidArgumentException');
+        $this->expectExceptionGuzzle('\InvalidArgumentException');
         $uri->withHost(''); // Now it becomes invalid
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage A relative URI must not have a path beginning with a segment containing a colon
-     */
     public function testRelativeUriWithPathBeginngWithColonSegmentIsInvalid()
     {
+        $this->expectExceptionGuzzle('InvalidArgumentException', 'A relative URI must not have a path beginning with a segment containing a colon');
+
         (new Uri)->withPath('mailto:foo');
     }
 
@@ -646,7 +631,7 @@ class UriTest extends BaseTest
         $uri = (new Uri('urn:/mailto:foo'))->withScheme('');
         $this->assertSame('/mailto:foo', $uri->getPath());
 
-        $this->expectException('\InvalidArgumentException');
+        $this->expectExceptionGuzzle('\InvalidArgumentException');
         (new Uri('urn:mailto:foo'))->withScheme('');
     }
 

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -157,13 +157,13 @@ class UtilsTest extends BaseTest
         $this->assertSame(md5('foobazbar'), Psr7\Utils::hash($s, 'md5'));
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testCalculatesHashThrowsWhenSeekFails()
     {
         $s = new NoSeekStream(Psr7\Utils::streamFor('foobazbar'));
         $s->read(2);
+
+        $this->expectExceptionGuzzle('RuntimeException');
+
         Psr7\Utils::hash($s, 'md5');
     }
 
@@ -178,16 +178,14 @@ class UtilsTest extends BaseTest
     public function testOpensFilesSuccessfully()
     {
         $r = Psr7\Utils::tryFopen(__FILE__, 'r');
-        $this->assertInternalType('resource', $r);
+        $this->assertInternalTypeGuzzle('resource', $r);
         fclose($r);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Unable to open /path/to/does/not/exist using mode r
-     */
     public function testThrowsExceptionNotWarning()
     {
+        $this->expectExceptionGuzzle('RuntimeException', 'Unable to open /path/to/does/not/exist using mode r');
+
         Psr7\Utils::tryFopen('/path/to/does/not/exist', 'r');
     }
 
@@ -200,11 +198,10 @@ class UtilsTest extends BaseTest
         );
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testValidatesUri()
     {
+        $this->expectExceptionGuzzle('InvalidArgumentException');
+
         Psr7\Utils::uriFor([]);
     }
 
@@ -259,11 +256,10 @@ class UtilsTest extends BaseTest
         $this->assertSame($s, Psr7\Utils::streamFor($s));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testThrowsExceptionForUnknown()
     {
+        $this->expectExceptionGuzzle('InvalidArgumentException');
+
         Psr7\Utils::streamFor(new \stdClass());
     }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,7 +1,0 @@
-<?php
-
-require_once __DIR__ . '/../vendor/autoload.php';
-
-if (!class_exists('PHPUnit\Framework\Error\Warning')) {
-    class_alias('PHPUnit_Framework_Error_Warning', 'PHPUnit\Framework\Error\Warning');
-}


### PR DESCRIPTION
We support PHP 5.4, so Symfony's bridge is not so easy. Never the less, there was already phpunit work around code I could just expand upon. After updating the tests to run on all versions of PHPUnit, they pass on PHP 8.0 with no src changes.