### PR TITLE
[2.6] Make `StreamWrapper::stream_stat()` returns `false` if inner stream's size is `null`

### DIFF
--- a/src/StreamWrapper.php
+++ b/src/StreamWrapper.php
@@ -136,10 +136,14 @@ final class StreamWrapper
      *   ctime: int,
      *   blksize: int,
      *   blocks: int
-     * }
+     * }|false
      */
-    public function stream_stat(): array
+    public function stream_stat()
     {
+        if ($this->stream->getSize() === null) {
+            return false;
+        }
+
         static $modeMap = [
             'r' => 33060,
             'rb' => 33060,

--- a/tests/StreamWrapperTest.php
+++ b/tests/StreamWrapperTest.php
@@ -6,6 +6,7 @@ namespace GuzzleHttp\Tests\Psr7;
 
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\StreamWrapper;
+use GuzzleHttp\Psr7\Utils;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\StreamInterface;
 
@@ -186,5 +187,16 @@ class StreamWrapperTest extends TestCase
 
         $stream->rewind();
         self::assertXmlStringEqualsXmlString('<?xml version="1.0"?><foo />', (string) $stream);
+    }
+
+    public function testWrappedNullSizedStreamStaysNullSized(): void
+    {
+        $nullSizedStream = new Psr7\PumpStream(function () { return ''; });
+        $this->assertNull($nullSizedStream->getSize());
+
+        $resource = StreamWrapper::getResource($nullSizedStream);
+        $stream = Utils::streamFor($resource);
+
+        $this->assertNull($stream->getSize());
     }
 }


### PR DESCRIPTION
Fixes #593