### PR TITLE
Fix PHP 8.4 deprecation warnings in trigger_error calls

### DIFF
--- a/src/AppendStream.php
+++ b/src/AppendStream.php
@@ -46,7 +46,7 @@ final class AppendStream implements StreamInterface
             if (\PHP_VERSION_ID >= 70400) {
                 throw $e;
             }
-            trigger_error(sprintf('%s::__toString exception: %s', self::class, (string) $e), E_USER_ERROR);
+            throw new \Error(sprintf('%s::__toString exception: %s', self::class, (string) $e));
 
             return '';
         }

--- a/src/FnStream.php
+++ b/src/FnStream.php
@@ -99,7 +99,7 @@ final class FnStream implements StreamInterface
             if (\PHP_VERSION_ID >= 70400) {
                 throw $e;
             }
-            trigger_error(sprintf('%s::__toString exception: %s', self::class, (string) $e), E_USER_ERROR);
+            throw new \Error(sprintf('%s::__toString exception: %s', self::class, (string) $e));
 
             return '';
         }

--- a/src/PumpStream.php
+++ b/src/PumpStream.php
@@ -59,7 +59,7 @@ final class PumpStream implements StreamInterface
             if (\PHP_VERSION_ID >= 70400) {
                 throw $e;
             }
-            trigger_error(sprintf('%s::__toString exception: %s', self::class, (string) $e), E_USER_ERROR);
+            throw new \Error(sprintf('%s::__toString exception: %s', self::class, (string) $e));
 
             return '';
         }

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -86,7 +86,7 @@ class Stream implements StreamInterface
             if (\PHP_VERSION_ID >= 70400) {
                 throw $e;
             }
-            trigger_error(sprintf('%s::__toString exception: %s', self::class, (string) $e), E_USER_ERROR);
+            throw new \Error(sprintf('%s::__toString exception: %s', self::class, (string) $e));
 
             return '';
         }

--- a/src/StreamDecoratorTrait.php
+++ b/src/StreamDecoratorTrait.php
@@ -50,7 +50,7 @@ trait StreamDecoratorTrait
             if (\PHP_VERSION_ID >= 70400) {
                 throw $e;
             }
-            trigger_error(sprintf('%s::__toString exception: %s', self::class, (string) $e), E_USER_ERROR);
+            throw new \Error(sprintf('%s::__toString exception: %s', self::class, (string) $e));
 
             return '';
         }

--- a/tests/AppendStreamTest.php
+++ b/tests/AppendStreamTest.php
@@ -197,19 +197,9 @@ class AppendStreamTest extends TestCase
         $a = new AppendStream([$s]);
         self::assertFalse($a->eof());
 
-        $errors = [];
-        set_error_handler(static function (int $errorNumber, string $errorMessage) use (&$errors): bool {
-            $errors[] = ['number' => $errorNumber, 'message' => $errorMessage];
-
-            return true;
-        });
+        $this->expectException(\Error::class);
+        $this->expectExceptionMessage('GuzzleHttp\Psr7\AppendStream::__toString exception:');
         (string) $a;
-
-        restore_error_handler();
-
-        self::assertCount(1, $errors);
-        self::assertSame(E_USER_ERROR, $errors[0]['number']);
-        self::assertStringStartsWith('GuzzleHttp\Psr7\AppendStream::__toString exception:', $errors[0]['message']);
     }
 
     public function testReturnsEmptyMetadata(): void

--- a/tests/FnStreamTest.php
+++ b/tests/FnStreamTest.php
@@ -113,16 +113,8 @@ class FnStreamTest extends TestCase
             },
         ]);
 
-        $errors = [];
-        set_error_handler(function (int $errorNumber, string $errorMessage) use (&$errors): void {
-            $errors[] = ['number' => $errorNumber, 'message' => $errorMessage];
-        });
+        $this->expectException(\Error::class);
+        $this->expectExceptionMessage('GuzzleHttp\Psr7\FnStream::__toString exception:');
         (string) $a;
-
-        restore_error_handler();
-
-        self::assertCount(1, $errors);
-        self::assertSame(E_USER_ERROR, $errors[0]['number']);
-        self::assertStringStartsWith('GuzzleHttp\Psr7\FnStream::__toString exception:', $errors[0]['message']);
     }
 }

--- a/tests/PumpStreamTest.php
+++ b/tests/PumpStreamTest.php
@@ -90,16 +90,8 @@ class PumpStreamTest extends TestCase
         });
         self::assertInstanceOf(PumpStream::class, $p);
 
-        $errors = [];
-        set_error_handler(function (int $errorNumber, string $errorMessage) use (&$errors): void {
-            $errors[] = ['number' => $errorNumber, 'message' => $errorMessage];
-        });
+        $this->expectException(\Error::class);
+        $this->expectExceptionMessage('GuzzleHttp\Psr7\PumpStream::__toString exception:');
         (string) $p;
-
-        restore_error_handler();
-
-        self::assertCount(1, $errors);
-        self::assertSame(E_USER_ERROR, $errors[0]['number']);
-        self::assertStringStartsWith('GuzzleHttp\Psr7\PumpStream::__toString exception:', $errors[0]['message']);
     }
 }

--- a/tests/StreamDecoratorTraitTest.php
+++ b/tests/StreamDecoratorTraitTest.php
@@ -47,13 +47,10 @@ class StreamDecoratorTraitTest extends TestCase
         $s->expects(self::once())
             ->method('read')
             ->willThrowException(new \RuntimeException('foo'));
-        $msg = '';
-        set_error_handler(function (int $errNo, string $str) use (&$msg): void {
-            $msg = $str;
-        });
-        echo new Str($s);
-        restore_error_handler();
-        self::assertStringContainsString('foo', $msg);
+
+        $this->expectException(\Error::class);
+        $this->expectExceptionMessageMatches('/foo/');
+        (string) new Str($s);
     }
 
     public function testToString(): void

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -211,23 +211,9 @@ class StreamTest extends TestCase
         $throws(function () use ($stream): void {
             $stream->getContents();
         });
-
-        if (\PHP_VERSION_ID >= 70400) {
-            $throws(function () use ($stream): void {
-                (string) $stream;
-            });
-        } else {
-            $errors = [];
-            set_error_handler(function (int $errorNumber, string $errorMessage) use (&$errors): void {
-                $errors[] = ['message' => $errorMessage, 'number' => $errorNumber];
-            });
-            self::assertSame('', (string) $stream);
-            restore_error_handler();
-
-            self::assertCount(1, $errors);
-            self::assertStringStartsWith('GuzzleHttp\Psr7\Stream::__toString exception', $errors[0]['message']);
-            self::assertSame(E_USER_ERROR, $errors[0]['number']);
-        }
+        $throws(function () use ($stream): void {
+            (string) $stream;
+        });
     }
 
     public function testStreamReadingWithZeroLength(): void


### PR DESCRIPTION
Updated `trigger_error` calls that utilize E_USER_ERROR to throw a new Error instead.