### PR TITLE
Fix `Message::bodySummary` when `preg_match` fails

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -77,11 +77,11 @@ final class Message
 
         // Matches any printable character, including unicode characters:
         // letters, marks, numbers, punctuation, spacing, and separators.
-        if (preg_match('/[^\pL\pM\pN\pP\pS\pZ\n\r\t]/u', $summary)) {
-            return null;
+        if (preg_match('/[^\pL\pM\pN\pP\pS\pZ\n\r\t]/u', $summary) === 0) {
+            return $summary;
         }
 
-        return $summary;
+        return null;
     }
 
     /**

--- a/src/Message.php
+++ b/src/Message.php
@@ -77,11 +77,11 @@ final class Message
 
         // Matches any printable character, including unicode characters:
         // letters, marks, numbers, punctuation, spacing, and separators.
-        if (preg_match('/[^\pL\pM\pN\pP\pS\pZ\n\r\t]/u', $summary) === 0) {
-            return $summary;
+        if (preg_match('/[^\pL\pM\pN\pP\pS\pZ\n\r\t]/u', $summary) !== 0) {
+            return null;
         }
 
-        return null;
+        return $summary;
     }
 
     /**


### PR DESCRIPTION
preg_replace returns "false" on failure which interpreted as OK result which is wrong.
Reform statement in positive manner makes it right
