### PR TITLE
Harden URI host and scheme validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Hardened URI host and scheme validation. Hosts now reject control characters, whitespace, URI delimiters, backslashes, ambiguous port separators, and malformed IP-literal brackets. Schemes now reject whitespace and control characters.
+- `ServerRequest::getUriFromGlobals()` now ignores malformed `HTTP_HOST` values and uses the existing fallback host sources.
+- Passing a host and port together to `Uri::withHost()` is no longer accepted; use `withHost('example.com')->withPort(8080)` instead.
 - Validate iterator chunks passed to `Utils::streamFor()`
 - Validate unsupported values passed to `Query::build()`
 - Stop adding default `Content-Length` headers to `multipart/form-data` parts to comply with RFC 7578 section 4.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Hardened URI host and scheme validation. Hosts now reject control characters, whitespace, URI delimiters, backslashes, ambiguous port separators, and malformed IP-literal brackets. Schemes now reject whitespace and control characters.
-- `ServerRequest::getUriFromGlobals()` now ignores malformed `HTTP_HOST` values and uses the existing fallback host sources.
-- Passing a host and port together to `Uri::withHost()` is no longer accepted; use `withHost('example.com')->withPort(8080)` instead.
+- Harden URI host and scheme validation
+- Ignore malformed `HTTP_HOST` values in `ServerRequest::getUriFromGlobals()`
+- Reject hosts with embedded ports in `Uri::withHost()`
 - Validate iterator chunks passed to `Utils::streamFor()`
 - Validate unsupported values passed to `Query::build()`
 - Stop adding default `Content-Length` headers to `multipart/form-data` parts to comply with RFC 7578 section 4.8

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,6 +4,46 @@ Guzzle PSR-7 Upgrade Guide
 2.x to 3.0
 ----------
 
+#### URI Host and Scheme Validation
+
+URI hosts containing control characters, whitespace, URI delimiters, backslashes,
+ambiguous port separators, or malformed IP-literal brackets are no longer
+accepted. URI schemes containing whitespace or control characters are also no
+longer accepted.
+
+If you previously passed a host and port together to `withHost()`, split them
+between `withHost()` and `withPort()`:
+
+```php
+// 2.x, no longer accepted in 3.0
+$uri = $uri->withHost('example.com:8080');
+
+// 3.0
+$uri = $uri->withHost('example.com')->withPort(8080);
+```
+
+Normal URI strings with ports are still supported:
+
+```php
+$uri = new Uri('https://example.com:8080/path');
+```
+
+Common host forms such as `localhost`, single-label hosts, underscores, Unicode
+hosts, valid IPv6 literals, and normal host and port URI strings remain
+supported.
+
+The stricter validation also applies when a request is created or modified from
+a custom `UriInterface` implementation and its host is used to generate or
+update a `Host` header.
+
+`ServerRequest::getUriFromGlobals()` now ignores malformed `HTTP_HOST` values
+and falls back to `SERVER_NAME`, then `SERVER_ADDR`, then the existing default
+host behavior.
+
+Applications that need to reject malformed inbound `Host` headers should
+validate the request host before calling `getUriFromGlobals()` or inspect the
+original server parameters.
+
 #### Query Builder Values
 
 `Query::build()` now rejects unsupported values instead of relying on PHP string

--- a/src/Request.php
+++ b/src/Request.php
@@ -132,6 +132,8 @@ class Request implements RequestInterface
             return;
         }
 
+        Uri::assertValidHost($host);
+
         if (($port = $this->uri->getPort()) !== null) {
             $host .= ':'.$port;
         }

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -191,16 +191,84 @@ class ServerRequest extends Request implements ServerRequestInterface
      */
     private static function extractHostAndPortFromAuthority(string $authority): array
     {
-        $uri = 'http://'.$authority;
-        $parts = parse_url($uri);
-        if (!is_array($parts)) {
+        if ($authority === '') {
             return [null, null];
         }
 
-        $host = $parts['host'] ?? null;
-        $port = $parts['port'] ?? null;
+        $host = $authority;
+        $port = null;
+
+        if ($authority[0] === '[') {
+            $closingBracket = strpos($authority, ']');
+            if ($closingBracket === false) {
+                return [null, null];
+            }
+
+            $host = substr($authority, 0, $closingBracket + 1);
+            $remainder = substr($authority, $closingBracket + 1);
+            if ($remainder !== '') {
+                if ($remainder[0] !== ':') {
+                    return [null, null];
+                }
+
+                $port = self::parsePortFromAuthority(substr($remainder, 1));
+                if ($port === null) {
+                    return [null, null];
+                }
+            }
+        } elseif (false !== ($colon = strpos($authority, ':'))) {
+            $host = substr($authority, 0, $colon);
+            $port = self::parsePortFromAuthority(substr($authority, $colon + 1));
+            if ($port === null) {
+                return [null, null];
+            }
+        }
+
+        if ($host === '') {
+            return [null, null];
+        }
+
+        try {
+            Uri::assertValidHost($host);
+        } catch (InvalidArgumentException $e) {
+            return [null, null];
+        }
 
         return [$host, $port];
+    }
+
+    private static function parsePortFromAuthority(string $port): ?int
+    {
+        if ($port === '' || !ctype_digit($port)) {
+            return null;
+        }
+
+        $port = ltrim($port, '0');
+        if ($port === '') {
+            return 0;
+        }
+
+        if (strlen($port) > 5 || (int) $port > 0xFFFF) {
+            return null;
+        }
+
+        return (int) $port;
+    }
+
+    /**
+     * @param mixed $host
+     */
+    private static function withHostFromGlobals(UriInterface $uri, $host): ?UriInterface
+    {
+        if (!is_string($host)) {
+            return null;
+        }
+
+        try {
+            return $uri->withHost($host);
+        } catch (InvalidArgumentException $e) {
+            return null;
+        }
     }
 
     /**
@@ -214,21 +282,34 @@ class ServerRequest extends Request implements ServerRequestInterface
         $uri = $uri->withScheme(!empty($https) && $https !== 'off' ? 'https' : 'http');
 
         $hasPort = false;
+        $hasHost = false;
         $authority = self::getServerParam('HTTP_HOST');
         if ($authority !== null) {
             [$host, $port] = self::extractHostAndPortFromAuthority($authority);
             if ($host !== null) {
-                $uri = $uri->withHost($host);
+                $hostUri = self::withHostFromGlobals($uri, $host);
+                if ($hostUri !== null) {
+                    $uri = $hostUri;
+                    $hasHost = true;
+
+                    if ($port !== null) {
+                        $hasPort = true;
+                        $uri = $uri->withPort($port);
+                    }
+                }
+            }
+        }
+
+        foreach (['SERVER_NAME', 'SERVER_ADDR'] as $serverParam) {
+            if ($hasHost) {
+                continue;
             }
 
-            if ($port !== null) {
-                $hasPort = true;
-                $uri = $uri->withPort($port);
+            $hostUri = self::withHostFromGlobals($uri, self::getServerParam($serverParam));
+            if ($hostUri !== null) {
+                $uri = $hostUri;
+                $hasHost = true;
             }
-        } elseif (($serverName = self::getServerParam('SERVER_NAME')) !== null) {
-            $uri = $uri->withHost($serverName);
-        } elseif (($serverAddr = self::getServerParam('SERVER_ADDR')) !== null) {
-            $uri = $uri->withHost($serverAddr);
         }
 
         $serverPort = self::getServerParam('SERVER_PORT');

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -81,7 +81,13 @@ class Uri implements UriInterface, \JsonSerializable
             if ($parts === false) {
                 throw new MalformedUriException("Unable to parse URI: $uri");
             }
-            $this->applyParts($parts);
+            try {
+                $this->applyParts($parts);
+            } catch (MalformedUriException $e) {
+                throw $e;
+            } catch (\InvalidArgumentException $e) {
+                throw new MalformedUriException($e->getMessage(), 0, $e);
+            }
         }
     }
 
@@ -390,10 +396,42 @@ class Uri implements UriInterface, \JsonSerializable
     public static function fromParts(array $parts): UriInterface
     {
         $uri = new self();
-        $uri->applyParts($parts);
-        $uri->validateState();
+        try {
+            $uri->applyParts($parts);
+            $uri->validateState();
+        } catch (MalformedUriException $e) {
+            throw $e;
+        } catch (\InvalidArgumentException $e) {
+            throw new MalformedUriException($e->getMessage(), 0, $e);
+        }
 
         return $uri;
+    }
+
+    /**
+     * @throws \InvalidArgumentException If the host is invalid.
+     *
+     * @internal
+     */
+    public static function assertValidHost(string $host): void
+    {
+        if ($host === '') {
+            return;
+        }
+
+        if (preg_match('/[\x00-\x20\x7F\/\?#@\\\\]/', $host)) {
+            throw new \InvalidArgumentException(sprintf('Invalid host: "%s"', $host));
+        }
+
+        if (strpos($host, '[') !== false || strpos($host, ']') !== false) {
+            self::assertValidIpLiteralHost($host);
+
+            return;
+        }
+
+        if (strpos($host, ':') !== false) {
+            throw new \InvalidArgumentException(sprintf('Invalid host: "%s"', $host));
+        }
     }
 
     public function getScheme(): string
@@ -604,7 +642,12 @@ class Uri implements UriInterface, \JsonSerializable
             throw new \InvalidArgumentException('Scheme must be a string');
         }
 
-        return \strtr($scheme, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz');
+        $scheme = \strtr($scheme, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz');
+        if (preg_match('/[\x00-\x20\x7F]/', $scheme)) {
+            throw new \InvalidArgumentException(sprintf('Invalid scheme: "%s"', $scheme));
+        }
+
+        return $scheme;
     }
 
     /**
@@ -636,7 +679,28 @@ class Uri implements UriInterface, \JsonSerializable
             throw new \InvalidArgumentException('Host must be a string');
         }
 
-        return \strtr($host, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz');
+        $host = \strtr($host, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz');
+        self::assertValidHost($host);
+
+        return $host;
+    }
+
+    private static function assertValidIpLiteralHost(string $host): void
+    {
+        if ($host[0] !== '[' || substr($host, -1) !== ']') {
+            throw new \InvalidArgumentException(sprintf('Invalid host: "%s"', $host));
+        }
+
+        $address = substr($host, 1, -1);
+        if (\filter_var($address, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false) {
+            return;
+        }
+
+        if (preg_match('/^v[0-9a-f]+\.['.self::CHAR_UNRESERVED.self::CHAR_SUB_DELIMS.':]+$/iD', $address)) {
+            return;
+        }
+
+        throw new \InvalidArgumentException(sprintf('Invalid host: "%s"', $host));
     }
 
     /**

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -166,19 +166,23 @@ final class Utils
         if (!isset($changes['uri'])) {
             $uri = $request->getUri();
         } else {
+            /** @var UriInterface */
+            $uri = $changes['uri'];
+
             // Remove the host header if one is on the URI
-            if ($host = $changes['uri']->getHost()) {
+            if ($host = $uri->getHost()) {
+                Uri::assertValidHost($host);
+
                 $changes['set_headers']['Host'] = $host;
 
-                if ($port = $changes['uri']->getPort()) {
+                if ($port = $uri->getPort()) {
                     $standardPorts = ['http' => 80, 'https' => 443];
-                    $scheme = $changes['uri']->getScheme();
+                    $scheme = $uri->getScheme();
                     if (isset($standardPorts[$scheme]) && $port != $standardPorts[$scheme]) {
                         $changes['set_headers']['Host'] .= ':'.$port;
                     }
                 }
             }
-            $uri = $changes['uri'];
         }
 
         if (!empty($changes['remove_headers'])) {

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Uri;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UriInterface;
 
 /**
  * @covers \GuzzleHttp\Psr7\MessageTrait
@@ -312,6 +313,17 @@ class RequestTest extends TestCase
         $r = new Request('GET', 'http://foo.com:8124/bar');
         $r = $r->withUri(new Uri('http://foo.com:8125/bar'));
         self::assertSame('foo.com:8125', $r->getHeaderLine('host'));
+    }
+
+    public function testGeneratedHostHeaderRejectsInvalidUriHostFromCustomUri(): void
+    {
+        $uri = $this->createMock(UriInterface::class);
+        $uri->method('getHost')->willReturn("foo\nbar");
+        $uri->method('getPort')->willReturn(null);
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        new Request('GET', $uri);
     }
 
     /**

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -351,8 +351,20 @@ class ServerRequestTest extends TestCase
                 array_merge($server, ['HTTP_HOST' => '[::1]:8000']),
             ],
             'Invalid host' => [
-                'https://localhost/blog/article.php?id=10&user=foo',
+                'https://www.example.org/blog/article.php?id=10&user=foo',
                 array_merge($server, ['HTTP_HOST' => 'a:b']),
+            ],
+            'Host header with newline' => [
+                'https://www.example.org/blog/article.php?id=10&user=foo',
+                array_merge($server, ['HTTP_HOST' => "www.example.org\n.evil"]),
+            ],
+            'Host header with multiple ports' => [
+                'https://www.example.org/blog/article.php?id=10&user=foo',
+                array_merge($server, ['HTTP_HOST' => 'www.example.org:443:8324']),
+            ],
+            'Invalid HTTP_HOST and SERVER_NAME -> fallback to SERVER_ADDR' => [
+                'https://217.112.82.20/blog/article.php?id=10&user=foo',
+                array_merge($server, ['HTTP_HOST' => 'www.example.org:443:8324', 'SERVER_NAME' => 'bad host']),
             ],
             'Different port with SERVER_PORT' => [
                 'https://www.example.org:8324/blog/article.php?id=10&user=foo',

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -117,6 +117,16 @@ class UriTest extends TestCase
             // currently invalid as well but should not according to RFC 3986.
             ['http://'],
             ['urn://host:with:colon'], // host cannot contain ":"
+            ['http://example.com'."\n".'.evil/'],
+            ['http://example.com:80:90/'],
+            ['http://user@example.com:80:90/path'],
+            ['http://[::1]:80:90/'],
+            ['http://[::1'],
+            [' http://a.b/p?q#f'],
+            ['ht tp://example.com'],
+            ['//example.com:80:90'],
+            ['//example.com'."\n".':80'],
+            ['//[::1]:80:90'],
         ];
     }
 
@@ -208,10 +218,66 @@ class UriTest extends TestCase
         (new Uri())->withScheme([]);
     }
 
+    /**
+     * @dataProvider getInvalidSchemes
+     */
+    public function testSchemeMustBeValid(string $scheme): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        (new Uri())->withScheme($scheme);
+    }
+
+    public static function getInvalidSchemes(): iterable
+    {
+        for ($i = 0; $i <= 0x20; ++$i) {
+            yield 'ascii 0x'.strtoupper(dechex($i)) => ['ht'.chr($i).'tp'];
+        }
+
+        yield 'ascii 0x7F' => ['ht'.chr(0x7F).'tp'];
+    }
+
+    public function testFromPartsRejectsSchemeWithControlCharacter(): void
+    {
+        $this->expectException(MalformedUriException::class);
+
+        Uri::fromParts(['scheme' => "ht\ntp", 'host' => 'example.com']);
+    }
+
     public function testHostMustHaveCorrectType(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         (new Uri())->withHost([]);
+    }
+
+    /**
+     * @dataProvider getInvalidHosts
+     */
+    public function testHostMustBeValid(string $host): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        (new Uri())->withHost($host);
+    }
+
+    public static function getInvalidHosts(): iterable
+    {
+        for ($i = 0; $i <= 0x20; ++$i) {
+            yield 'ascii 0x'.strtoupper(dechex($i)) => ['example'.chr($i).'com'];
+        }
+
+        yield 'ascii 0x7F' => ['example'.chr(0x7F).'com'];
+        yield 'colon' => ['example.com:80'];
+        yield 'path delimiter' => ['example.com/path'];
+        yield 'query delimiter' => ['example.com?query'];
+        yield 'fragment delimiter' => ['example.com#fragment'];
+        yield 'userinfo delimiter' => ['user@example.com'];
+        yield 'backslash' => ['example\\com'];
+        yield 'unbracketed IPv6' => ['::1'];
+        yield 'bracketed IPv6 with port' => ['[::1]:80'];
+        yield 'unterminated bracketed IPv6' => ['[::1'];
+        yield 'unbalanced opening bracket' => ['example[com'];
+        yield 'unbalanced closing bracket' => ['example]com'];
     }
 
     public function testPathMustHaveCorrectType(): void
@@ -499,6 +565,21 @@ class UriTest extends TestCase
 
         self::assertSame('example.com', $uri->getHost());
         self::assertSame('//example.com', (string) $uri);
+    }
+
+    public function testCommonNonDnsHostsStayValid(): void
+    {
+        $uri = (new Uri())->withHost('foo_bar');
+        self::assertSame('foo_bar', $uri->getHost());
+        self::assertSame('//foo_bar', (string) $uri);
+
+        $uri = (new Uri())->withHost('localhost');
+        self::assertSame('localhost', $uri->getHost());
+        self::assertSame('//localhost', (string) $uri);
+
+        $uri = new Uri('http://[v1.fe80]/');
+        self::assertSame('[v1.fe80]', $uri->getHost());
+        self::assertSame('http://[v1.fe80]/', (string) $uri);
     }
 
     public function testPortIsNullIfStandardPortForScheme(): void

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -461,6 +461,17 @@ class UtilsTest extends TestCase
         self::assertSame('www.foo.com:8000', (string) $r2->getHeaderLine('host'));
     }
 
+    public function testModifyRequestRejectsInvalidUriHostFromCustomUri(): void
+    {
+        $uri = $this->createMock(UriInterface::class);
+        $uri->method('getHost')->willReturn("foo\nbar");
+        $uri->method('getPort')->willReturn(null);
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        Psr7\Utils::modifyRequest(new Psr7\Request('GET', '/'), ['uri' => $uri]);
+    }
+
     public function testCanModifyRequestWithCaseInsensitiveHeader(): void
     {
         $r1 = new Psr7\Request('GET', 'http://foo.com', ['User-Agent' => 'foo']);


### PR DESCRIPTION
Hardens URI host validation and `Host` header generation for 3.0. Also addresses the 3.0-compatible part of #648 by rejecting raw whitespace and control characters in URI schemes, while keeping full RFC 3986 scheme syntax validation deferred to #643 for 4.0.

---

Fixes #583.