### PR TITLE
[2.8] Add regression test for detach() on non-seekable streams

### DIFF
--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -161,6 +161,20 @@ class StreamTest extends TestCase
         $stream->close();
     }
 
+    public function testDetachNonSeekableStreamAndClearProperties(): void
+    {
+        $handle = popen('echo foo', 'r');
+        $stream = new Stream($handle);
+        self::assertFalse($stream->isSeekable());
+        $detached = $stream->detach();
+        self::assertIsResource($detached);
+        self::assertNull($stream->detach());
+
+        $this->assertStreamStateAfterClosedOrDetached($stream);
+
+        pclose($detached);
+    }
+
     public function testCloseResourceAndClearProperties(): void
     {
         $handle = fopen('php://temp', 'r');


### PR DESCRIPTION
`Stream::detach()` used to call `ftell()`, `feof()`, and `stream_get_meta_data()`
on the resource after clearing the internal reference. On non-seekable stream types
(e.g. `tcp_socket/ssl`), `ftell()` raises a `TypeError` on PHP 8.

Those calls were removed from `detach()`, but no test covered this scenario.
Add a regression test using a `popen` pipe (non-seekable) to confirm `detach()`
returns the resource cleanly and leaves the `Stream` object in the expected
detached state.

Fixes #630.