### PR TITLE
add option ipv4 support

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -113,7 +113,21 @@ class Uri implements UriInterface, \JsonSerializable
             $url = $matches[2];
         }
 
-        /** @var string */
+        // If option IPv4
+        if (preg_match("%^(.*://)\[((?:[0-9a-fA-F]{1,4}:){4}):((?:\d{1,3}\.){3}\d{1,3})](.*?)$%", $url, $matches)) {
+            /** @var array{0:string, 1:string, 2:string, 3:string, 4:string} $matches */
+            $ipv4_address = $matches[3];
+            $ipParts      = explode('.', $ipv4_address);
+            if (count($ipParts) === 4) {
+                $part7 = base_convert((string)(($ipParts[0] * 256) + $ipParts[1]), 10, 16);
+                $part8 = base_convert((string)(($ipParts[2] * 256) + $ipParts[3]), 10, 16);
+
+                $prefix = $matches[1] . '[' . $matches[2] . ':' . $part7 . ':' . $part8 . ']';
+                $url    = $matches[4];
+            }
+        }
+
+        /** @var string $encodedUrl */
         $encodedUrl = preg_replace_callback(
             '%[^:/@?&=#]+%usD',
             static function ($matches) {

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -117,13 +117,13 @@ class Uri implements UriInterface, \JsonSerializable
         if (preg_match("%^(.*://)\[((?:[0-9a-fA-F]{1,4}:){4}):((?:\d{1,3}\.){3}\d{1,3})](.*?)$%", $url, $matches)) {
             /** @var array{0:string, 1:string, 2:string, 3:string, 4:string} $matches */
             $ipv4_address = $matches[3];
-            $ipParts      = explode('.', $ipv4_address);
+            $ipParts = explode('.', $ipv4_address);
             if (count($ipParts) === 4) {
-                $part7 = base_convert((string)(((int)$ipParts[0] * 256) + (int)$ipParts[1]), 10, 16);
-                $part8 = base_convert((string)(((int)$ipParts[2] * 256) + (int)$ipParts[3]), 10, 16);
+                $part7 = base_convert((string) (((int) $ipParts[0] * 256) + (int) $ipParts[1]), 10, 16);
+                $part8 = base_convert((string) (((int) $ipParts[2] * 256) + (int) $ipParts[3]), 10, 16);
 
-                $prefix = $matches[1] . '[' . $matches[2] . ':' . $part7 . ':' . $part8 . ']';
-                $url    = $matches[4];
+                $prefix = $matches[1].'['.$matches[2].':'.$part7.':'.$part8.']';
+                $url = $matches[4];
             }
         }
 

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -119,8 +119,8 @@ class Uri implements UriInterface, \JsonSerializable
             $ipv4_address = $matches[3];
             $ipParts      = explode('.', $ipv4_address);
             if (count($ipParts) === 4) {
-                $part7 = base_convert((string)(($ipParts[0] * 256) + $ipParts[1]), 10, 16);
-                $part8 = base_convert((string)(($ipParts[2] * 256) + $ipParts[3]), 10, 16);
+                $part7 = base_convert((string)(((int)$ipParts[0] * 256) + (int)$ipParts[1]), 10, 16);
+                $part8 = base_convert((string)(((int)$ipParts[2] * 256) + (int)$ipParts[3]), 10, 16);
 
                 $prefix = $matches[1] . '[' . $matches[2] . ':' . $part7 . ':' . $part8 . ']';
                 $url    = $matches[4];


### PR DESCRIPTION
this may fix

- [#33](https://github.com/huankong233/94list-laravel/issues/33)
- [#3191](https://github.com/guzzle/guzzle/issues/3191)

I convert the ipv4 part into hex and follow the rule set the `prefix` and `url` variable