### PR TITLE
Remove testParseUriPortCannotBeZero

### DIFF
--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -134,13 +134,6 @@ class UriTest extends TestCase
         (new Uri())->withPort(-1);
     }
 
-    public function testParseUriPortCannotBeZero(): void
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unable to parse URI');
-        new Uri('//example.com:0');
-    }
-
     public function testSchemeMustHaveCorrectType(): void
     {
         $this->expectException(\InvalidArgumentException::class);


### PR DESCRIPTION
Starting in PHP 7.3.24 and 7.4.12, parse_url() supports URL with zero as a port [[0]]. However, in these versions,
it does *not* return it. In the following minor releases, it will [[1]]. An insane version matrix would be required to keep this test, so just remove it.

Fixes #356

[0]: http://bugs.php.net/80114
[1]: http://bugs.php.net/80266