### PR TITLE
Add `@return` to define the return type for non-PHP 7.2 compatible types

### DIFF
--- a/src/AppendStream.php
+++ b/src/AppendStream.php
@@ -237,6 +237,11 @@ final class AppendStream implements StreamInterface
         throw new \RuntimeException('Cannot write to an AppendStream');
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @return mixed
+     */
     public function getMetadata($key = null)
     {
         return $key ? null : [];

--- a/src/BufferStream.php
+++ b/src/BufferStream.php
@@ -133,6 +133,11 @@ final class BufferStream implements StreamInterface
         return strlen($string);
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @return mixed
+     */
     public function getMetadata($key = null)
     {
         if ($key === 'hwm') {

--- a/src/FnStream.php
+++ b/src/FnStream.php
@@ -167,6 +167,11 @@ final class FnStream implements StreamInterface
         return call_user_func($this->_fn_getContents);
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @return mixed
+     */
     public function getMetadata($key = null)
     {
         return call_user_func($this->_fn_getMetadata, $key);

--- a/src/PumpStream.php
+++ b/src/PumpStream.php
@@ -148,6 +148,11 @@ final class PumpStream implements StreamInterface
         return $result;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @return mixed
+     */
     public function getMetadata($key = null)
     {
         if (!$key) {

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -285,6 +285,11 @@ class ServerRequest extends Request implements ServerRequestInterface
         return $new;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @return array|object|null
+     */
     public function getParsedBody()
     {
         return $this->parsedBody;
@@ -303,6 +308,11 @@ class ServerRequest extends Request implements ServerRequestInterface
         return $this->attributes;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @return mixed
+     */
     public function getAttribute($attribute, $default = null)
     {
         if (false === array_key_exists($attribute, $this->attributes)) {

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -257,6 +257,11 @@ class Stream implements StreamInterface
         return $result;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @return mixed
+     */
     public function getMetadata($key = null)
     {
         if (!isset($this->stream)) {

--- a/src/StreamDecoratorTrait.php
+++ b/src/StreamDecoratorTrait.php
@@ -78,6 +78,11 @@ trait StreamDecoratorTrait
         $this->stream->close();
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @return mixed
+     */
     public function getMetadata($key = null)
     {
         return $this->stream->getMetadata($key);


### PR DESCRIPTION
This documents the return type for methods implementing PSR-7 interfaces, but where the return type is not compatible with PHP 7.2.

Besides making the return type more descriptive when reading the method definition, this also suppresses type deprecation notices when using guzzle/psr7 with Symfony 5.4+.