### PR TITLE
Preserve URI implementations in UriResolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Preserve custom request implementations in `Utils::modifyRequest()`
 - Make `Uri::__toString()` side-effect-free
+- Preserve custom URI implementations in `UriResolver::resolve()`
 
 ## 2.9.1 - Unreleased
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Preserve custom request implementations in `Utils::modifyRequest()`
-- Make `Uri::__toString()` side-effect-free
 - Preserve custom URI implementations in `UriResolver::resolve()`
+- Make `Uri::__toString()` side-effect-free
 
 ## 2.9.1 - Unreleased
 

--- a/src/UriResolver.php
+++ b/src/UriResolver.php
@@ -67,41 +67,37 @@ final class UriResolver
         }
 
         if ($rel->getAuthority() != '') {
-            $targetAuthority = $rel->getAuthority();
-            $targetPath = self::removeDotSegments($rel->getPath());
-            $targetQuery = $rel->getQuery();
-        } else {
-            $targetAuthority = $base->getAuthority();
-            if ($rel->getPath() === '') {
-                $targetPath = $base->getPath();
-                $targetQuery = $rel->getQuery() != '' ? $rel->getQuery() : $base->getQuery();
-            } else {
-                if ($rel->getPath()[0] === '/') {
-                    $targetPath = $rel->getPath();
-                } else {
-                    if ($targetAuthority != '' && $base->getPath() === '') {
-                        $targetPath = '/'.$rel->getPath();
-                    } else {
-                        $lastSlashPos = strrpos($base->getPath(), '/');
-                        if ($lastSlashPos === false) {
-                            $targetPath = $rel->getPath();
-                        } else {
-                            $targetPath = substr($base->getPath(), 0, $lastSlashPos + 1).$rel->getPath();
-                        }
-                    }
-                }
-                $targetPath = self::removeDotSegments($targetPath);
-                $targetQuery = $rel->getQuery();
-            }
+            return $rel
+                ->withScheme($base->getScheme())
+                ->withPath(self::removeDotSegments($rel->getPath()));
         }
 
-        return new Uri(Uri::composeComponents(
-            $base->getScheme(),
-            $targetAuthority,
-            $targetPath,
-            $targetQuery,
-            $rel->getFragment()
-        ));
+        if ($rel->getPath() === '') {
+            $targetPath = $base->getPath();
+            $targetQuery = $rel->getQuery() != '' ? $rel->getQuery() : $base->getQuery();
+        } else {
+            if ($rel->getPath()[0] === '/') {
+                $targetPath = $rel->getPath();
+            } else {
+                if ($base->getAuthority() != '' && $base->getPath() === '') {
+                    $targetPath = '/'.$rel->getPath();
+                } else {
+                    $lastSlashPos = strrpos($base->getPath(), '/');
+                    if ($lastSlashPos === false) {
+                        $targetPath = $rel->getPath();
+                    } else {
+                        $targetPath = substr($base->getPath(), 0, $lastSlashPos + 1).$rel->getPath();
+                    }
+                }
+            }
+            $targetPath = self::removeDotSegments($targetPath);
+            $targetQuery = $rel->getQuery();
+        }
+
+        return $base
+            ->withPath($targetPath)
+            ->withQuery($targetQuery)
+            ->withFragment($rel->getFragment());
     }
 
     /**

--- a/tests/UriResolverTest.php
+++ b/tests/UriResolverTest.php
@@ -32,6 +32,40 @@ class UriResolverTest extends TestCase
         self::assertSame($expectedTarget, (string) UriResolver::resolve($baseUri, $targetUri));
     }
 
+    public function testResolveReturnsBaseUriWhenReferenceIsEmpty(): void
+    {
+        $baseUri = self::customUri('https://example.com/a/b');
+
+        self::assertSame($baseUri, UriResolver::resolve($baseUri, new Uri('')));
+    }
+
+    public function testResolvePreservesReferenceUriImplementationWhenReferenceIsAbsolute(): void
+    {
+        $referenceUri = self::customUri('http://other.example/a/../b?x=y#fragment');
+        $targetUri = UriResolver::resolve(new Uri('https://example.com/a/b'), $referenceUri);
+
+        self::assertSame(get_class($referenceUri), get_class($targetUri));
+        self::assertSame('http://other.example/b?x=y#fragment', (string) $targetUri);
+    }
+
+    public function testResolvePreservesReferenceUriImplementationWhenReferenceHasAuthority(): void
+    {
+        $referenceUri = self::customUri('//other.example/a/../b?x=y#fragment');
+        $targetUri = UriResolver::resolve(new Uri('https://example.com/a/b'), $referenceUri);
+
+        self::assertSame(get_class($referenceUri), get_class($targetUri));
+        self::assertSame('https://other.example/b?x=y#fragment', (string) $targetUri);
+    }
+
+    public function testResolvePreservesBaseUriImplementationWhenReferenceInheritsAuthority(): void
+    {
+        $baseUri = self::customUri('https://example.com/a/b/c?old=1#old');
+        $targetUri = UriResolver::resolve($baseUri, new Uri('../d?new=1#new'));
+
+        self::assertSame(get_class($baseUri), get_class($targetUri));
+        self::assertSame('https://example.com/a/d?new=1#new', (string) $targetUri);
+    }
+
     /**
      * @dataProvider getResolveTestCases
      */
@@ -206,5 +240,11 @@ class UriResolverTest extends TestCase
             // absolute target URI without authority but base URI has one
             ['urn://a/b/',      'urn:/b/',      'urn:/b/'],
         ];
+    }
+
+    private static function customUri(string $uri): UriInterface
+    {
+        return new class($uri) extends Uri {
+        };
     }
 }

--- a/tests/UriResolverTest.php
+++ b/tests/UriResolverTest.php
@@ -66,6 +66,56 @@ class UriResolverTest extends TestCase
         self::assertSame('https://example.com/a/d?new=1#new', (string) $targetUri);
     }
 
+    public function testResolvePreservesBaseUriImplementationWhenReferenceHasAbsolutePath(): void
+    {
+        $baseUri = self::customUri('https://example.com/a/b/c?old=1#old');
+        $targetUri = UriResolver::resolve($baseUri, new Uri('/d/e?new=1#new'));
+
+        self::assertSame(get_class($baseUri), get_class($targetUri));
+        self::assertSame('https://example.com/d/e?new=1#new', (string) $targetUri);
+    }
+
+    public function testResolvePreservesBaseUriImplementationWhenReferenceHasNoPath(): void
+    {
+        $baseUri = self::customUri('https://example.com/a/b/c?old=1#old');
+        $targetUriWithQuery = UriResolver::resolve($baseUri, new Uri('?new=1#new'));
+
+        self::assertSame(get_class($baseUri), get_class($targetUriWithQuery));
+        self::assertSame('https://example.com/a/b/c?new=1#new', (string) $targetUriWithQuery);
+
+        $targetUriWithoutQuery = UriResolver::resolve($baseUri, new Uri('#new'));
+
+        self::assertSame(get_class($baseUri), get_class($targetUriWithoutQuery));
+        self::assertSame('https://example.com/a/b/c?old=1#new', (string) $targetUriWithoutQuery);
+    }
+
+    public function testResolvePreservesBaseUriImplementationWhenBaseHasAuthorityAndEmptyPath(): void
+    {
+        $baseUri = self::customUri('https://example.com');
+        $targetUri = UriResolver::resolve($baseUri, new Uri('a'));
+
+        self::assertSame(get_class($baseUri), get_class($targetUri));
+        self::assertSame('https://example.com/a', (string) $targetUri);
+    }
+
+    public function testResolvePreservesBaseUriImplementationWhenBasePathHasNoSlash(): void
+    {
+        $baseUri = self::customUri('urn:no-slash');
+        $targetUri = UriResolver::resolve($baseUri, new Uri('e'));
+
+        self::assertSame(get_class($baseUri), get_class($targetUri));
+        self::assertSame('urn:e', (string) $targetUri);
+    }
+
+    public function testResolvePreservesReferenceUriImplementationWhenReferenceHasAuthorityAndBaseHasNoScheme(): void
+    {
+        $referenceUri = self::customUri('//other.example/a/../b?x=y#fragment');
+        $targetUri = UriResolver::resolve(new Uri('/'), $referenceUri);
+
+        self::assertSame(get_class($referenceUri), get_class($targetUri));
+        self::assertSame('//other.example/b?x=y#fragment', (string) $targetUri);
+    }
+
     /**
      * @dataProvider getResolveTestCases
      */


### PR DESCRIPTION
Preserves custom URI implementations in `UriResolver::resolve()` by applying resolved URI changes through PSR-7 `with*()` methods instead of constructing a concrete Guzzle URI.

Tests:
- `docker run -w /data -v ${PWD}:/data:delegated --rm registry.gitlab.com/grahamcampbell/php:7.4-base vendor/bin/phpunit tests/UriResolverTest.php`
- `docker run -w /data -v ${PWD}:/data:delegated --rm registry.gitlab.com/grahamcampbell/php:7.4-base vendor/bin/phpunit`