### PR TITLE
Support uppercase IPv6 addresses in URI

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -107,7 +107,7 @@ class Uri implements UriInterface, \JsonSerializable
     {
         // If IPv6
         $prefix = '';
-        if (preg_match('%^(.*://\[[0-9:a-f]+\])(.*?)$%', $url, $matches)) {
+        if (preg_match('%^(.*://\[[0-9:a-fA-F]+\])(.*?)$%', $url, $matches)) {
             /** @var array{0:string, 1:string, 2:string} $matches */
             $prefix = $matches[1];
             $url = $matches[2];


### PR DESCRIPTION
RFC8187 implies that the HEXDIG values that compose an IP-Literal substring (IPv6 is a special case of IP-Literal) can contain both lowercase and uppercase characters for the non-numeric part. As a consequence, all characters in [0-9a-fA-f] are valid in an IPv6 literal address as found in the URI.

References:
* https://datatracker.ietf.org/doc/html/rfc5234
* https://datatracker.ietf.org/doc/html/rfc8187