### PR TITLE
Add test for malformed bodySummary

### DIFF
--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -271,6 +271,13 @@ class MessageTest extends TestCase
         self::assertSame('’é€௵ဪ‱', Psr7\Message::bodySummary($message));
     }
 
+    public function testMessageBodySummaryWithSpecialUTF8CharactersAndLargeBody(): void
+    {
+        $message = new Psr7\Response(200, [], '🤦🏾‍♀️');
+        // The first Unicode codepoint of the body has four bytes.
+        self::assertNull(Psr7\Message::bodySummary($message, 3));
+    }
+
     public function testMessageBodySummaryWithEmptyBody(): void
     {
         $message = new Psr7\Response(200, [], '');


### PR DESCRIPTION
The documentation comment states: “Will return null if the response is not printable.” but until recently, this was not actually true – the function would gladly return a string truncated in the middle of an Unicode codepoint. 3f849aa7a8063828d8f68e652758f68683bf14a2 fixed that.

Let’s add a corresponding test.
