### PR TITLE
fix: seek stream cloned from php input to begining

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -32,4 +32,6 @@ jobs:
         run: php -S 127.0.0.1:10002 tests/Integration/server.php &
 
       - name: Run tests
+        env:
+          TEST_SERVER: 127.0.0.1:10002
         run: ./vendor/bin/phpunit --testsuite Integration

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,10 +16,6 @@
     </testsuite>
   </testsuites>
 
-  <php>
-    <server name="TEST_SERVER" value="http://127.0.0.1:10002" />
-  </php>
-
   <filter>
     <whitelist>
       <directory suffix=".php">src/</directory>

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -314,6 +314,7 @@ final class Utils
                 if (\stream_get_meta_data($resource)['uri'] === 'php://input') {
                     $stream = self::tryFopen('php://temp', 'w+');
                     fwrite($stream, stream_get_contents($resource));
+                    fseek($stream, 0);
                     $resource = $stream;
                 }
                 return new Stream($resource, $options);


### PR DESCRIPTION
Request created from globals always return empty string as a body.

to test it try create run the following code:

```
$request = \GuzzleHttp\Psr7\ServerRequest::fromGlobals();
var_dump($request->getBody()->getContents());
```

and do a POST request with non empty body.

Unfortunately I did not find the way to create a unit test for that case because of this condition:
```
\stream_get_meta_data($resource)['uri'] === 'php://input'
```

there is no way to create a mock of `$resource`