### PR TITLE
Make caseless remove robust

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -25,7 +25,7 @@ final class Utils
         }
 
         foreach ($data as $k => $v) {
-            if (!in_array(strtolower($k), $keys)) {
+            if (!is_string($k) || !in_array(strtolower($k), $keys)) {
                 $result[$k] = $v;
             }
         }

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -470,4 +470,38 @@ class UtilsTest extends TestCase
 
         self::assertSame(['foo' => 'bar'], $modifiedRequest->getAttributes());
     }
+
+    /**
+     * @return list<array{0: string[], 1: array, 2: array}>
+     */
+    public function providesCaselessRemoveCases(): array
+    {
+        return [
+            [
+                ['foo-bar'],
+                ['Foo-Bar' => 'hello'],
+                []
+            ],
+            [
+                ['foo-bar'],
+                ['hello'],
+                ['hello']
+            ],
+            [
+                ['foo-Bar'],
+                ['Foo-Bar' => 'hello', 123 => '', 'Foo-BAR' => 'hello123', 'foobar' => 'baz'],
+                [123 => '', 'foobar' => 'baz'],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providesCaselessRemoveCases
+     *
+     * @param string[] $keys
+     */
+    public function testCaselessRemove(array $keys, array $data, array $expected): void
+    {
+        self::assertSame($expected, Psr7\Utils::caselessRemove($keys, $data));
+    }
 }


### PR DESCRIPTION
Related to https://github.com/guzzle/psr7/issues/429. Allows for validation to happen downstream instead of crashing on an internal error. Also, the type information on this function technically says any kind of array key is allowed, sooo. ;)

As to why fix this only on 2.x? On 1.x, it was actually doing casting for us, so the behaviour there was to remove keys with integer value 1 if the string key was '1'. This PR instead skips over integer keys, which I think is the better behaviour, but also technically a breaking change. Since this is not working at all in 2.0.0, we're good to make that change in 2.1.0. :trollface: