### PR TITLE
Fixed reading in the entire request into RAM

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -161,11 +161,6 @@ parameters:
 			path: src/Utils.php
 
 		-
-			message: "#^Parameter \\#2 \\$str of function fwrite expects string, string\\|false given\\.$#"
-			count: 1
-			path: src/Utils.php
-
-		-
 			message: "#^Variable \\$handle might not be defined\\.$#"
 			count: 1
 			path: src/Utils.php

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -304,7 +304,7 @@ final class Utils
                 /** @var resource $resource */
                 if ((\stream_get_meta_data($resource)['uri'] ?? '') === 'php://input') {
                     $stream = self::tryFopen('php://temp', 'w+');
-                    fwrite($stream, stream_get_contents($resource));
+                    stream_copy_to_stream($resource, $stream);
                     fseek($stream, 0);
                     $resource = $stream;
                 }


### PR DESCRIPTION
There is a special case for `php://input` as it behaves differently than other streams apparently. As a result, that stream is put into a `php://temp` stream. However, the original implementation reads in the entire request into RAM, essentially removing streaming functionality. That results into out of memory errors, if the request is large enough.

refs #354,  [#2276@guzzle](https://github.com/guzzle/guzzle/issues/2276)