### PR TITLE
Fix missing null in `Query::parse()` with multiple values

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -43,7 +43,7 @@ final class Query
             $parts = explode('=', $kvp, 2);
             $key = $decoder($parts[0]);
             $value = isset($parts[1]) ? $decoder($parts[1]) : null;
-            if (!isset($result[$key])) {
+            if (!array_key_exists($key, $result)) {
                 $result[$key] = $value;
             } else {
                 if (!is_array($result[$key])) {

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -45,6 +45,8 @@ class QueryTest extends TestCase
             // Ensure it doesn't leave things behind with repeated values
             // Can parse mult-values items
             ['q=a&q=b&q=c', ['q' => ['a', 'b', 'c']]],
+            // Keeps first null when parsing mult-values
+            ['q&q=&q=a', ['q' => [null, '', 'a']]],
         ];
     }
 


### PR DESCRIPTION
With a query like `q&q=a`, the first value (`null`) got lost due to an `isset()` call.