### PR TITLE
Filter empty Content-Type and Content-Length in fromGlobals function.

### DIFF
--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -168,7 +168,7 @@ class ServerRequest extends Request implements ServerRequestInterface
         $method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
         $headers = getallheaders();
         $disallowEmpty = ['content-type', 'content-length'];
-        $headers = array_filter($headers, function($v, $k) use ($disallowEmpty) {
+        $headers = array_filter($headers, function ($v, $k) use ($disallowEmpty) {
             return !(in_array(strtolower($k), $disallowEmpty) && $v === '');
         }, ARRAY_FILTER_USE_BOTH);
 

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -167,6 +167,11 @@ class ServerRequest extends Request implements ServerRequestInterface
     {
         $method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
         $headers = getallheaders();
+        $disallowEmpty = ['content-type', 'content-length'];
+        $headers = array_filter($headers, function($v, $k) use ($disallowEmpty) {
+            return !(in_array(strtolower($k), $disallowEmpty) && $v === '');
+        }, ARRAY_FILTER_USE_BOTH);
+
         $uri = self::getUriFromGlobals();
         $body = new CachingStream(new LazyOpenStream('php://input', 'r+'));
         $protocol = isset($_SERVER['SERVER_PROTOCOL']) ? str_replace('HTTP/', '', $_SERVER['SERVER_PROTOCOL']) : '1.1';

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -441,6 +441,11 @@ class ServerRequestTest extends TestCase
         ];
 
         self::assertEquals($expectedFiles, $server->getUploadedFiles());
+
+        $_SERVER['CONTENT_TYPE'] = '';
+        $server = ServerRequest::fromGlobals();
+        $headers = $server->getHeaders();
+        self::assertArrayNotHasKey('Content-Type', $headers);
     }
 
     public function testUploadedFiles(): void


### PR DESCRIPTION
As mentioned in issue #363. @GrahamCampbell 

Perhaps an oldschool `isset` is faster than an array filter, but should matter much in the context of a full request. Added a test for good measure.

