### PR TITLE
Use native stream URI for size cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Harden `ServerRequest::fromGlobals()` against malformed `$_SERVER` values
+- Prevent custom stream metadata from affecting internal size handling
 - Preserve custom request implementations in `Utils::modifyRequest()`
 - Preserve custom URI implementations in `UriResolver::resolve()`
 - Make `Uri::__toString()` side-effect-free

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -217,12 +217,6 @@ parameters:
 			path: src/Stream.php
 
 		-
-			message: '#^Property GuzzleHttp\\Psr7\\Stream\:\:\$uri \(string\|null\) does not accept mixed\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: src/Stream.php
-
-		-
 			message: '#^Unreachable statement \- code above always terminates\.$#'
 			identifier: deadCode.unreachable
 			count: 1

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -63,7 +63,7 @@ class Stream implements StreamInterface
         $this->seekable = $meta['seekable'];
         $this->readable = (bool) preg_match(self::READABLE_MODES, $meta['mode']);
         $this->writable = (bool) preg_match(self::WRITABLE_MODES, $meta['mode']);
-        $this->uri = $this->getMetadata('uri');
+        $this->uri = $meta['uri'] ?? null;
     }
 
     /**

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -321,6 +321,14 @@ class UtilsTest extends TestCase
         self::assertArrayHasKey('hwm', $s->getMetadata());
     }
 
+    public function testCustomUriMetadataDoesNotAffectStreamSize(): void
+    {
+        $s = Psr7\Utils::streamFor('foo', ['metadata' => ['uri' => []]]);
+
+        self::assertSame([], $s->getMetadata('uri'));
+        self::assertSame(3, $s->getSize());
+    }
+
     public function testCanSetSize(): void
     {
         $s = Psr7\Utils::streamFor('', ['size' => 10]);


### PR DESCRIPTION
This keeps Stream's internal stat-cache URI tied to the native PHP stream metadata instead of allowing custom metadata['uri'] to override it. Custom metadata is still returned unchanged from getMetadata(), but it can no longer make getSize() pass a non-string URI into clearstatcache(). The PR includes a regression test and removes the matching PHPStan baseline entry.