### PR TITLE
add UploadedFile::getFile()

### DIFF
--- a/src/UploadedFile.php
+++ b/src/UploadedFile.php
@@ -189,6 +189,11 @@ class UploadedFile implements UploadedFileInterface
         }
     }
 
+    public function getFile(): ?string
+    {
+        return $this->file;
+    }
+
     public function getSize(): ?int
     {
         return $this->size;


### PR DESCRIPTION
the main reason for adding the getter is to be able to get the file path from `UploadedFile` objects
currently, only the stream can be fetched
the file is needed, in case a developer wants to use a function like [getimagesize()](https://www.php.net/manual/en/function.getimagesize.php)
- [x] add `UploadedFile::getFile()`