### PR TITLE
[2.8] Encode plus sign in withQueryValue() and withQueryValues()

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -51,7 +51,7 @@ class Uri implements UriInterface, \JsonSerializable
      * @see https://datatracker.ietf.org/doc/html/rfc3986#section-2.2
      */
     private const CHAR_SUB_DELIMS = '!\$&\'\(\)\*\+,;=';
-    private const QUERY_SEPARATORS_REPLACEMENT = ['=' => '%3D', '&' => '%26'];
+    private const QUERY_SEPARATORS_REPLACEMENT = ['=' => '%3D', '&' => '%26', '+' => '%2B'];
 
     /** @var string Uri scheme. */
     private $scheme = '';

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -661,7 +661,8 @@ class Uri implements UriInterface, \JsonSerializable
 
     private static function generateQueryString(string $key, ?string $value): string
     {
-        // Query string separators ("=", "&") within the key or value need to be encoded
+        // Query string separators ("=", "&") and literal plus signs ("+") within the
+        // key or value need to be encoded
         // (while preventing double-encoding) before setting the query string. All other
         // chars that need percent-encoding will be encoded by withQuery().
         $queryString = strtr($key, self::QUERY_SEPARATORS_REPLACEMENT);

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -390,6 +390,17 @@ class UriTest extends TestCase
         self::assertSame('E%3Dmc%5e2=ein%26stein', $uri->getQuery(), 'Encoded key/value do not get double-encoded');
     }
 
+    public function testWithQueryValueEncodesPlusSign(): void
+    {
+        $uri = new Uri();
+        $uri = Uri::withQueryValue($uri, 'a+b', 'c+d');
+        self::assertSame('a%2Bb=c%2Bd', $uri->getQuery(), 'Plus signs in key and value get encoded to %2B');
+
+        $uri = new Uri();
+        $uri = Uri::withQueryValue($uri, 'query', 'a+b c');
+        self::assertSame('query=a%2Bb%20c', $uri->getQuery(), 'Plus sign is encoded distinctly from space');
+    }
+
     public function testWithoutQueryValueHandlesEncoding(): void
     {
         // It also tests that the case of the percent-encoding does not matter,


### PR DESCRIPTION
`Uri::withQueryValue()` and `Uri::withQueryValues()` do not percent-encode `+`
in keys or values. Most HTTP servers interpret an unencoded `+` in a query
string as a space (per the `application/x-www-form-urlencoded` convention),
which corrupts values that contain literal plus signs.

`+` is a sub-delimiter under RFC 3986, so `filterQueryAndFragment()` lets it
through. But `Query::build()` already encodes `+` to `%2B` via `rawurlencode()`.
The fix adds `'+' => '%2B'` to `QUERY_SEPARATORS_REPLACEMENT` so both code
paths produce the same output.

Added a test covering `+` in keys, values, and alongside spaces.

Fixes #618.