### PR TITLE
Replace `sha1(uniqid())` by `bin2hex(random_bytes(20))`

### DIFF
--- a/src/MultipartStream.php
+++ b/src/MultipartStream.php
@@ -34,7 +34,7 @@ final class MultipartStream implements StreamInterface
      */
     public function __construct(array $elements = [], string $boundary = null)
     {
-        $this->boundary = $boundary ?: sha1(uniqid('', true));
+        $this->boundary = $boundary ?: bin2hex(random_bytes(20));
         $this->stream = $this->createStream($elements);
     }
 

--- a/tests/UploadedFileTest.php
+++ b/tests/UploadedFileTest.php
@@ -181,7 +181,7 @@ class UploadedFileTest extends TestCase
         $uploadedFile = new UploadedFile('not ok', 0, $status);
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('upload error');
-        $uploadedFile->moveTo(__DIR__ . '/' . sha1(uniqid('', true)));
+        $uploadedFile->moveTo(__DIR__ . '/' . bin2hex(random_bytes(20)));
     }
 
     /**


### PR DESCRIPTION
The output size and format is identical, but `random_bytes()` provides much better randomness than `uniqid()` even with the $more_entropy parameter which adds only 32 Bits of entropy on top of the current (micro)time which is more or less known externally.

For MultipartStream that might result in a guessable boundary, which might allow an attacker to modify the semantics of an outgoing request with a well-crafted file.