### PR TITLE
Fallback to `application/octet-stream` if we are unable to guess the content type for a multipart file upload

### DIFF
--- a/src/MultipartStream.php
+++ b/src/MultipartStream.php
@@ -137,9 +137,7 @@ final class MultipartStream implements StreamInterface
         // Set a default Content-Type if one was not supplied
         $type = $this->getHeader($headers, 'content-type');
         if (!$type && ($filename === '0' || $filename)) {
-            if ($type = MimeType::fromFilename($filename)) {
-                $headers['Content-Type'] = $type;
-            }
+            $headers['Content-Type'] = MimeType::fromFilename($filename) ?? 'application/octet-stream';
         }
 
         return [$stream, $headers];

--- a/tests/MultipartStreamTest.php
+++ b/tests/MultipartStreamTest.php
@@ -143,7 +143,7 @@ class MultipartStreamTest extends TestCase
 
         $f3 = Psr7\FnStream::decorate(Psr7\Utils::streamFor('bar'), [
             'getMetadata' => static function (): string {
-                return '/foo/bar.gif';
+                return '/foo/bar.unknown';
             },
         ]);
 
@@ -176,9 +176,9 @@ class MultipartStreamTest extends TestCase
             "\r\n",
             "baz\r\n",
             "--boundary\r\n",
-            "Content-Disposition: form-data; name=\"qux\"; filename=\"bar.gif\"\r\n",
+            "Content-Disposition: form-data; name=\"qux\"; filename=\"bar.unknown\"\r\n",
             "Content-Length: 3\r\n",
-            "Content-Type: image/gif\r\n",
+            "Content-Type: application/octet-stream\r\n",
             "\r\n",
             "bar\r\n",
             "--boundary--\r\n",


### PR DESCRIPTION
Needs tests. Closes #567. Probably should be considered a feature and target 2.6.