### PR TITLE
Validate Query::build values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Validate iterator chunks passed to `Utils::streamFor()`
+- Validate unsupported values passed to `Query::build()`
 - Stop adding default `Content-Length` headers to `multipart/form-data` parts to comply with RFC 7578 section 4.8
 
 ## 2.10.0 - 2026-05-19

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,6 +4,30 @@ Guzzle PSR-7 Upgrade Guide
 2.x to 3.0
 ----------
 
+#### Query Builder Values
+
+`Query::build()` now rejects unsupported values instead of relying on PHP string
+casts. Query values must be scalar, `null`, stringable objects, or flat arrays of
+those values.
+
+Nested arrays, resources, and objects without `__toString()` now throw
+`InvalidArgumentException`.
+
+```php
+// Before: could produce warnings or silently mangle the value.
+Query::build(['filter' => ['name' => ['value']]]);
+
+// After: use explicit query keys for nested query shapes.
+Query::build(['filter[name]' => 'value']);
+```
+
+Flat arrays are still supported for repeated query parameters:
+
+```php
+Query::build(['tag' => ['a', 'b']]);
+// tag=a&tag=b
+```
+
 #### Iterator-backed Streams
 
 `Utils::streamFor()` now validates values yielded by `Iterator` instances before

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -193,12 +193,6 @@ parameters:
 			path: src/PumpStream.php
 
 		-
-			message: '#^Cannot cast mixed to string\.$#'
-			identifier: cast.string
-			count: 1
-			path: src/Query.php
-
-		-
 			message: '#^Method GuzzleHttp\\Psr7\\ServerRequest\:\:normalizeNestedFileSpec\(\) should return array\<Psr\\Http\\Message\\UploadedFileInterface\> but returns array\<int\|string, array\<Psr\\Http\\Message\\UploadedFileInterface\>\|Psr\\Http\\Message\\UploadedFileInterface\>\.$#'
 			identifier: return.type
 			count: 1

--- a/src/Query.php
+++ b/src/Query.php
@@ -89,24 +89,22 @@ final class Query
             throw new \InvalidArgumentException('Invalid type');
         }
 
-        $castBool = $treatBoolsAsInts ? static function ($v) { return (int) $v; } : static function ($v) { return $v ? 'true' : 'false'; };
-
         $qs = '';
         foreach ($params as $k => $v) {
             $k = $encoder((string) $k);
             if (!is_array($v)) {
                 $qs .= $k;
-                $v = is_bool($v) ? $castBool($v) : $v;
+                $v = self::normalizeValue($v, $treatBoolsAsInts);
                 if ($v !== null) {
-                    $qs .= '='.$encoder((string) $v);
+                    $qs .= '='.$encoder($v);
                 }
                 $qs .= '&';
             } else {
                 foreach ($v as $vv) {
                     $qs .= $k;
-                    $vv = is_bool($vv) ? $castBool($vv) : $vv;
+                    $vv = self::normalizeValue($vv, $treatBoolsAsInts);
                     if ($vv !== null) {
-                        $qs .= '='.$encoder((string) $vv);
+                        $qs .= '='.$encoder($vv);
                     }
                     $qs .= '&';
                 }
@@ -114,5 +112,29 @@ final class Query
         }
 
         return $qs ? (string) substr($qs, 0, -1) : '';
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private static function normalizeValue($value, bool $treatBoolsAsInts): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (is_bool($value)) {
+            return $treatBoolsAsInts ? (string) (int) $value : ($value ? 'true' : 'false');
+        }
+
+        if (is_scalar($value)) {
+            return (string) $value;
+        }
+
+        if (is_object($value) && method_exists($value, '__toString')) {
+            return $value->__toString();
+        }
+
+        throw new \InvalidArgumentException('Query string values must be scalar, null, or stringable objects');
     }
 }

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -121,4 +121,60 @@ class QueryTest extends TestCase
         ];
         self::assertEquals('foo=true&bar=false', Psr7\Query::build($data, PHP_QUERY_RFC3986, false));
     }
+
+    public function testBuildAcceptsStringableObjectValue(): void
+    {
+        $value = new class {
+            public function __toString(): string
+            {
+                return 'bar baz';
+            }
+        };
+
+        self::assertSame('foo=bar%20baz', Psr7\Query::build(['foo' => $value]));
+    }
+
+    public function testBuildAcceptsStringableObjectArrayValue(): void
+    {
+        $value = new class {
+            public function __toString(): string
+            {
+                return 'bar';
+            }
+        };
+
+        self::assertSame('foo=bar&foo=baz', Psr7\Query::build(['foo' => [$value, 'baz']]));
+    }
+
+    public function testBuildRejectsNestedArrayValue(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Query string values must be scalar, null, or stringable objects');
+
+        Psr7\Query::build(['foo' => ['bar' => ['baz']]]);
+    }
+
+    public function testBuildRejectsNestedListValue(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Query string values must be scalar, null, or stringable objects');
+
+        Psr7\Query::build(['foo' => [['bar']]]);
+    }
+
+    public function testBuildRejectsUnsupportedObjectValue(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Query string values must be scalar, null, or stringable objects');
+
+        Psr7\Query::build(['foo' => new \stdClass()]);
+    }
+
+    public function testBuildRejectsUnsupportedObjectArrayValue(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Query string values must be scalar, null, or stringable objects');
+
+        Psr7\Query::build(['foo' => ['bar', new \stdClass()]]);
+    }
 }


### PR DESCRIPTION
This makes Query::build() reject unsupported values instead of relying on PHP string casts that can mangle nested arrays or fail later with less useful errors. Scalar values, null, booleans, flat arrays, and stringable objects remain supported, and the upgrading guide documents the stricter input behavior for 3.0.