### PR TITLE
Support PHP 8.2

### DIFF
--- a/src/FnStream.php
+++ b/src/FnStream.php
@@ -23,12 +23,16 @@ final class FnStream implements StreamInterface
     /** @var array<string, callable> */
     private $methods;
 
+    /** @var array<string, callable> */
+    private $fnMethods;
+
     /**
      * @param array<string, callable> $methods Hash of method name to a callable.
      */
     public function __construct(array $methods)
     {
         $this->methods = $methods;
+        $this->fnMethods = [];
 
         // Create the functions on the class
         foreach ($methods as $name => $fn) {
@@ -37,14 +41,33 @@ final class FnStream implements StreamInterface
     }
 
     /**
-     * Lazily determine which methods are not implemented.
+     * Get FnMethods
      *
      * @throws \BadMethodCallException
      */
-    public function __get(string $name): void
+    public function __get(string $name): mixed
     {
+        if (isset($this->fnMethods[$name])) {
+            return $this->fnMethods[$name];
+        }
         throw new \BadMethodCallException(str_replace('_fn_', '', $name)
             . '() is not implemented in the FnStream');
+    }
+
+    /**
+     * Set FnMethods
+     */
+    public function __set(string $name, mixed $value): void
+    {
+        $this->fnMethods[$name] = $value;
+    }
+
+    /**
+     * Isset FnMethods
+     */
+    public function __isset(string $name): bool
+    {
+        return isset($this->fnMethods[$name]);
     }
 
     /**

--- a/src/FnStream.php
+++ b/src/FnStream.php
@@ -45,7 +45,7 @@ final class FnStream implements StreamInterface
      *
      * @throws \BadMethodCallException
      */
-    public function __get(string $name): mixed
+    public function __get(string $name)
     {
         if (isset($this->fnMethods[$name])) {
             return $this->fnMethods[$name];
@@ -57,7 +57,7 @@ final class FnStream implements StreamInterface
     /**
      * Set FnMethods
      */
-    public function __set(string $name, mixed $value): void
+    public function __set(string $name, $value): void
     {
         $this->fnMethods[$name] = $value;
     }

--- a/src/FnStream.php
+++ b/src/FnStream.php
@@ -45,7 +45,7 @@ final class FnStream implements StreamInterface
      *
      * @throws \BadMethodCallException
      */
-    public function __get(string $name)
+    public function __get(string $name): callable
     {
         if (isset($this->fnMethods[$name])) {
             return $this->fnMethods[$name];
@@ -56,6 +56,8 @@ final class FnStream implements StreamInterface
 
     /**
      * Set FnMethods
+     *
+     * @param callable $value fn method
      */
     public function __set(string $name, $value): void
     {

--- a/src/StreamDecoratorTrait.php
+++ b/src/StreamDecoratorTrait.php
@@ -14,7 +14,7 @@ use Psr\Http\Message\StreamInterface;
 trait StreamDecoratorTrait
 {
     /** @var array<string, StreamInterface> */
-    private $streams; 
+    private $streams;
 
     /**
      * @param StreamInterface $stream Stream to decorate
@@ -46,10 +46,10 @@ trait StreamDecoratorTrait
 
     /**
      * Magic method used to set new streams
-     * 
-     * @return void
+     *
+     * @param StreamInterface $value Stream to decorate
      */
-    public function __set(string $name, $value)
+    public function __set(string $name, $value): void
     {
         $this->streams[$name] = $value;
     }

--- a/src/StreamDecoratorTrait.php
+++ b/src/StreamDecoratorTrait.php
@@ -49,7 +49,7 @@ trait StreamDecoratorTrait
      * 
      * @return void
      */
-    public function __set(string $name, mixed $value)
+    public function __set(string $name, $value)
     {
         $this->streams[$name] = $value;
     }

--- a/src/StreamDecoratorTrait.php
+++ b/src/StreamDecoratorTrait.php
@@ -13,28 +13,45 @@ use Psr\Http\Message\StreamInterface;
  */
 trait StreamDecoratorTrait
 {
+    /** @var array<string, StreamInterface> */
+    private $streams; 
+
     /**
      * @param StreamInterface $stream Stream to decorate
      */
     public function __construct(StreamInterface $stream)
     {
+        $this->streams = [];
         $this->stream = $stream;
     }
 
     /**
-     * Magic method used to create a new stream if streams are not added in
+     * Magic method used to return streams and create a new stream if streams are not added in
      * the constructor of a decorator (e.g., LazyOpenStream).
      *
      * @return StreamInterface
      */
     public function __get(string $name)
     {
+        if (isset($this->streams[$name])) {
+            return $this->streams[$name];
+        }
         if ($name === 'stream') {
-            $this->stream = $this->createStream();
-            return $this->stream;
+            $this->streams[$name] = $this->createStream();
+            return $this->streams[$name];
         }
 
         throw new \UnexpectedValueException("$name not found on class");
+    }
+
+    /**
+     * Magic method used to set new streams
+     * 
+     * @return void
+     */
+    public function __set(string $name, mixed $value)
+    {
+        $this->streams[$name] = $value;
     }
 
     public function __toString(): string


### PR DESCRIPTION
As stated in #482, as of PHP 8.2, dynamic use of properties has been deprecated.

https://wiki.php.net/rfc/deprecate_dynamic_properties

I solved it using `__get`, `__set` and `__isset` magic methods.