### PR TITLE
Throw when StreamWrapper resource creation fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Harden `ServerRequest::fromGlobals()` against malformed `$_SERVER` values
 - Prevent custom stream metadata from affecting internal size handling
+- Throw when `StreamWrapper::getResource()` cannot create a resource
 - Preserve custom request implementations in `Utils::modifyRequest()`
 - Preserve custom URI implementations in `UriResolver::resolve()`
 - Make `Uri::__toString()` side-effect-free

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -223,12 +223,6 @@ parameters:
 			path: src/Stream.php
 
 		-
-			message: '#^Method GuzzleHttp\\Psr7\\StreamWrapper\:\:getResource\(\) should return resource but returns resource\|false\.$#'
-			identifier: return.type
-			count: 1
-			path: src/StreamWrapper.php
-
-		-
 			message: '#^Method GuzzleHttp\\Psr7\\UploadedFile\:\:isStringNotEmpty\(\) has parameter \$param with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1

--- a/src/StreamWrapper.php
+++ b/src/StreamWrapper.php
@@ -44,7 +44,13 @@ final class StreamWrapper
                 .'writable, or both.');
         }
 
-        return fopen('guzzle://stream', $mode, false, self::createStreamContext($stream));
+        $resource = @fopen('guzzle://stream', $mode, false, self::createStreamContext($stream));
+
+        if ($resource === false) {
+            throw new \RuntimeException('Unable to create stream resource');
+        }
+
+        return $resource;
     }
 
     /**

--- a/tests/StreamWrapperTest.php
+++ b/tests/StreamWrapperTest.php
@@ -102,6 +102,7 @@ class StreamWrapperTest extends TestCase
 
     /**
      * @runInSeparateProcess
+     *
      * @preserveGlobalState disabled
      */
     public function testGetResourceThrowsWhenFopenFails(): void

--- a/tests/StreamWrapperTest.php
+++ b/tests/StreamWrapperTest.php
@@ -100,6 +100,24 @@ class StreamWrapperTest extends TestCase
         self::assertFalse($result);
     }
 
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testGetResourceThrowsWhenFopenFails(): void
+    {
+        if (in_array('guzzle', stream_get_wrappers(), true)) {
+            stream_wrapper_unregister('guzzle');
+        }
+
+        self::assertTrue(stream_wrapper_register('guzzle', FailingGuzzleStreamWrapper::class));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Unable to create stream resource');
+
+        StreamWrapper::getResource(Utils::streamFor('foo'));
+    }
+
     public function testCanOpenReadonlyStream(): void
     {
         $stream = $this->createMock(StreamInterface::class);
@@ -198,5 +216,16 @@ class StreamWrapperTest extends TestCase
         $stream = Utils::streamFor($resource);
 
         $this->assertNull($stream->getSize());
+    }
+}
+
+final class FailingGuzzleStreamWrapper
+{
+    /** @var resource */
+    public $context;
+
+    public function stream_open(string $path, string $mode, int $options, ?string &$openedPath = null): bool
+    {
+        return false;
     }
 }


### PR DESCRIPTION
This makes StreamWrapper::getResource() follow its documented contract when fopen('guzzle://stream', ...) fails. Instead of leaking false to callers, it now throws a RuntimeException. The PR adds isolated coverage for that failure path and removes the matching PHPStan baseline entry.