### PR TITLE
Improve migration from v1 to v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,7 +115,7 @@ Identical to the RC release.
 ### Removed
 
 - PHP < 7.2 support
-- All functions in the `GuzzleHttp\Psr7` namespace
+- All functions in the `GuzzleHttp\Psr7` namespace. Use `GuzzleHttp\Psr7\Utils`' methods instead.
 
 ## 1.8.1 - 2021-03-21
 


### PR DESCRIPTION
Direct suggestion for using `GuzzleHttp\Psr7\Utils` in the changelog is better than looking at [deprecations](https://github.com/guzzle/psr7/blob/1.9.0/src/functions.php#L80). When you have older version installed, you probably see deprecations in your code, but when you upgrade to newer version and your code fails, you just get e.g. `Error: Call to undefined function GuzzleHttp\Psr7\stream_for()`.