### PR TITLE
Allow `psr/http-message: ^2.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
     "require": {
         "php": "^7.2.5 || ^8.0",
         "psr/http-factory": "^1.0",
-        "psr/http-message": "^1.1",
+        "psr/http-message": "^1.1 || ^2.0",
         "ralouphie/getallheaders": "^3.0"
     },
     "provide": {


### PR DESCRIPTION
We already have return types everywhere, thus we are compatible with 2.0.