### PR TITLE
Add invalid status code to exception.

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -154,7 +154,7 @@ class Response implements ResponseInterface
     private function assertStatusCodeRange(int $statusCode): void
     {
         if ($statusCode < 100 || $statusCode >= 600) {
-            throw new \InvalidArgumentException('Status code must be an integer value between 1xx and 5xx.');
+            throw new \InvalidArgumentException('Status code must be an integer value between 1xx and 5xx.', $statusCode);
         }
     }
 }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -355,6 +355,7 @@ class ResponseTest extends TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Status code must be an integer value between 1xx and 5xx.');
+        $this->expectExceptionCode($invalidValues);
         new Response($invalidValues);
     }
 
@@ -368,6 +369,7 @@ class ResponseTest extends TestCase
         $response = new Response();
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Status code must be an integer value between 1xx and 5xx.');
+        $this->expectExceptionCode($invalidValues);
         $response->withStatus($invalidValues);
     }
 


### PR DESCRIPTION
We use guzzle as a client for a system that returns invalid status codes. In order to handle those status codes, it would be helpful to pass this on with the exception that is thrown. 