### PR TITLE
Corrected mime type for `.acc` files to `audio/aac`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Corrected mime type for `.acc` files to `audio/aac`
+
 ## 2.5.0 - 2023-04-17
 
 ### Changed

--- a/src/MimeType.php
+++ b/src/MimeType.php
@@ -18,7 +18,7 @@ final class MimeType
         '7zip' => 'application/x-7z-compressed',
         '123' => 'application/vnd.lotus-1-2-3',
         'aab' => 'application/x-authorware-bin',
-        'aac' => 'audio/x-acc',
+        'aac' => 'audio/aac',
         'aam' => 'application/x-authorware-map',
         'aas' => 'application/x-authorware-seg',
         'abw' => 'application/x-abiword',


### PR DESCRIPTION
Closes #571.