### PR TITLE
style : remove the backslash

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -151,7 +151,7 @@ class Request implements RequestInterface
     private function assertMethod($method): void
     {
         if (!is_string($method) || $method === '') {
-            throw new \InvalidArgumentException('Method must be a non-empty string.');
+            throw new InvalidArgumentException('Method must be a non-empty string.');
         }
     }
 }


### PR DESCRIPTION
 * I just removed the backslash on the InvalidArgumentException class because it is  already imported by the use keyword at the beginning.