### PR TITLE
[2.9] Fix parsing of relative path references containing a colon in a non-initial path segment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fix parsing of relative path references containing a colon in a non-initial path segment
+
 ## 2.9.0 - 2026-03-10
 
 ### Added

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -105,6 +105,10 @@ class Uri implements UriInterface, \JsonSerializable
      */
     private static function parse(string $url)
     {
+        if (self::isPathNoSchemeReference($url)) {
+            return self::parsePathNoSchemeReference($url);
+        }
+
         // If IPv6
         $prefix = '';
         if (preg_match('%^(.*://\[[0-9:a-fA-F]+\])(.*?)$%', $url, $matches)) {
@@ -129,6 +133,39 @@ class Uri implements UriInterface, \JsonSerializable
         }
 
         return array_map('urldecode', $result);
+    }
+
+    private static function isPathNoSchemeReference(string $url): bool
+    {
+        if ($url === '' || $url[0] === '/' || $url[0] === '?' || $url[0] === '#') {
+            return false;
+        }
+
+        $firstSegment = substr($url, 0, strcspn($url, '/?#'));
+
+        return strpos($firstSegment, ':') === false;
+    }
+
+    /**
+     * @return array{path: string, query?: string, fragment?: string}
+     */
+    private static function parsePathNoSchemeReference(string $url): array
+    {
+        $parts = [];
+
+        if (false !== ($fragmentPosition = strpos($url, '#'))) {
+            $parts['fragment'] = substr($url, $fragmentPosition + 1);
+            $url = substr($url, 0, $fragmentPosition);
+        }
+
+        if (false !== ($queryPosition = strpos($url, '?'))) {
+            $parts['query'] = substr($url, $queryPosition + 1);
+            $url = substr($url, 0, $queryPosition);
+        }
+
+        $parts['path'] = $url;
+
+        return $parts;
     }
 
     public function __toString(): string

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -123,7 +123,7 @@ class UriTest extends TestCase
     /**
      * @dataProvider getPathNoSchemeReferencesWithColonInLaterSegment
      */
-    public function testParsesPathNoSchemeReferenceWithColonInLaterSegment(string $input, string $path, string $query = '', string $fragment = ''): void
+    public function testParsesPathNoSchemeReferenceWithColonInLaterSegment(string $input, string $path, string $query = '', string $fragment = '', ?string $expectedString = null): void
     {
         $uri = new Uri($input);
 
@@ -134,7 +134,8 @@ class UriTest extends TestCase
         self::assertSame($path, $uri->getPath());
         self::assertSame($query, $uri->getQuery());
         self::assertSame($fragment, $uri->getFragment());
-        self::assertSame($input, (string) $uri);
+        self::assertSame($expectedString ?? $input, (string) $uri);
+        self::assertTrue(Uri::isRelativePathReference($uri));
     }
 
     public static function getPathNoSchemeReferencesWithColonInLaterSegment(): iterable
@@ -145,6 +146,9 @@ class UriTest extends TestCase
             ['foo/bar:0?x=1#frag', 'foo/bar:0', 'x=1', 'frag'],
             ['foo/bar:baz?x=y:z#frag:ment', 'foo/bar:baz', 'x=y:z', 'frag:ment'],
             ['./foo:0', './foo:0'],
+            ['foo/bar:0/baz?q=a:b&r=c#h:i', 'foo/bar:0/baz', 'q=a:b&r=c', 'h:i'],
+            ['caf%C3%A9/foo:1', 'caf%C3%A9/foo:1'],
+            ['café/foo:1', 'caf%C3%A9/foo:1', '', '', 'caf%C3%A9/foo:1'],
         ];
     }
 
@@ -173,6 +177,7 @@ class UriTest extends TestCase
             ['?q=foo:0', '', '', '', null, '', 'q=foo:0', ''],
             ['#foo:0', '', '', '', null, '', '', 'foo:0'],
             ['https://example.com/foo:0', 'https', 'example.com', 'example.com', null, '/foo:0', '', ''],
+            ['//host/foo:bar', '', 'host', 'host', null, '/foo:bar', '', ''],
         ];
     }
 

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -120,6 +120,62 @@ class UriTest extends TestCase
         ];
     }
 
+    /**
+     * @dataProvider getPathNoSchemeReferencesWithColonInLaterSegment
+     */
+    public function testParsesPathNoSchemeReferenceWithColonInLaterSegment(string $input, string $path, string $query = '', string $fragment = ''): void
+    {
+        $uri = new Uri($input);
+
+        self::assertSame('', $uri->getScheme());
+        self::assertSame('', $uri->getAuthority());
+        self::assertSame('', $uri->getHost());
+        self::assertNull($uri->getPort());
+        self::assertSame($path, $uri->getPath());
+        self::assertSame($query, $uri->getQuery());
+        self::assertSame($fragment, $uri->getFragment());
+        self::assertSame($input, (string) $uri);
+    }
+
+    public static function getPathNoSchemeReferencesWithColonInLaterSegment(): iterable
+    {
+        return [
+            ['model/amazon.titan-image-generator-v2:0/invoke', 'model/amazon.titan-image-generator-v2:0/invoke'],
+            ['foo/bar:0', 'foo/bar:0'],
+            ['foo/bar:0?x=1#frag', 'foo/bar:0', 'x=1', 'frag'],
+            ['foo/bar:baz?x=y:z#frag:ment', 'foo/bar:baz', 'x=y:z', 'frag:ment'],
+            ['./foo:0', './foo:0'],
+        ];
+    }
+
+    /**
+     * @dataProvider getNonPathNoSchemeReferencesWithColon
+     */
+    public function testNonPathNoSchemeReferencesWithColonKeepExistingParsing(string $input, string $scheme, string $authority, string $host, ?int $port, string $path, string $query, string $fragment): void
+    {
+        $uri = new Uri($input);
+
+        self::assertSame($scheme, $uri->getScheme());
+        self::assertSame($authority, $uri->getAuthority());
+        self::assertSame($host, $uri->getHost());
+        self::assertSame($port, $uri->getPort());
+        self::assertSame($path, $uri->getPath());
+        self::assertSame($query, $uri->getQuery());
+        self::assertSame($fragment, $uri->getFragment());
+        self::assertSame($input, (string) $uri);
+    }
+
+    public static function getNonPathNoSchemeReferencesWithColon(): iterable
+    {
+        return [
+            ['foo:bar/baz', 'foo', '', '', null, 'bar/baz', '', ''],
+            ['//host:123/foo:0', '', 'host:123', 'host', 123, '/foo:0', '', ''],
+            ['?q=foo:0', '', '', '', null, '', 'q=foo:0', ''],
+            ['#foo:0', '', '', '', null, '', '', 'foo:0'],
+            ['https://example.com/foo:0', 'https', 'example.com', 'example.com', null, '/foo:0', '', ''],
+        ];
+    }
+
     public function testPortMustBeValid(): void
     {
         $this->expectException(\InvalidArgumentException::class);


### PR DESCRIPTION
Replaces https://github.com/guzzle/guzzle/pull/3332.