### PR TITLE
Update MimeType map to include .jfif extension

### DIFF
--- a/src/MimeType.php
+++ b/src/MimeType.php
@@ -434,6 +434,7 @@ final class MimeType
         'jar' => 'application/java-archive',
         'jardiff' => 'application/x-java-archive-diff',
         'java' => 'text/x-java-source',
+        'jfif' => 'image/jpeg',
         'jhc' => 'image/jphc',
         'jisp' => 'application/vnd.jisp',
         'jls' => 'image/jls',


### PR DESCRIPTION
Add jfif extension, used by Windows 10 and 11 as a default extension of image/jpeg MIME type.

Several topics about users complaining about this:
1. https://www.elevenforum.com/t/windows-11-saves-my-jepgs-as-jfif-files-by-default.17336/
2. https://learn.microsoft.com/en-us/answers/questions/4361827/all-browsers-suddenly-save-all-images-from-all-sou

At a project of mine, we currently face a problem with that as users will email/send a picture of a document to themselves via WhatsApp – and while they can upload it and system will recognize it as image/jpeg just fine, we cannot use Guzzle to send it to an external service without specifying MIME type manually (it will send it as application/octet-stream by default).

I recognize it may be classified as my project's issue, but the issue is so pervasive that I think others may have found themselves scratching their heads as well.

Other projects that recognize .jfif as image/jpeg:
1. https://github.com/symfony/mime/blob/7.3/MimeTypes.php#L2605C1-L2605C49
2. Laravel at its core uses finfo, which will apply a heuristic to see the file conforms to a JPEG/JFIF fi;e structure and respond with image/jpeg; it uses symfony/mime under the hood to guess a file extension for it, if asked.