### PR TITLE
Take care of files without extension

### DIFF
--- a/src/MimeType.php
+++ b/src/MimeType.php
@@ -1213,6 +1213,7 @@ final class MimeType
         'zirz' => 'application/vnd.zul',
         'zmm' => 'application/vnd.handheld-entertainment+xml',
         'zsh' => 'text/x-scriptzsh',
+        '' => 'application/octet-stream',
     ];
 
     /**


### PR DESCRIPTION
If not set as a default it could crash in an internal server error