### PR TITLE
Fix `Utils::modifyRequest` dropping `ServerRequest` attributes

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -203,7 +203,7 @@ final class Utils
         }
 
         if ($request instanceof ServerRequestInterface) {
-            return (new ServerRequest(
+            $new = (new ServerRequest(
                 isset($changes['method']) ? $changes['method'] : $request->getMethod(),
                 $uri,
                 $headers,
@@ -217,6 +217,12 @@ final class Utils
             ->withQueryParams($request->getQueryParams())
             ->withCookieParams($request->getCookieParams())
             ->withUploadedFiles($request->getUploadedFiles());
+        
+            foreach ($request->getAttributes() as $key => $value) {
+                $new = $new->withAttribute($key, $value);
+            }
+
+            return $new;
         }
 
         return new Request(

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -455,4 +455,15 @@ class UtilsTest extends BaseTest
 
         self::assertSame(['name' => 'value'], $modifiedRequest->getQueryParams());
     }
+
+    public function testModifyServerRequestRetainsAttributes()
+    {
+        $request = (new Psr7\ServerRequest('GET', 'http://example.com/bla'))
+            ->withAttribute('foo', 'bar');
+
+        /** @var Psr7\ServerRequest $modifiedRequest */
+        $modifiedRequest = Psr7\Utils::modifyRequest($request, []);
+
+        self::assertSame(['foo' => 'bar'], $modifiedRequest->getAttributes());
+    }
 }


### PR DESCRIPTION
Fixes #344.