### PR TITLE
Validate iterator chunks in streamFor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Validate iterator chunks passed to `Utils::streamFor()`
 - Stop adding default `Content-Length` headers to `multipart/form-data` parts to comply with RFC 7578 section 4.8
 
 ## 2.10.0 - 2026-05-19

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,6 +1,29 @@
 Guzzle PSR-7 Upgrade Guide
 ==========================
 
+2.x to 3.0
+----------
+
+#### Iterator-backed Streams
+
+`Utils::streamFor()` now validates values yielded by `Iterator` instances before
+passing them to the internal `PumpStream`. Scalar values, `null`, and stringable
+objects are converted to string chunks. Arrays, resources, and non-stringable
+objects now throw `UnexpectedValueException`.
+
+Iterator exhaustion is now the only EOF signal for iterator-backed streams.
+Yielding `false` or `null` no longer ends the stream; those values are converted
+to empty string chunks instead. If your iterator yielded `false` or `null` to
+stop streaming, update it to finish iteration instead.
+
+```php
+// Before: yielding false or null could stop an iterator-backed stream early.
+$stream = Utils::streamFor(new ArrayIterator([false, 'body']));
+
+// After: false and null are stream chunks. End the iterator to signal EOF.
+$stream = Utils::streamFor(new ArrayIterator(['body']));
+```
+
 1.x to 2.0
 ----------
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -283,12 +283,6 @@ parameters:
 			path: src/Utils.php
 
 		-
-			message: '#^Parameter \#1 \$source of class GuzzleHttp\\Psr7\\PumpStream constructor expects callable\(int\)\: \(string\|false\|null\), Closure\(\)\: mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Utils.php
-
-		-
 			message: '#^Unreachable statement \- code above always terminates\.$#'
 			identifier: deadCode.unreachable
 			count: 1

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -364,14 +364,22 @@ final class Utils
                 if ($resource instanceof StreamInterface) {
                     return $resource;
                 } elseif ($resource instanceof \Iterator) {
-                    return new PumpStream(function () use ($resource) {
+                    return new PumpStream(function (int $length) use ($resource) {
                         if (!$resource->valid()) {
                             return false;
                         }
                         $result = $resource->current();
                         $resource->next();
 
-                        return $result;
+                        if ($result === null || is_scalar($result)) {
+                            return (string) $result;
+                        }
+
+                        if (is_object($result) && method_exists($result, '__toString')) {
+                            return (string) $result;
+                        }
+
+                        throw new \UnexpectedValueException('Iterator must yield scalar, null, or stringable values');
                     }, $options);
                 } elseif (method_exists($resource, '__toString')) {
                     return self::streamFor((string) $resource, $options);

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -351,6 +351,61 @@ class UtilsTest extends TestCase
         self::assertSame(9, $p->tell());
     }
 
+    public function testIteratorBasedStreamDoesNotTreatFalseAsEof(): void
+    {
+        $stream = Psr7\Utils::streamFor(new \ArrayIterator([false, 'x']));
+
+        self::assertSame('x', $stream->getContents());
+    }
+
+    public function testIteratorBasedStreamDoesNotTreatNullAsEof(): void
+    {
+        $stream = Psr7\Utils::streamFor(new \ArrayIterator([null, 'x']));
+
+        self::assertSame('x', $stream->getContents());
+    }
+
+    public function testIteratorBasedStreamCastsScalarValuesToStrings(): void
+    {
+        $stream = Psr7\Utils::streamFor(new \ArrayIterator([1, 2.5, true, false, 'x']));
+
+        self::assertSame('12.51x', $stream->getContents());
+    }
+
+    public function testIteratorBasedStreamCastsStringableObjectsToStrings(): void
+    {
+        $value = new class {
+            public function __toString(): string
+            {
+                return 'foo';
+            }
+        };
+
+        $stream = Psr7\Utils::streamFor(new \ArrayIterator([$value, 'bar']));
+
+        self::assertSame('foobar', $stream->getContents());
+    }
+
+    public function testIteratorBasedStreamRejectsArrayValues(): void
+    {
+        $stream = Psr7\Utils::streamFor(new \ArrayIterator([['x']]));
+
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('Iterator must yield scalar, null, or stringable values');
+
+        $stream->getContents();
+    }
+
+    public function testIteratorBasedStreamRejectsNonStringableObjects(): void
+    {
+        $stream = Psr7\Utils::streamFor(new \ArrayIterator([new \stdClass()]));
+
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('Iterator must yield scalar, null, or stringable values');
+
+        $stream->getContents();
+    }
+
     public function testConvertsRequestsToStrings(): void
     {
         $request = new Psr7\Request('PUT', 'http://foo.com/hi?123', [


### PR DESCRIPTION
This makes iterator-backed streams normalize yielded chunks before handing them to PumpStream. Scalar, null, and stringable values become string chunks, while unsupported values now fail with a clear exception instead of being treated as EOF or failing later inside the buffer. The upgrading guide calls out the behavior change for iterators that previously yielded false or null to end the stream.