### PR TITLE
Fixed bad test

### DIFF
--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -130,7 +130,7 @@ class UriTest extends BaseTest
         (new Uri())->withPort(-1);
     }
 
-    public function testParseUriPortCannotBeZero()
+    public function testParseUriPortCannotBeNegative()
     {
         $this->expectExceptionGuzzle('InvalidArgumentException', 'Unable to parse URI');
 

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -134,7 +134,7 @@ class UriTest extends BaseTest
     {
         $this->expectExceptionGuzzle('InvalidArgumentException', 'Unable to parse URI');
 
-        new Uri('//example.com:0');
+        new Uri('//example.com:-1');
     }
 
     public function testSchemeMustHaveCorrectType()


### PR DESCRIPTION
PHP 7.3.24, 7.4.12 and 8.0.0RC1 or higher now allow zero as a port: https://github.com/php/php-src/commit/81b2f3e5d9fcdffd87a4fcd12bd8c708a97091e1.