### PR TITLE
Throw an exception when the multipart option is misformatted

### DIFF
--- a/src/MultipartStream.php
+++ b/src/MultipartStream.php
@@ -68,6 +68,9 @@ final class MultipartStream implements StreamInterface
         $stream = new AppendStream();
 
         foreach ($elements as $element) {
+            if (!is_array($element)) {
+                throw new \UnexpectedValueException("An array is expected");
+            }
             $this->addElement($stream, $element);
         }
 


### PR DESCRIPTION
I spend a lot of time searching for an error that was only a misformatted data in the multipart request option, and the server just die without give any information about of error. I think that an exception would be useful for other people that is as absent-minded as me.

Example of my mistake: 

```php
$options['multipart'] = [
    'name' => 'arquivo',
    'contents' => $logo
];
$client->request('POST', $url, $options);
```
