### PR TITLE
Declare StreamDecoratorTrait::$stream property

### DIFF
--- a/src/StreamDecoratorTrait.php
+++ b/src/StreamDecoratorTrait.php
@@ -13,6 +13,9 @@ use Psr\Http\Message\StreamInterface;
  */
 trait StreamDecoratorTrait
 {
+    /** @var StreamInterface */
+    protected $stream;
+
     /**
      * @param StreamInterface $stream Stream to decorate
      */

--- a/src/StreamDecoratorTrait.php
+++ b/src/StreamDecoratorTrait.php
@@ -14,7 +14,7 @@ use Psr\Http\Message\StreamInterface;
 trait StreamDecoratorTrait
 {
     /** @var StreamInterface */
-    protected $stream;
+    public $stream;
 
     /**
      * @param StreamInterface $stream Stream to decorate

--- a/src/StreamDecoratorTrait.php
+++ b/src/StreamDecoratorTrait.php
@@ -14,7 +14,7 @@ use Psr\Http\Message\StreamInterface;
 trait StreamDecoratorTrait
 {
     /** @var StreamInterface */
-    public $stream;
+    protected $stream;
 
     /**
      * @param StreamInterface $stream Stream to decorate


### PR DESCRIPTION
On PHP 8.2, usage of dynamic properties is deprecated (see https://wiki.php.net/rfc/deprecate_dynamic_properties).

I propose to declare this property.

An alternative solution could be to use `#[AllowDynamicProperties]` attribute.