### PR TITLE
[2.7] Add support for keeping boolean values "as is" in query

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -63,12 +63,14 @@ final class Query
      * string. This function does not modify the provided keys when an array is
      * encountered (like `http_build_query()` would).
      *
-     * @param array     $params   Query string parameters.
-     * @param int|false $encoding Set to false to not encode, PHP_QUERY_RFC3986
-     *                            to encode using RFC3986, or PHP_QUERY_RFC1738
-     *                            to encode using RFC1738.
+     * @param array     $params              Query string parameters.
+     * @param int|false $encoding            Set to false to not encode, PHP_QUERY_RFC3986
+     *                                       to encode using RFC3986, or PHP_QUERY_RFC1738
+     *                                       to encode using RFC1738.
+     * @param bool      $treatBooleansAsInts When `true` values are cast to int (e.g. ['foo' => false] gives `foo=0`).
+     *                                       When `false` values are cast to strings (e.g. ['foo' => false] gives `foo=false`).
      */
-    public static function build(array $params, $encoding = PHP_QUERY_RFC3986): string
+    public static function build(array $params, $encoding = PHP_QUERY_RFC3986, bool $treatBooleansAsInts = true): string
     {
         if (!$params) {
             return '';
@@ -86,12 +88,16 @@ final class Query
             throw new \InvalidArgumentException('Invalid type');
         }
 
+        $castBool = $treatBooleansAsInts
+            ? function ($v) { return (int) $v; }
+        : function ($v) { return $v ? 'true' : 'false'; };
+
         $qs = '';
         foreach ($params as $k => $v) {
             $k = $encoder((string) $k);
             if (!is_array($v)) {
                 $qs .= $k;
-                $v = is_bool($v) ? (int) $v : $v;
+                $v = is_bool($v) ? $castBool($v) : $v;
                 if ($v !== null) {
                     $qs .= '='.$encoder((string) $v);
                 }
@@ -99,7 +105,7 @@ final class Query
             } else {
                 foreach ($v as $vv) {
                     $qs .= $k;
-                    $vv = is_bool($vv) ? (int) $vv : $vv;
+                    $vv = is_bool($vv) ? $castBool($vv) : $vv;
                     if ($vv !== null) {
                         $qs .= '='.$encoder((string) $vv);
                     }

--- a/src/Query.php
+++ b/src/Query.php
@@ -88,9 +88,7 @@ final class Query
             throw new \InvalidArgumentException('Invalid type');
         }
 
-        $castBool = $treatBooleansAsInts
-            ? static function ($v) { return (int) $v; }
-            : static function ($v) { return $v ? 'true' : 'false'; };
+        $castBool = $treatBooleansAsInts ? static function ($v) { return (int) $v; } : static function ($v) { return $v ? 'true' : 'false'; };
 
         $qs = '';
         foreach ($params as $k => $v) {

--- a/src/Query.php
+++ b/src/Query.php
@@ -89,8 +89,8 @@ final class Query
         }
 
         $castBool = $treatBooleansAsInts
-            ? function ($v) { return (int) $v; }
-        : function ($v) { return $v ? 'true' : 'false'; };
+            ? static function ($v) { return (int) $v; }
+            : static function ($v) { return $v ? 'true' : 'false'; };
 
         $qs = '';
         foreach ($params as $k => $v) {

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -7,10 +7,6 @@ namespace GuzzleHttp\Tests\Psr7;
 use GuzzleHttp\Psr7;
 use PHPUnit\Framework\TestCase;
 
-use function http_build_query;
-
-use const PHP_QUERY_RFC3986;
-
 class QueryTest extends TestCase
 {
     public function parseQueryProvider()

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -7,6 +7,10 @@ namespace GuzzleHttp\Tests\Psr7;
 use GuzzleHttp\Psr7;
 use PHPUnit\Framework\TestCase;
 
+use function http_build_query;
+
+use const PHP_QUERY_RFC3986;
+
 class QueryTest extends TestCase
 {
     public function parseQueryProvider()
@@ -114,5 +118,11 @@ class QueryTest extends TestCase
             'bar' => [false, 'false'],
         ];
         self::assertEquals('foo=1&foo=true&bar=0&bar=false', Psr7\Query::build($data, PHP_QUERY_RFC1738));
+
+        $data = [
+            'foo' => true,
+            'bar' => false,
+        ];
+        self::assertEquals('foo=true&bar=false', Psr7\Query::build($data, PHP_QUERY_RFC3986, false));
     }
 }


### PR DESCRIPTION
I've stumbled upon this for like milion times now.

This is a follow up of https://github.com/guzzle/psr7/pull/391

Currently, there's no way not to cast boolean values to int in a query. `http_build_query()` casts booleans to ints, however, that is not always the wanted behaviour when constructing a query to call some API.

E.g. [Swagger](https://editor.swagger.io/) sends `=true` `=false` for params of type `boolean`. There are APIs that require this value format (e.g. https://github.com/PowerDNS/pdns).

This has been discussed many times over and over and the conclusion I make of it is that the behaviour should be configurable since it depends on the target API (e.g. see https://github.com/OpenAPITools/openapi-generator/issues/2204).

Therefore, I propose a flag that allows switch the behaviour in `Query::build()`. It should be BC compatible with the default value.