### PR TITLE
Fix deprecation warnings in PHP 8.2

### DIFF
--- a/src/CachingStream.php
+++ b/src/CachingStream.php
@@ -21,6 +21,11 @@ final class CachingStream implements StreamInterface
     private $skipReadBytes = 0;
 
     /**
+     * @var StreamInterface
+     */
+    private $stream;
+
+    /**
      * We will treat the buffer object as the body of the stream
      *
      * @param StreamInterface $stream Stream to cache. The cursor is assumed to be at the beginning of the stream.

--- a/src/DroppingStream.php
+++ b/src/DroppingStream.php
@@ -17,6 +17,9 @@ final class DroppingStream implements StreamInterface
     /** @var int */
     private $maxLength;
 
+    /** @var StreamInterface */
+    private $stream;
+
     /**
      * @param StreamInterface $stream    Underlying stream to decorate.
      * @param int             $maxLength Maximum size before dropping data.

--- a/src/FnStream.php
+++ b/src/FnStream.php
@@ -12,6 +12,7 @@ use Psr\Http\Message\StreamInterface;
  * Allows for easy testing and extension of a provided stream without needing
  * to create a concrete class for a simple extension point.
  */
+#[\AllowDynamicProperties]
 final class FnStream implements StreamInterface
 {
     private const SLOTS = [

--- a/src/InflateStream.php
+++ b/src/InflateStream.php
@@ -21,6 +21,9 @@ final class InflateStream implements StreamInterface
 {
     use StreamDecoratorTrait;
 
+    /** @var StreamInterface */
+    private $stream;
+
     public function __construct(StreamInterface $stream)
     {
         $resource = StreamWrapper::getResource($stream);

--- a/src/LazyOpenStream.php
+++ b/src/LazyOpenStream.php
@@ -10,6 +10,7 @@ use Psr\Http\Message\StreamInterface;
  * Lazily reads or writes to a file that is opened only after an IO operation
  * take place on the stream.
  */
+#[\AllowDynamicProperties]
 final class LazyOpenStream implements StreamInterface
 {
     use StreamDecoratorTrait;

--- a/src/LimitStream.php
+++ b/src/LimitStream.php
@@ -19,6 +19,9 @@ final class LimitStream implements StreamInterface
     /** @var int Limit the number of bytes that can be read */
     private $limit;
 
+    /** @var StreamInterface */
+    private $stream;
+
     /**
      * @param StreamInterface $stream Stream to wrap
      * @param int             $limit  Total number of bytes to allow to be read

--- a/src/MultipartStream.php
+++ b/src/MultipartStream.php
@@ -17,6 +17,9 @@ final class MultipartStream implements StreamInterface
     /** @var string */
     private $boundary;
 
+    /** @var StreamInterface */
+    private $stream;
+
     /**
      * @param array  $elements Array of associative arrays, each containing a
      *                         required "name" key mapping to the form field,

--- a/src/NoSeekStream.php
+++ b/src/NoSeekStream.php
@@ -13,6 +13,9 @@ final class NoSeekStream implements StreamInterface
 {
     use StreamDecoratorTrait;
 
+    /** @var StreamInterface */
+    private $stream;
+
     public function seek($offset, $whence = SEEK_SET): void
     {
         throw new \RuntimeException('Cannot seek a NoSeekStream');

--- a/tests/StreamDecoratorTraitTest.php
+++ b/tests/StreamDecoratorTraitTest.php
@@ -9,9 +9,12 @@ use GuzzleHttp\Psr7\StreamDecoratorTrait;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\StreamInterface;
 
-class Str implements StreamInterface
+final class Str implements StreamInterface
 {
     use StreamDecoratorTrait;
+
+    /** @var StreamInterface */
+    private $stream;
 }
 
 /**

--- a/tests/StreamDecoratorTraitTest.php
+++ b/tests/StreamDecoratorTraitTest.php
@@ -9,7 +9,7 @@ use GuzzleHttp\Psr7\StreamDecoratorTrait;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\StreamInterface;
 
-final class Str implements StreamInterface
+class Str implements StreamInterface
 {
     use StreamDecoratorTrait;
 


### PR DESCRIPTION
Declare explicit properties where possible:

Any class that is final and sets the `$stream` property in the constructor can
have the property defined, because it is impossible for there to be child
classes that rely on an overriden constructor that leverages the lazy
initialization of the stream.

I opted to make this property private which is a small BC break, because
implicitly created properties are effectively public.

For `LazyOpenStream` and `FnStream` I've opted to use the
`\AllowDynamicProperties` attribute to minimize the amount of changed required.
This should be cleaned up in the next major.

Resolves guzzle/psr7#482
Closes guzzle/psr7#518
see guzzle/psr7#516