### PR TITLE
[2.8] Allow empty lists as header values

### DIFF
--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -174,10 +174,6 @@ trait MessageTrait
             return $this->trimAndValidateHeaderValues([$value]);
         }
 
-        if (count($value) === 0) {
-            throw new \InvalidArgumentException('Header value can not be an empty array.');
-        }
-
         return $this->trimAndValidateHeaderValues($value);
     }
 

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -188,6 +188,14 @@ class RequestTest extends TestCase
         ], $r->getHeaders());
     }
 
+    public function testEmptyListHeaderValue(): void
+    {
+        $r = new Request('GET', 'https://example.com/', ['Foo' => []]);
+        self::assertSame('', $r->getHeaderLine('Foo'));
+        self::assertSame([], $r->getHeader('Foo'));
+        self::assertSame(['Host' => ['example.com'], 'Foo' => []], $r->getHeaders());
+    }
+
     public function testCanGetHeaderAsCsv(): void
     {
         $r = new Request('GET', 'http://foo.com/baz?bar=bam', [

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -253,6 +253,14 @@ class ResponseTest extends TestCase
         self::assertSame('bar', $r->getHeaderLine('123'));
     }
 
+    public function testConstructResponseEmptyListHeaderValue(): void
+    {
+        $r = new Response(200, ['Foo' => []]);
+        self::assertSame('', $r->getHeaderLine('Foo'));
+        self::assertSame([], $r->getHeader('Foo'));
+        self::assertSame(['Foo' => []], $r->getHeaders());
+    }
+
     /**
      * @dataProvider invalidHeaderProvider
      */
@@ -266,7 +274,6 @@ class ResponseTest extends TestCase
     public function invalidHeaderProvider(): iterable
     {
         return [
-            ['foo', [], 'Header value can not be an empty array.'],
             ['', '', '"" is not valid header name'],
             ['foo', new \stdClass(),  'Header value must be scalar or null but stdClass provided.'],
         ];


### PR DESCRIPTION
Closes #626 

**Description:**

RFC 9110 (and its predecessors) do not forbid empty header field lists. While senders are explicitly prohibited from including empty list elements (e.g., consecutive commas), an entire list may be empty — as long as the field's grammar permits it (i.e., it's defined using #element, not 1#element). 

This change removes the empty list validation in `normalizeHeaderValue()` and adds tests on the `Request` and `Response` construction paths.