### PR TITLE
Preserve request implementations in modifyRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.10.0 - Unreleased
+
+### Changed
+
+- Preserve custom request implementations in `Utils::modifyRequest()`
+
 ## 2.9.1 - Unreleased
 
 ### Fixed

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace GuzzleHttp\Psr7;
 
 use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
 
@@ -195,34 +194,68 @@ final class Utils
             $uri = $uri->withQuery($changes['query']);
         }
 
-        if ($request instanceof ServerRequestInterface) {
-            $new = (new ServerRequest(
-                $changes['method'] ?? $request->getMethod(),
-                $uri,
-                $headers,
-                $changes['body'] ?? $request->getBody(),
-                $changes['version'] ?? $request->getProtocolVersion(),
-                $request->getServerParams()
-            ))
-            ->withParsedBody($request->getParsedBody())
-            ->withQueryParams($request->getQueryParams())
-            ->withCookieParams($request->getCookieParams())
-            ->withUploadedFiles($request->getUploadedFiles());
-
-            foreach ($request->getAttributes() as $key => $value) {
-                $new = $new->withAttribute($key, $value);
+        $hasHost = false;
+        foreach (array_keys($headers) as $header) {
+            if (strtolower((string) $header) === 'host') {
+                $hasHost = true;
+                break;
             }
-
-            return $new;
         }
 
-        return new Request(
-            $changes['method'] ?? $request->getMethod(),
-            $uri,
-            $headers,
-            $changes['body'] ?? $request->getBody(),
-            $changes['version'] ?? $request->getProtocolVersion()
-        );
+        // Match Request::__construct() by adding a Host header when one is not provided.
+        if (!$hasHost && $uri->getHost() !== '') {
+            $host = $uri->getHost();
+
+            if (($port = $uri->getPort()) !== null) {
+                $host .= ':'.$port;
+            }
+
+            $headers = ['Host' => [$host]] + $headers;
+        }
+
+        $new = $request;
+
+        if (isset($changes['method'])) {
+            $new = $new->withMethod($changes['method']);
+        }
+
+        if (isset($changes['uri']) || isset($changes['query'])) {
+            $new = $new->withUri($uri, true);
+        }
+
+        if ($headers !== $new->getHeaders()) {
+            foreach (array_keys($new->getHeaders()) as $header) {
+                /** @var RequestInterface */
+                $new = $new->withoutHeader($header);
+            }
+
+            $addedHeaders = [];
+            foreach ($headers as $header => $value) {
+                $header = (string) $header;
+                $normalized = strtolower($header);
+
+                if (isset($addedHeaders[$normalized])) {
+                    /** @var RequestInterface */
+                    $new = $new->withAddedHeader($addedHeaders[$normalized], $value);
+                } else {
+                    /** @var RequestInterface */
+                    $new = $new->withHeader($header, $value);
+                    $addedHeaders[$normalized] = $header;
+                }
+            }
+        }
+
+        if (isset($changes['body'])) {
+            /** @var RequestInterface */
+            $new = $new->withBody(self::streamFor($changes['body']));
+        }
+
+        if (isset($changes['version'])) {
+            /** @var RequestInterface */
+            $new = $new->withProtocolVersion($changes['version']);
+        }
+
+        return $new;
     }
 
     /**

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -409,11 +409,11 @@ class UtilsTest extends TestCase
     {
         $r1 = new Psr7\Request('GET', 'http://foo.com');
         $r2 = Psr7\Utils::modifyRequest($r1, []);
-        self::assertInstanceOf('GuzzleHttp\Psr7\Request', $r2);
+        self::assertSame($r1, $r2);
 
         $r1 = new Psr7\ServerRequest('GET', 'http://foo.com');
         $r2 = Psr7\Utils::modifyRequest($r1, []);
-        self::assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $r2);
+        self::assertSame($r1, $r2);
     }
 
     public function testReturnsUriAsIsWhenNoChanges(): void
@@ -449,6 +449,140 @@ class UtilsTest extends TestCase
         $r1 = new Psr7\ServerRequest('GET', 'http://foo.com');
         $r2 = Psr7\Utils::modifyRequest($r1, ['remove_headers' => ['non-existent']]);
         self::assertInstanceOf('Psr\Http\Message\ServerRequestInterface', $r2);
+    }
+
+    public function testModifyRequestPreservesConcreteRequestSubclass(): void
+    {
+        $request = new class('GET', 'http://example.com', 'user-123') extends Psr7\Request {
+            /** @var string */
+            private $userId;
+
+            public function __construct(string $method, $uri, string $userId)
+            {
+                $this->userId = $userId;
+
+                parent::__construct($method, $uri);
+            }
+
+            public function userId(): string
+            {
+                return $this->userId;
+            }
+        };
+
+        $modified = Psr7\Utils::modifyRequest($request, [
+            'method' => 'POST',
+            'uri' => new Psr7\Uri('http://www.example.com/path'),
+            'query' => 'a=b',
+            'set_headers' => ['X-Test' => '1'],
+            'body' => 'payload',
+            'version' => '2',
+        ]);
+
+        self::assertSame(get_class($request), get_class($modified));
+        self::assertSame('user-123', $modified->userId());
+        self::assertSame('POST', $modified->getMethod());
+        self::assertSame('http://www.example.com/path?a=b', (string) $modified->getUri());
+        self::assertSame('www.example.com', $modified->getHeaderLine('Host'));
+        self::assertSame('1', $modified->getHeaderLine('X-Test'));
+        self::assertSame('payload', (string) $modified->getBody());
+        self::assertSame('2', $modified->getProtocolVersion());
+
+        self::assertSame('GET', $request->getMethod());
+        self::assertFalse($request->hasHeader('X-Test'));
+    }
+
+    public function testModifyRequestPreservesConcreteServerRequestSubclass(): void
+    {
+        $request = new class(
+            'GET',
+            'http://example.com',
+            [],
+            null,
+            '1.1',
+            ['server' => 'value'],
+            'ctx'
+        ) extends Psr7\ServerRequest {
+            /** @var string */
+            private $context;
+
+            public function __construct(
+                string $method,
+                $uri,
+                array $headers,
+                $body,
+                string $version,
+                array $serverParams,
+                string $context
+            ) {
+                $this->context = $context;
+
+                parent::__construct($method, $uri, $headers, $body, $version, $serverParams);
+            }
+
+            public function context(): string
+            {
+                return $this->context;
+            }
+        };
+
+        $file = new Psr7\UploadedFile('Test', 100, \UPLOAD_ERR_OK);
+        $request = $request
+            ->withCookieParams(['cookie' => 'value'])
+            ->withQueryParams(['query' => 'value'])
+            ->withParsedBody(['body' => 'value'])
+            ->withUploadedFiles([$file])
+            ->withAttribute('attribute', 'value');
+
+        $modified = Psr7\Utils::modifyRequest($request, [
+            'set_headers' => ['X-Test' => '1'],
+        ]);
+
+        self::assertSame(get_class($request), get_class($modified));
+        self::assertSame('ctx', $modified->context());
+        self::assertSame(['server' => 'value'], $modified->getServerParams());
+        self::assertSame(['cookie' => 'value'], $modified->getCookieParams());
+        self::assertSame(['query' => 'value'], $modified->getQueryParams());
+        self::assertSame(['body' => 'value'], $modified->getParsedBody());
+        self::assertSame([$file], $modified->getUploadedFiles());
+        self::assertSame(['attribute' => 'value'], $modified->getAttributes());
+        self::assertSame('1', $modified->getHeaderLine('X-Test'));
+    }
+
+    public function testModifyRequestConvertsBodyWithStreamFor(): void
+    {
+        $request = new Psr7\Request('GET', 'http://example.com');
+
+        $modified = Psr7\Utils::modifyRequest($request, [
+            'body' => 'payload',
+        ]);
+
+        self::assertInstanceOf(StreamInterface::class, $modified->getBody());
+        self::assertSame('payload', (string) $modified->getBody());
+    }
+
+    public function testModifyRequestReaddsHostHeaderWhenFinalHeadersDoNotContainHost(): void
+    {
+        $request = (new Psr7\Request('GET', 'http://example.com'))->withoutHeader('Host');
+
+        $modified = Psr7\Utils::modifyRequest($request, [
+            'set_headers' => ['X-Test' => '1'],
+        ]);
+
+        self::assertSame('example.com', $modified->getHeaderLine('Host'));
+        self::assertSame('1', $modified->getHeaderLine('X-Test'));
+    }
+
+    public function testModifyRequestPreservesConstructorStyleHeaderAggregation(): void
+    {
+        $request = new Psr7\Request('GET', 'http://foo.com');
+
+        $modified = Psr7\Utils::modifyRequest($request, [
+            'uri' => new Psr7\Uri('http://bar.com'),
+            'set_headers' => ['host' => 'custom'],
+        ]);
+
+        self::assertSame(['host' => ['custom', 'bar.com']], $modified->getHeaders());
     }
 
     public function testModifyServerRequestWithUploadedFiles(): void
@@ -505,7 +639,7 @@ class UtilsTest extends TestCase
             ->withAttribute('foo', 'bar');
 
         /** @var Psr7\ServerRequest $modifiedRequest */
-        $modifiedRequest = Psr7\Utils::modifyRequest($request, []);
+        $modifiedRequest = Psr7\Utils::modifyRequest($request, ['set_headers' => ['baz' => 'qux']]);
 
         self::assertSame(['foo' => 'bar'], $modifiedRequest->getAttributes());
     }

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -494,15 +494,7 @@ class UtilsTest extends TestCase
 
     public function testModifyRequestPreservesConcreteServerRequestSubclass(): void
     {
-        $request = new class(
-            'GET',
-            'http://example.com',
-            [],
-            null,
-            '1.1',
-            ['server' => 'value'],
-            'ctx'
-        ) extends Psr7\ServerRequest {
+        $request = new class('GET', 'http://example.com', [], null, '1.1', ['server' => 'value'], 'ctx') extends Psr7\ServerRequest {
             /** @var string */
             private $context;
 


### PR DESCRIPTION
Preserve custom request implementations when applying Utils::modifyRequest() changes.