### PR TITLE
Add Header::splitList()

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -77,7 +77,7 @@ parameters:
 
 		-
 			message: "#^Argument of an invalid type array\\<int, string\\>\\|false supplied for foreach, only iterables are supported\\.$#"
-			count: 2
+			count: 1
 			path: src/Header.php
 
 		-

--- a/src/Header.php
+++ b/src/Header.php
@@ -51,20 +51,8 @@ final class Header
     {
         $result = [];
         foreach ((array) $header as $value) {
-            foreach ((array) $value as $v) {
-                if (strpos($v, ',') === false) {
-                    $trimmed = trim($v);
-                    if ($trimmed !== '') {
-                        $result[] = $trimmed;
-                    }
-                    continue;
-                }
-                foreach (preg_split('/,(?=([^"]*"([^"]|\\\\.)*")*[^"]*$)/', $v) as $vv) {
-                    $trimmed = trim($vv);
-                    if ($trimmed !== '') {
-                        $result[] = $trimmed;
-                    }
-                }
+            foreach (self::splitList($value) as $parsed) {
+                $result[] = $parsed;
             }
         }
 

--- a/src/Header.php
+++ b/src/Header.php
@@ -44,6 +44,8 @@ final class Header
      * headers into an array of headers with no comma separated values.
      *
      * @param string|array $header Header to normalize.
+     *
+     * @deprecated Use self::splitList() instead.
      */
     public static function normalize($header): array
     {

--- a/src/Header.php
+++ b/src/Header.php
@@ -19,20 +19,22 @@ final class Header
         static $trimmed = "\"'  \n\t\r";
         $params = $matches = [];
 
-        foreach (self::normalize($header) as $val) {
-            $part = [];
-            foreach (preg_split('/;(?=([^"]*"[^"]*")*[^"]*$)/', $val) as $kvp) {
-                if (preg_match_all('/<[^>]+>|[^=]+/', $kvp, $matches)) {
-                    $m = $matches[0];
-                    if (isset($m[1])) {
-                        $part[trim($m[0], $trimmed)] = trim($m[1], $trimmed);
-                    } else {
-                        $part[] = trim($m[0], $trimmed);
+        foreach ((array) $header as $value) {
+            foreach (self::splitList($value) as $val) {
+                $part = [];
+                foreach (preg_split('/;(?=([^"]*"[^"]*")*[^"]*$)/', $val) as $kvp) {
+                    if (preg_match_all('/<[^>]+>|[^=]+/', $kvp, $matches)) {
+                        $m = $matches[0];
+                        if (isset($m[1])) {
+                            $part[trim($m[0], $trimmed)] = trim($m[1], $trimmed);
+                        } else {
+                            $part[] = trim($m[0], $trimmed);
+                        }
                     }
                 }
-            }
-            if ($part) {
-                $params[] = $part;
+                if ($part) {
+                    $params[] = $part;
+                }
             }
         }
 

--- a/tests/HeaderTest.php
+++ b/tests/HeaderTest.php
@@ -150,13 +150,8 @@ class HeaderTest extends TestCase
         self::assertSame($result, Psr7\Header::normalize($header));
     }
 
-    public function splitListProvider(): array
-    {
-        return $this->normalizeProvider();
-    }
-
     /**
-     * @dataProvider splitListProvider
+     * @dataProvider normalizeProvider
      */
     public function testSplitList($header, $result): void
     {

--- a/tests/HeaderTest.php
+++ b/tests/HeaderTest.php
@@ -149,4 +149,38 @@ class HeaderTest extends TestCase
         self::assertSame($result, Psr7\Header::normalize([$header]));
         self::assertSame($result, Psr7\Header::normalize($header));
     }
+
+    public function splitListProvider(): array
+    {
+        return $this->normalizeProvider();
+    }
+
+    /**
+     * @dataProvider splitListProvider
+     */
+    public function testSplitList($header, $result): void
+    {
+        self::assertSame($result, Psr7\Header::splitList($header));
+    }
+
+    public function testSplitListRejectsNestedArrays(): void
+    {
+        $this->expectException(\TypeError::class);
+
+        Psr7\Header::splitList([['foo']]);
+    }
+
+    public function testSplitListArrayContainingNonStrings(): void
+    {
+        $this->expectException(\TypeError::class);
+
+        Psr7\Header::splitList(['foo', 'bar', 1, false]);
+    }
+
+    public function testSplitListRejectsNonStrings(): void
+    {
+        $this->expectException(\TypeError::class);
+
+        Psr7\Header::splitList(false);
+    }
 }


### PR DESCRIPTION
Header::splitList() is a replacement for the existing normalize() method with a
cleaned up API, proper explanation and a more specific method name instead of
the vague `normalize()` that could refer to anything.

The primary difference in the API is that normalize() accepts `string[][]`,
whereas `splitList()` is expected to take a `string[]`: The return value of a
call to `MessageInterface::getHeader()`. Alternatively a `string` may be
passed, corresponding to the return value of
`MessageInterface::getHeaderLine()`.

Further `splitList()` will properly verify the types and throw a `TypeError` if
the input is not well-defined. This allows for a clean migration to a
`string|array` parameter type if the minimum version of guzzle/psr7 is
increased to PHP 8.