### PR TITLE
Fix stringable object detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Validate iterator chunks passed to `Utils::streamFor()`
 - Stop adding default `Content-Length` headers to `multipart/form-data` parts to comply with RFC 7578 section 4.8
 
+### Fixed
+
+- Do not treat objects with `__call()` as stringable in `Utils::streamFor()`
+
 ## 2.10.0 - 2026-05-19
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Validate iterator chunks passed to `Utils::streamFor()`
 - Stop adding default `Content-Length` headers to `multipart/form-data` parts to comply with RFC 7578 section 4.8
 
-### Fixed
-
-- Do not treat objects with `__call()` as stringable in `Utils::streamFor()`
-
 ## 2.10.0 - 2026-05-19
 
 ### Changed

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -375,13 +375,13 @@ final class Utils
                             return (string) $result;
                         }
 
-                        if (is_object($result) && method_exists($result, '__toString')) {
+                        if (is_object($result) && method_exists($result, '__toString') && is_callable([$result, '__toString'])) {
                             return (string) $result;
                         }
 
                         throw new \UnexpectedValueException('Iterator must yield scalar, null, or stringable values');
                     }, $options);
-                } elseif (method_exists($resource, '__toString')) {
+                } elseif (method_exists($resource, '__toString') && is_callable([$resource, '__toString'])) {
                     return self::streamFor((string) $resource, $options);
                 }
                 break;

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -301,6 +301,20 @@ class UtilsTest extends TestCase
         self::assertSame('foo', (string) $s);
     }
 
+    public function testFactoryDoesNotCreateFromObjectWithMagicCall(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        Psr7\Utils::streamFor(new class() {
+            /**
+             * @param mixed[] $arguments
+             */
+            public function __call(string $name, array $arguments): void
+            {
+            }
+        });
+    }
+
     public function testCreatePassesThrough(): void
     {
         $s = Psr7\Utils::streamFor('foo');
@@ -399,6 +413,23 @@ class UtilsTest extends TestCase
     public function testIteratorBasedStreamRejectsNonStringableObjects(): void
     {
         $stream = Psr7\Utils::streamFor(new \ArrayIterator([new \stdClass()]));
+
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('Iterator must yield scalar, null, or stringable values');
+
+        $stream->getContents();
+    }
+
+    public function testIteratorBasedStreamRejectsObjectWithMagicCall(): void
+    {
+        $stream = Psr7\Utils::streamFor(new \ArrayIterator([new class() {
+            /**
+             * @param mixed[] $arguments
+             */
+            public function __call(string $name, array $arguments): void
+            {
+            }
+        }]));
 
         $this->expectException(\UnexpectedValueException::class);
         $this->expectExceptionMessage('Iterator must yield scalar, null, or stringable values');


### PR DESCRIPTION
Summary: Updates Utils::streamFor() to require an actual callable __toString() method before casting objects to strings; applies the same guard to iterator-backed stream chunks; adds regression tests for objects with __call() but no __toString(). Verification: git diff --check; vendor/bin/phpunit tests/UtilsTest.php.