### PR TITLE
Add support SOH symbol to assert of MessageTrait

### DIFF
--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -151,7 +151,12 @@ trait MessageTrait
                 $header = (string) $header;
             }
             $this->assertHeader($header);
-            $value = $this->normalizeHeaderValue($value);
+
+            try {
+                $value = $this->normalizeHeaderValue($value);
+            } catch (\InvalidArgumentException $e) {
+                continue;
+            }
             $normalized = strtolower($header);
             if (isset($this->headerNames[$normalized])) {
                 $header = $this->headerNames[$normalized];
@@ -259,7 +264,7 @@ trait MessageTrait
         // Clients must not send a request with line folding and a server sending folded headers is
         // likely very rare. Line folding is a fairly obscure feature of HTTP/1.1 and thus not accepting
         // folding is not likely to break any legitimate use case.
-        if (! preg_match('/^[\x01\x20\x09\x21-\x7E\x80-\xFF]*$/', $value)) {
+        if (! preg_match('/^[\x20\x09\x21-\x7E\x80-\xFF]*$/', $value)) {
             throw new \InvalidArgumentException(sprintf('"%s" is not valid header value', $value));
         }
     }

--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -259,7 +259,7 @@ trait MessageTrait
         // Clients must not send a request with line folding and a server sending folded headers is
         // likely very rare. Line folding is a fairly obscure feature of HTTP/1.1 and thus not accepting
         // folding is not likely to break any legitimate use case.
-        if (! preg_match('/^[\x20\x09\x21-\x7E\x80-\xFF]*$/', $value)) {
+        if (! preg_match('/^[\x01\x20\x09\x21-\x7E\x80-\xFF]*$/', $value)) {
             throw new \InvalidArgumentException(sprintf('"%s" is not valid header value', $value));
         }
     }

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -189,13 +189,12 @@ class RequestTest extends TestCase
 
     public function testHeaderValueStartOfHeading(): void
     {
-        $r = new Request('GET', 'https://example.com/', [
-            'GA' => '/___utmvaPNBuPVKNZ=YUnaMdB; path=/; Max-Age=900'
-        ]);
-        self::assertSame([
-            'Host' => ['example.com'],
-            'GA' => ['/___utmvaPNBuPVKNZ=YUnaMdB; path=/; Max-Age=900']
-        ], $r->getHeaders());
+        self::assertSame(
+            ['Host' => ['example.com']],
+            (new Request('GET', 'https://example.com/', [
+                'GA' => "YUn\x01aMdB; path=/; Max-Age=900"
+            ]))->getHeaders()
+        );
     }
 
     public function testCanGetHeaderAsCsv(): void
@@ -218,7 +217,7 @@ class RequestTest extends TestCase
                 $header
             )
         );
-        $r = new Request(
+        new Request(
             'GET',
             'http://foo.com/baz?bar=bam',
             [
@@ -321,15 +320,15 @@ class RequestTest extends TestCase
      */
     public function testContainsNotAllowedCharsOnHeaderValue(string $value): void
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(sprintf('"%s" is not valid header value', $value));
-
-        $r = new Request(
-            'GET',
-            'http://foo.com/baz?bar=bam',
-            [
-                'testing' => $value
-            ]
+        self::assertEquals(
+            ['Host' => ['foo.com']],
+            (new Request(
+                'GET',
+                'http://foo.com/baz?bar=bam',
+                [
+                    'testing' => $value
+                ]
+            ))->getHeaders()
         );
     }
 
@@ -346,9 +345,6 @@ class RequestTest extends TestCase
         ];
 
         for ($i = 0; $i <= 0xff; $i++) {
-            if ($i == 0x01) {
-                continue;
-            }
             if (\chr($i) == "\t") {
                 continue;
             }

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -187,6 +187,17 @@ class RequestTest extends TestCase
         ], $r->getHeaders());
     }
 
+    public function testHeaderValueStartOfHeading(): void
+    {
+        $r = new Request('GET', 'https://example.com/', [
+            'GA' => '/___utmvaPNBuPVKNZ=YUnaMdB; path=/; Max-Age=900'
+        ]);
+        self::assertSame([
+            'Host' => ['example.com'],
+            'GA' => ['/___utmvaPNBuPVKNZ=YUnaMdB; path=/; Max-Age=900']
+        ], $r->getHeaders());
+    }
+
     public function testCanGetHeaderAsCsv(): void
     {
         $r = new Request('GET', 'http://foo.com/baz?bar=bam', [
@@ -335,6 +346,9 @@ class RequestTest extends TestCase
         ];
 
         for ($i = 0; $i <= 0xff; $i++) {
+            if ($i == 0x01) {
+                continue;
+            }
             if (\chr($i) == "\t") {
                 continue;
             }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -257,18 +257,25 @@ class ResponseTest extends TestCase
      */
     public function testConstructResponseInvalidHeader($header, $headerValue, $expectedMessage): void
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage($expectedMessage);
-        new Response(200, [$header => $headerValue]);
+        self::assertEmpty(
+            (new Response(200, [$header => $headerValue]))->getHeaders()
+        );
     }
 
     public function invalidHeaderProvider(): iterable
     {
         return [
             ['foo', [], 'Header value can not be an empty array.'],
-            ['', '', '"" is not valid header name'],
             ['foo', new \stdClass(),  'Header value must be scalar or null but stdClass provided.'],
         ];
+    }
+
+    public function testConstructResponseEmptyHeaderName(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('"" is not valid header name');
+
+        new Response(200, ['' => '']);
     }
 
     /**


### PR DESCRIPTION
I noticed quite common behaviour as described in commentary  https://github.com/guzzle/psr7/issues/489#issuecomment-1080758509

But I noticed that in my googleAnalytics cookie exists SOH symbol which is not allowed with current regular expression 