### PR TITLE
Fix namespace in changelog entry for 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,7 +103,7 @@ Identical to the RC release.
 ### Removed
 
 - PHP < 7.2 support
-- All functions in the Guzzle\Psr7 namespace
+- All functions in the `GuzzleHttp\Psr7` namespace
 
 ## 1.8.1 - 2021-03-21
 


### PR DESCRIPTION
Quite late, I know, but I just upgraded Guzzle 1 -> 2 in an app and noticed errors about undefined functions. When going through the changelogs at the same time I thought "they must be still there, since only `Guzzle\Psr7` functions were removed" 😅

I thought then that it might make sense to still adapt this in case other people check old breaking changes (in the current branch's CHANGELOG at least) and make a similar mistake.