### PR TITLE
Replace Header::normalize() by Header::splitList() in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,18 @@ $knownEtags = Header::splitList($request->getHeader('if-none-match'));
 
 Example headers include `accept`, `cache-control` and `if-none-match`.
 
+
+## `GuzzleHttp\Psr7\Header::normalize` (deprecated)
+
+`public static function normalize(string|array $header): array`
+
+`Header::normalize()` is deprecated in favor of [`Header::splitList()`](README.md#guzzlehttppsr7headersplitlist)
+which performs the same operation with a cleaned up API and improved
+documentation.
+
+Converts an array of header values that may contain comma separated
+headers into an array of headers with no comma separated values.
+
 ## `GuzzleHttp\Psr7\Query::parse`
 
 `public static function parse(string $str, int|bool $urlEncoding = true): array`

--- a/README.md
+++ b/README.md
@@ -405,6 +405,7 @@ documentation.
 Converts an array of header values that may contain comma separated
 headers into an array of headers with no comma separated values.
 
+
 ## `GuzzleHttp\Psr7\Query::parse`
 
 `public static function parse(string $str, int|bool $urlEncoding = true): array`

--- a/README.md
+++ b/README.md
@@ -380,13 +380,18 @@ of the header. When a parameter does not contain a value, but just
 contains a key, this function will inject a key with a '' string value.
 
 
-## `GuzzleHttp\Psr7\Header::normalize`
+## `GuzzleHttp\Psr7\Header::splitList`
 
-`public static function normalize(string|array $header): array`
+`public static function splitList(string|string[] $header): string[]`
 
-Converts an array of header values that may contain comma separated
-headers into an array of headers with no comma separated values.
+Splits a HTTP header defined to contain a comma-separated list into
+each individual value:
 
+```
+$knownEtags = Header::splitList($request->getHeader('if-none-match'));
+```
+
+Example headers include `accept`, `cache-control` and `if-none-match`.
 
 ## `GuzzleHttp\Psr7\Query::parse`
 

--- a/src/Header.php
+++ b/src/Header.php
@@ -62,7 +62,7 @@ final class Header
     }
 
     /**
-     * Splits a HTTP header defined to contain comma-separated list into
+     * Splits a HTTP header defined to contain a comma-separated list into
      * each individual value. Empty values will be removed.
      *
      * Example headers include 'accept', 'cache-control' and 'if-none-match'.


### PR DESCRIPTION
`splitList()` is a replacement for `normalize()`. It was forgotten to adjust
the README.md in guzzle/psr7#477.