### PR TITLE
Can create `MultipartStream` with none `uri` metadata field

### DIFF
--- a/src/MultipartStream.php
+++ b/src/MultipartStream.php
@@ -89,7 +89,7 @@ final class MultipartStream implements StreamInterface
 
         if (empty($element['filename'])) {
             $uri = $element['contents']->getMetadata('uri');
-            if (substr($uri, 0, 6) !== 'php://') {
+            if ($uri && \is_string($uri) && \substr($uri, 0, 6) !== 'php://') {
                 $element['filename'] = $uri;
             }
         }

--- a/tests/MultipartStreamTest.php
+++ b/tests/MultipartStreamTest.php
@@ -243,4 +243,26 @@ EOT;
 
         self::assertSame($expected, str_replace("\r", '', (string) $b));
     }
+
+    public function testCanCreateWithNoneMetadataStreamField(): void
+    {
+        $str = 'dummy text';
+        $a = Psr7\Utils::streamFor(static function() use ($str): string { return $str; });
+        $b = new Psr7\LimitStream($a, \strlen($str));
+        $c = new MultipartStream([
+            [
+                'name'     => 'foo',
+                'contents' => $b,
+            ],
+        ], 'boundary');
+
+        self::assertSame(\implode("\r\n", [
+            '--boundary',
+            'Content-Disposition: form-data; name="foo"',
+            '',
+            $str,
+            '--boundary--',
+            '',
+        ]), (string)$c);
+    }
 }


### PR DESCRIPTION
fix #445 