### PR TITLE
Stop mimicking PHP 8.1 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,10 +48,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Mimic PHP 8.1
-        run: composer config platform.php 8.1.999
-        if: matrix.php > 8.1
-
       - name: Install dependencies
         run: composer update --no-interaction --no-progress
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -27,10 +27,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Mimic PHP 8.1
-        run: composer config platform.php 8.1.999
-        if: matrix.php > 8.1
-
       - name: Install dependencies
         run: composer update --no-interaction --no-progress
 


### PR DESCRIPTION
This is no longer required since PHPUnit 9.5.23.