### PR TITLE
Added missing return type

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -525,7 +525,7 @@ class Uri implements UriInterface, \JsonSerializable
         return $new;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): string
     {
         return $this->__toString();
     }


### PR DESCRIPTION
This is not a breaking change - this is new code, not yet released. This is a bug fix, however. PHP 8.1 insists on there being a return type on this method.

---

Closes https://github.com/guzzle/psr7/issues/466.