### PR TITLE
Fixed typo in php docBlock

### DIFF
--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -80,7 +80,7 @@ class ServerRequest extends Request implements ServerRequestInterface
     /**
      * Return an UploadedFile instance array.
      *
-     * @param array $files A array which respect $_FILES structure
+     * @param array $files An array which respect $_FILES structure
      *
      * @throws InvalidArgumentException for unrecognized values
      */


### PR DESCRIPTION
Fix a small typo I've noticed in the PHP doc.

`a array` => `an array`

Hope It still helps 🙂
