### PR TITLE
Fix CachingStream detach resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 2.9,1 - Unreleased
+## 2.9.1 - Unreleased
 
 ### Fixed
 
 - Fix parsing of relative path references containing a colon in a non-initial path segment
+- Fix `CachingStream::detach()` returning an incomplete resource before the decorated stream has been fully read (#605)
 - Fix `Message::bodySummary()` returning `null` when truncating printable UTF-8 bodies inside a multibyte character
 
 ## 2.9.0 - 2026-03-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix parsing of relative path references containing a colon in a non-initial path segment
-- Fix `CachingStream::detach()` returning an incomplete resource before the decorated stream has been fully read (#605)
+- Fix `CachingStream::detach()` returning an incomplete resource before the decorated stream has been fully read
 - Fix `Message::bodySummary()` returning `null` when truncating printable UTF-8 bodies inside a multibyte character
 
 ## 2.9.0 - 2026-03-10

--- a/src/CachingStream.php
+++ b/src/CachingStream.php
@@ -25,6 +25,9 @@ final class CachingStream implements StreamInterface
      */
     private $stream;
 
+    /** @var bool */
+    private $detached = false;
+
     /**
      * We will treat the buffer object as the body of the stream
      *
@@ -41,6 +44,10 @@ final class CachingStream implements StreamInterface
 
     public function getSize(): ?int
     {
+        if ($this->detached) {
+            return null;
+        }
+
         $remoteSize = $this->remoteStream->getSize();
 
         if (null === $remoteSize) {
@@ -134,6 +141,23 @@ final class CachingStream implements StreamInterface
         return $this->stream->eof() && $this->remoteStream->eof();
     }
 
+    public function detach()
+    {
+        if ($this->detached) {
+            return null;
+        }
+
+        $position = $this->tell();
+
+        $this->cacheEntireStream();
+        $this->stream->seek($position);
+
+        $resource = $this->stream->detach();
+        $this->detached = true;
+
+        return $resource;
+    }
+
     /**
      * Close both the remote stream and buffer stream
      */
@@ -141,6 +165,7 @@ final class CachingStream implements StreamInterface
     {
         $this->remoteStream->close();
         $this->stream->close();
+        $this->detached = true;
     }
 
     private function cacheEntireStream(): int

--- a/tests/CachingStreamTest.php
+++ b/tests/CachingStreamTest.php
@@ -145,6 +145,84 @@ class CachingStreamTest extends TestCase
         self::assertSame('tehiing', (string) $this->body);
     }
 
+    public function testDetachReturnsCompleteResourceWithoutPriorRead(): void
+    {
+        $body = new CachingStream(Psr7\Utils::streamFor('Hello world!'));
+
+        $resource = $body->detach();
+
+        self::assertIsResource($resource);
+        self::assertSame(0, ftell($resource));
+
+        $stats = fstat($resource);
+        self::assertIsArray($stats);
+        self::assertSame(11, $stats['size']);
+        self::assertSame('Hello world!', stream_get_contents($resource));
+
+        fclose($resource);
+        $body->close();
+    }
+
+    public function testDetachReturnsCompleteResourceAfterPartialRead(): void
+    {
+        $body = new CachingStream(Psr7\Utils::streamFor('Hello world!'));
+
+        self::assertSame('Hello ', $body->read(6));
+
+        $resource = $body->detach();
+
+        self::assertIsResource($resource);
+        self::assertSame(6, ftell($resource));
+        self::assertSame('world!', stream_get_contents($resource));
+
+        rewind($resource);
+        self::assertSame('Hello world!', stream_get_contents($resource));
+
+        fclose($resource);
+        $body->close();
+    }
+
+    public function testDetachPreservesCachedWritesAndUnreadRemoteBytes(): void
+    {
+        $body = new CachingStream(Psr7\Utils::streamFor('testing'));
+
+        self::assertSame('te', $body->read(2));
+        self::assertSame(2, $body->write('hi'));
+        $body->seek(0);
+
+        $resource = $body->detach();
+
+        self::assertIsResource($resource);
+        self::assertSame(0, ftell($resource));
+        self::assertSame('tehiing', stream_get_contents($resource));
+
+        fclose($resource);
+        $body->close();
+    }
+
+    public function testDetachReturnsNullAfterDetach(): void
+    {
+        $body = new CachingStream(Psr7\Utils::streamFor('testing'));
+
+        $resource = $body->detach();
+
+        self::assertIsResource($resource);
+        fclose($resource);
+
+        self::assertNull($body->detach());
+
+        $body->close();
+    }
+
+    public function testDetachReturnsNullAfterClose(): void
+    {
+        $body = new CachingStream(Psr7\Utils::streamFor('testing'));
+
+        $body->close();
+
+        self::assertNull($body->detach());
+    }
+
     public function testSkipsOverwrittenBytes(): void
     {
         $decorated = Psr7\Utils::streamFor(

--- a/tests/CachingStreamTest.php
+++ b/tests/CachingStreamTest.php
@@ -156,7 +156,7 @@ class CachingStreamTest extends TestCase
 
         $stats = fstat($resource);
         self::assertIsArray($stats);
-        self::assertSame(11, $stats['size']);
+        self::assertSame(strlen('Hello world!'), $stats['size']);
         self::assertSame('Hello world!', stream_get_contents($resource));
 
         fclose($resource);


### PR DESCRIPTION
Fix CachingStream::detach() so unread decorated contents are cached before returning the detached resource.

---

Closes #605.