### PR TITLE
Require `psr/http-message: ^1.1`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
     "require": {
         "php": "^7.2.5 || ^8.0",
         "psr/http-factory": "^1.0",
-        "psr/http-message": "^1.0",
+        "psr/http-message": "^1.1",
         "ralouphie/getallheaders": "^3.0"
     },
     "provide": {


### PR DESCRIPTION
This adds parameter types to the interfaces, allowing guzzle/psr7 to also add parameter types in a follow-up PR.