### PR TITLE
Fix Message::parseRequestUri() for numeric headers

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -175,6 +175,11 @@ final class Message
     public static function parseRequestUri(string $path, array $headers): string
     {
         $hostKey = array_filter(array_keys($headers), function ($k) {
+            if (is_int($k)) {
+                // Numeric array keys are converted to int by PHP but having a header name '123' is not forbidden by the spec.
+                $k = (string) $k;
+            }
+
             return strtolower($k) === 'host';
         });
 

--- a/src/Message.php
+++ b/src/Message.php
@@ -175,10 +175,8 @@ final class Message
     public static function parseRequestUri(string $path, array $headers): string
     {
         $hostKey = array_filter(array_keys($headers), function ($k) {
-            if (is_int($k)) {
-                // Numeric array keys are converted to int by PHP but having a header name '123' is not forbidden by the spec.
-                $k = (string) $k;
-            }
+            // Numeric array keys are converted to int by PHP.
+            $k = (string) $k;
 
             return strtolower($k) === 'host';
         });

--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -145,11 +145,9 @@ trait MessageTrait
     {
         $this->headerNames = $this->headers = [];
         foreach ($headers as $header => $value) {
-            if (is_int($header)) {
-                // Numeric array keys are converted to int by PHP but having a header name '123' is not forbidden by the spec
-                // and also allowed in withHeader(). So we need to cast it to string again for the following assertion to pass.
-                $header = (string) $header;
-            }
+            // Numeric array keys are converted to int by PHP.
+            $header = (string) $header;
+
             $this->assertHeader($header);
             $value = $this->normalizeHeaderValue($value);
             $normalized = strtolower($header);

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -126,6 +126,21 @@ class MessageTest extends TestCase
         self::assertSame('GET_DATA', $request->getMethod());
     }
 
+    public function testParsesRequestMessagesWithNumericHeader(): void
+    {
+        $req = "GET /abc HTTP/1.0\r\nHost: foo.com\r\nFoo: Bar\r\nBaz: Bam\r\nBaz: Qux\r\n123: 456\r\n\r\nTest";
+        $request = Psr7\Message::parseRequest($req);
+        self::assertSame('GET', $request->getMethod());
+        self::assertSame('/abc', $request->getRequestTarget());
+        self::assertSame('1.0', $request->getProtocolVersion());
+        self::assertSame('foo.com', $request->getHeaderLine('Host'));
+        self::assertSame('Bar', $request->getHeaderLine('Foo'));
+        self::assertSame('Bam, Qux', $request->getHeaderLine('Baz'));
+        self::assertSame('456', $request->getHeaderLine('123'));
+        self::assertSame('Test', (string)$request->getBody());
+        self::assertSame('http://foo.com/abc', (string)$request->getUri());
+    }
+
     public function testParsesRequestMessagesWithFoldedHeadersOnHttp10(): void
     {
         $req = "PUT / HTTP/1.0\r\nFoo: Bar\r\n Bam\r\n\r\n";


### PR DESCRIPTION
Fixes guzzle/psr7#497