### PR TITLE
[Query::build()] Make sure booleans are treated as ints

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -91,6 +91,7 @@ final class Query
             $k = $encoder((string) $k);
             if (!is_array($v)) {
                 $qs .= $k;
+                $v = is_bool($v) ? (int) $v : $v;
                 if ($v !== null) {
                     $qs .= '=' . $encoder((string) $v);
                 }
@@ -98,6 +99,7 @@ final class Query
             } else {
                 foreach ($v as $vv) {
                     $qs .= $k;
+                    $vv = is_bool($vv) ? (int) $vv : $vv;
                     if ($vv !== null) {
                         $qs .= '=' . $encoder((string) $vv);
                     }

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -99,18 +99,18 @@ class QueryTest extends TestCase
         self::assertSame('foo bar', $result['var']);
     }
 
-    public function testBuildBooleans()
+    public function testBuildBooleans(): void
     {
         $data = [
             'true' => true,
             'false' => false
         ];
-        $this->assertEquals(http_build_query($data), Psr7\Query::build($data));
+        self::assertEquals(http_build_query($data), Psr7\Query::build($data));
 
         $data = [
             'foo' => [true, 'true'],
             'bar' => [false, 'false']
         ];
-        $this->assertEquals('foo=1&foo=true&bar=0&bar=false', Psr7\Query::build($data, PHP_QUERY_RFC1738));
+        self::assertEquals('foo=1&foo=true&bar=0&bar=false', Psr7\Query::build($data, PHP_QUERY_RFC1738));
     }
 }

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -98,4 +98,19 @@ class QueryTest extends TestCase
         $result = Psr7\Query::parse('var=foo+bar', PHP_QUERY_RFC1738);
         self::assertSame('foo bar', $result['var']);
     }
+
+    public function testBuildBooleans()
+    {
+        $data = [
+            'true' => true,
+            'false' => false
+        ];
+        $this->assertEquals(http_build_query($data), Psr7\Query::build($data));
+
+        $data = [
+            'foo' => [true, 'true'],
+            'bar' => [false, 'false']
+        ];
+        $this->assertEquals('foo=1&foo=true&bar=0&bar=false', Psr7\Query::build($data, PHP_QUERY_RFC1738));
+    }
 }


### PR DESCRIPTION
This will fix #264