### PR TITLE
Fixed readme `EofCallbackStream` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,8 @@ class EofCallbackStream implements StreamInterface
 
     private $callback;
 
+    private $stream;
+
     public function __construct(StreamInterface $stream, callable $cb)
     {
         $this->stream = $stream;


### PR DESCRIPTION
On PHP 8.2, if you don't explicitly declare the property, you will get an error like `Deprecated: Creation of dynamic property EofCallbackStream::$stream is deprecated`

From what I can tell, other usages in this code base (e.g. https://github.com/guzzle/psr7/blob/b4719a1/src/DroppingStream.php#L15-L21) explicitly add a `$stream` property when they're using `StreamDecoratorTrait`.