### PR TITLE
[2.9] Accept a nested array in multipart option field value

### DIFF
--- a/src/MultipartStream.php
+++ b/src/MultipartStream.php
@@ -91,6 +91,23 @@ final class MultipartStream implements StreamInterface
             }
         }
 
+        if (is_array($element['contents'])) {
+            $prepare = function ($contents, $key, $root = null) use ($stream, &$values, &$prepare) {
+                $fieldName = $root ? sprintf('%s[%s]', $root, $key) : $key;
+
+                if (is_array($contents)) {
+                    array_walk($contents, $prepare, $fieldName);
+                    return;
+                }
+
+                $this->addElement($stream, ['name' => $fieldName, 'contents' => Utils::streamFor($contents)]);
+            };
+
+            array_walk($element['contents'], $prepare, $element['name']);
+
+            return;
+        }
+
         $element['contents'] = Utils::streamFor($element['contents']);
 
         if (empty($element['filename'])) {

--- a/src/MultipartStream.php
+++ b/src/MultipartStream.php
@@ -92,7 +92,7 @@ final class MultipartStream implements StreamInterface
         }
 
         if (is_array($element['contents'])) {
-            $prepare = function ($contents, $key, $root = null) use ($stream, &$values, &$prepare) {
+            $prepare = function ($contents, $key, $root = null) use ($stream, &$prepare) {
                 $fieldName = $root ? sprintf('%s[%s]', $root, $key) : $key;
 
                 if (is_array($contents)) {

--- a/src/MultipartStream.php
+++ b/src/MultipartStream.php
@@ -92,11 +92,12 @@ final class MultipartStream implements StreamInterface
         }
 
         if (is_array($element['contents'])) {
-            $prepare = function ($contents, $key, $root = null) use ($stream, &$prepare) {
+            $prepare = function ($contents, $key, $root = null) use ($stream, &$prepare): void {
                 $fieldName = $root ? sprintf('%s[%s]', $root, $key) : $key;
 
                 if (is_array($contents)) {
                     array_walk($contents, $prepare, $fieldName);
+
                     return;
                 }
 

--- a/tests/MultipartStreamTest.php
+++ b/tests/MultipartStreamTest.php
@@ -134,9 +134,9 @@ class MultipartStreamTest extends TestCase
                 'name' => 'foo',
                 'contents' => [
                     ['key' => 'bar'],
-                    ['key' => 'baz']
-                ]
-            ]
+                    ['key' => 'baz'],
+                ],
+            ],
         ], 'boundary');
 
         $expected = \implode('', [

--- a/tests/MultipartStreamTest.php
+++ b/tests/MultipartStreamTest.php
@@ -127,6 +127,35 @@ class MultipartStreamTest extends TestCase
         self::assertSame($expected, (string) $b);
     }
 
+    public function testExpandNestedArrayFields(): void
+    {
+        $b = new MultipartStream([
+            [
+                'name' => 'foo',
+                'contents' => [
+                    ['key' => 'bar'],
+                    ['key' => 'baz']
+                ]
+            ]
+        ], 'boundary');
+
+        $expected = \implode('', [
+            "--boundary\r\n",
+            "Content-Disposition: form-data; name=\"foo[0][key]\"\r\n",
+            "Content-Length: 3\r\n",
+            "\r\n",
+            "bar\r\n",
+            "--boundary\r\n",
+            "Content-Disposition: form-data; name=\"foo[1][key]\"\r\n",
+            "Content-Length: 3\r\n",
+            "\r\n",
+            "baz\r\n",
+            "--boundary--\r\n",
+        ]);
+
+        self::assertSame($expected, (string) $b);
+    }
+
     public function testSerializesFiles(): void
     {
         $f1 = Psr7\FnStream::decorate(Psr7\Utils::streamFor('foo'), [


### PR DESCRIPTION
This PR expands a `MultipartStream` element with a nested array `contents` into multiple separated and well-formed elements.

Basically, this:
```php
[
  'name' => 'foo',
  'contents' => [
    ['key' => 'bar'],
    ['key' => 'baz']
  ]
]
```
results into this:
```
--boundary
Content-Disposition: form-data; name=foo[0][key]
Content-Length: 3

bar
--boundary
Content-Disposition: form-data; name=foo[1][key]
Content-Length: 3

baz
--boundary--
```

This is an attempt to ease the DX for Guzzle, see https://github.com/guzzle/guzzle/issues/3260