### PR TITLE
Harden ServerRequest globals handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 2.10.0 - Unreleased
 
-### Fixed
-
-- Harden `ServerRequest::fromGlobals()` against malformed `$_SERVER` values
-
 ### Changed
 
 - Preserve custom request implementations in `Utils::modifyRequest()`
 - Preserve custom URI implementations in `UriResolver::resolve()`
 - Make `Uri::__toString()` side-effect-free
+- Harden `ServerRequest::fromGlobals()` against malformed `$_SERVER` values
 
 ## 2.9.1 - 2026-05-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Harden `ServerRequest::fromGlobals()` against malformed `$_SERVER` values
 - Preserve custom request implementations in `Utils::modifyRequest()`
 - Preserve custom URI implementations in `UriResolver::resolve()`
 - Make `Uri::__toString()` side-effect-free
-- Harden `ServerRequest::fromGlobals()` against malformed `$_SERVER` values
 
 ## 2.9.1 - 2026-05-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 2.10.0 - Unreleased
 
+### Fixed
+
+- Harden `ServerRequest::fromGlobals()` against malformed `$_SERVER` values
+
 ### Changed
 
 - Preserve custom request implementations in `Utils::modifyRequest()`

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -205,48 +205,6 @@ parameters:
 			path: src/ServerRequest.php
 
 		-
-			message: '#^Parameter \#1 \$authority of static method GuzzleHttp\\Psr7\\ServerRequest\:\:extractHostAndPortFromAuthority\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/ServerRequest.php
-
-		-
-			message: '#^Parameter \#1 \$host of method GuzzleHttp\\Psr7\\Uri\:\:withHost\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 2
-			path: src/ServerRequest.php
-
-		-
-			message: '#^Parameter \#1 \$method of class GuzzleHttp\\Psr7\\ServerRequest constructor expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/ServerRequest.php
-
-		-
-			message: '#^Parameter \#1 \$port of method GuzzleHttp\\Psr7\\Uri\:\:withPort\(\) expects int\|null, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/ServerRequest.php
-
-		-
-			message: '#^Parameter \#1 \$query of method GuzzleHttp\\Psr7\\Uri\:\:withQuery\(\) expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/ServerRequest.php
-
-		-
-			message: '#^Parameter \#2 \$str of function explode expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/ServerRequest.php
-
-		-
-			message: '#^Parameter \#3 \$subject of function str_replace expects array\<string\>\|string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/ServerRequest.php
-
-		-
 			message: '#^Offset ''size'' on array\{0\: int, 1\: int, 2\: int, 3\: int, 4\: int, 5\: int, 6\: int, 7\: int, \.\.\.\} in isset\(\) always exists and is not nullable\.$#'
 			identifier: isset.offset
 			count: 1

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -165,11 +165,12 @@ class ServerRequest extends Request implements ServerRequestInterface
      */
     public static function fromGlobals(): ServerRequestInterface
     {
-        $method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+        $method = self::getServerParam('REQUEST_METHOD') ?? 'GET';
         $headers = getallheaders();
         $uri = self::getUriFromGlobals();
         $body = new CachingStream(new LazyOpenStream('php://input', 'r+'));
-        $protocol = isset($_SERVER['SERVER_PROTOCOL']) ? str_replace('HTTP/', '', $_SERVER['SERVER_PROTOCOL']) : '1.1';
+        $serverProtocol = self::getServerParam('SERVER_PROTOCOL');
+        $protocol = $serverProtocol !== null ? str_replace('HTTP/', '', $serverProtocol) : '1.1';
 
         $serverRequest = new ServerRequest($method, $uri, $headers, $body, $protocol, $_SERVER);
 
@@ -180,11 +181,19 @@ class ServerRequest extends Request implements ServerRequestInterface
             ->withUploadedFiles(self::normalizeFiles($_FILES));
     }
 
+    private static function getServerParam(string $key): ?string
+    {
+        return isset($_SERVER[$key]) && is_string($_SERVER[$key]) ? $_SERVER[$key] : null;
+    }
+
+    /**
+     * @return array{0: string|null, 1: int|null}
+     */
     private static function extractHostAndPortFromAuthority(string $authority): array
     {
         $uri = 'http://'.$authority;
         $parts = parse_url($uri);
-        if (false === $parts) {
+        if (!is_array($parts)) {
             return [null, null];
         }
 
@@ -201,11 +210,13 @@ class ServerRequest extends Request implements ServerRequestInterface
     {
         $uri = new Uri('');
 
-        $uri = $uri->withScheme(!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off' ? 'https' : 'http');
+        $https = self::getServerParam('HTTPS');
+        $uri = $uri->withScheme(!empty($https) && $https !== 'off' ? 'https' : 'http');
 
         $hasPort = false;
-        if (isset($_SERVER['HTTP_HOST'])) {
-            [$host, $port] = self::extractHostAndPortFromAuthority($_SERVER['HTTP_HOST']);
+        $authority = self::getServerParam('HTTP_HOST');
+        if ($authority !== null) {
+            [$host, $port] = self::extractHostAndPortFromAuthority($authority);
             if ($host !== null) {
                 $uri = $uri->withHost($host);
             }
@@ -214,19 +225,21 @@ class ServerRequest extends Request implements ServerRequestInterface
                 $hasPort = true;
                 $uri = $uri->withPort($port);
             }
-        } elseif (isset($_SERVER['SERVER_NAME'])) {
-            $uri = $uri->withHost($_SERVER['SERVER_NAME']);
-        } elseif (isset($_SERVER['SERVER_ADDR'])) {
-            $uri = $uri->withHost($_SERVER['SERVER_ADDR']);
+        } elseif (($serverName = self::getServerParam('SERVER_NAME')) !== null) {
+            $uri = $uri->withHost($serverName);
+        } elseif (($serverAddr = self::getServerParam('SERVER_ADDR')) !== null) {
+            $uri = $uri->withHost($serverAddr);
         }
 
-        if (!$hasPort && isset($_SERVER['SERVER_PORT'])) {
-            $uri = $uri->withPort($_SERVER['SERVER_PORT']);
+        $serverPort = self::getServerParam('SERVER_PORT');
+        if (!$hasPort && $serverPort !== null && preg_match('/^[+-]?\d+$/', $serverPort) === 1) {
+            $uri = $uri->withPort((int) $serverPort);
         }
 
         $hasQuery = false;
-        if (isset($_SERVER['REQUEST_URI'])) {
-            $requestUriParts = explode('?', $_SERVER['REQUEST_URI'], 2);
+        $requestUri = self::getServerParam('REQUEST_URI');
+        if ($requestUri !== null) {
+            $requestUriParts = explode('?', $requestUri, 2);
             $uri = $uri->withPath($requestUriParts[0]);
             if (isset($requestUriParts[1])) {
                 $hasQuery = true;
@@ -234,8 +247,9 @@ class ServerRequest extends Request implements ServerRequestInterface
             }
         }
 
-        if (!$hasQuery && isset($_SERVER['QUERY_STRING'])) {
-            $uri = $uri->withQuery($_SERVER['QUERY_STRING']);
+        $queryString = self::getServerParam('QUERY_STRING');
+        if (!$hasQuery && $queryString !== null) {
+            $uri = $uri->withQuery($queryString);
         }
 
         return $uri;

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -358,9 +358,33 @@ class ServerRequestTest extends TestCase
                 'https://www.example.org:8324/blog/article.php?id=10&user=foo',
                 array_merge($server, ['SERVER_PORT' => '8324']),
             ],
+            'Invalid SERVER_PORT is ignored instead of coerced to zero' => [
+                'https://www.example.org/blog/article.php?id=10&user=foo',
+                array_merge($server, ['SERVER_PORT' => 'not-a-port']),
+            ],
+            'Non-string SERVER_PORT is ignored' => [
+                'https://www.example.org/blog/article.php?id=10&user=foo',
+                array_merge($server, ['SERVER_PORT' => ['443']]),
+            ],
+            'Non-string HTTP_HOST falls back to SERVER_NAME' => [
+                'https://www.example.org/blog/article.php?id=10&user=foo',
+                array_merge($server, ['HTTP_HOST' => ['www.example.org']]),
+            ],
+            'Non-string SERVER_NAME falls back to SERVER_ADDR' => [
+                'https://217.112.82.20/blog/article.php?id=10&user=foo',
+                array_merge($server, ['HTTP_HOST' => null, 'SERVER_NAME' => ['www.example.org']]),
+            ],
             'REQUEST_URI missing query string' => [
                 'https://www.example.org/blog/article.php?id=10&user=foo',
                 array_merge($server, ['REQUEST_URI' => '/blog/article.php']),
+            ],
+            'Non-string REQUEST_URI is treated as missing' => [
+                'https://www.example.org?id=10&user=foo',
+                array_merge($server, ['REQUEST_URI' => ['bad']]),
+            ],
+            'Non-string QUERY_STRING is treated as missing' => [
+                'https://www.example.org/blog/article.php',
+                array_merge($server, ['REQUEST_URI' => '/blog/article.php', 'QUERY_STRING' => ['bad']]),
             ],
             'Empty server variable' => [
                 'http://localhost',
@@ -459,6 +483,23 @@ class ServerRequestTest extends TestCase
         ];
 
         self::assertEquals($expectedFiles, $server->getUploadedFiles());
+    }
+
+    public function testFromGlobalsDefaultsNonStringMethodAndProtocol(): void
+    {
+        $_SERVER = [
+            'REQUEST_METHOD' => ['POST'],
+            'SERVER_PROTOCOL' => ['HTTP/1.1'],
+            'REQUEST_URI' => '/',
+            'SERVER_PORT' => '80',
+        ];
+
+        $_COOKIE = $_POST = $_GET = $_FILES = [];
+
+        $server = ServerRequest::fromGlobals();
+
+        self::assertSame('GET', $server->getMethod());
+        self::assertSame('1.1', $server->getProtocolVersion());
     }
 
     public function testUploadedFiles(): void


### PR DESCRIPTION
This hardens ServerRequest::fromGlobals() and getUriFromGlobals() so malformed values in $_SERVER are treated defensively instead of being passed straight into request and URI construction. Non-numeric SERVER_PORT values are ignored rather than being coerced to port 0, and the PR includes regression coverage plus the matching PHPStan baseline cleanup.