### PR TITLE
Added mimetype for woff2

### DIFF
--- a/src/MimeType.php
+++ b/src/MimeType.php
@@ -98,6 +98,7 @@ final class MimeType
       'wma' => 'audio/x-ms-wma',
       'wmv' => 'video/x-ms-wmv',
       'woff' => 'application/x-font-woff',
+      'woff2' => 'font/woff2',
       'wsdl' => 'application/wsdl+xml',
       'xbm' => 'image/x-xbitmap',
       'xls' => 'application/vnd.ms-excel',


### PR DESCRIPTION
I'm missing the "woff2" mimetype in the mapping.

Nginx added it as `font/woff2` some time ago: https://trac.nginx.org/nginx/ticket/1575