### PR TITLE
Fix modifyRequest with numeric header names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.10.1 - Upcoming
+
+### Fixed
+
+- Fix `Utils::modifyRequest()` with numeric header names
+
 ## 2.10.0 - 2026-05-19
 
 ### Changed

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -226,7 +226,7 @@ final class Utils
         if ($headers !== $new->getHeaders()) {
             foreach (array_keys($new->getHeaders()) as $header) {
                 /** @var RequestInterface */
-                $new = $new->withoutHeader($header);
+                $new = $new->withoutHeader((string) $header);
             }
 
             $addedHeaders = [];

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -672,6 +672,55 @@ class UtilsTest extends TestCase
         self::assertSame(['host' => ['custom', 'bar.com']], $modified->getHeaders());
     }
 
+    public function testModifyRequestPreservesNumericHeaderNames(): void
+    {
+        $request = new Psr7\Request('GET', 'http://example.com', ['123' => 'old']);
+
+        $modified = Psr7\Utils::modifyRequest($request, [
+            'set_headers' => ['X-Test' => '1'],
+        ]);
+
+        self::assertSame('old', $modified->getHeaderLine('123'));
+        self::assertSame('1', $modified->getHeaderLine('X-Test'));
+    }
+
+    public function testModifyRequestReplacesNumericHeaderNames(): void
+    {
+        $request = new Psr7\Request('GET', 'http://example.com', ['123' => 'old']);
+
+        $modified = Psr7\Utils::modifyRequest($request, [
+            'set_headers' => ['123' => 'new'],
+        ]);
+
+        self::assertSame('new', $modified->getHeaderLine('123'));
+    }
+
+    public function testModifyRequestRemovesNumericHeaderNames(): void
+    {
+        $request = new Psr7\Request('GET', 'http://example.com', ['123' => 'old']);
+
+        $modified = Psr7\Utils::modifyRequest($request, [
+            'remove_headers' => ['123'],
+        ]);
+
+        self::assertFalse($modified->hasHeader('123'));
+    }
+
+    public function testModifyRequestPreservesZeroHeaderNameWithoutParsingListStyleHeader(): void
+    {
+        $request = new Psr7\Request('POST', 'http://example.com', [
+            'Content-type: application/x-www-form-urlencoded',
+        ]);
+
+        $modified = Psr7\Utils::modifyRequest($request, [
+            'set_headers' => ['X-Test' => '1'],
+        ]);
+
+        self::assertSame('Content-type: application/x-www-form-urlencoded', $modified->getHeaderLine('0'));
+        self::assertSame('', $modified->getHeaderLine('Content-Type'));
+        self::assertSame('1', $modified->getHeaderLine('X-Test'));
+    }
+
     public function testModifyServerRequestWithUploadedFiles(): void
     {
         $request = new Psr7\ServerRequest('GET', 'http://example.com/bla');

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -706,21 +706,6 @@ class UtilsTest extends TestCase
         self::assertFalse($modified->hasHeader('123'));
     }
 
-    public function testModifyRequestPreservesZeroHeaderNameWithoutParsingListStyleHeader(): void
-    {
-        $request = new Psr7\Request('POST', 'http://example.com', [
-            'Content-type: application/x-www-form-urlencoded',
-        ]);
-
-        $modified = Psr7\Utils::modifyRequest($request, [
-            'set_headers' => ['X-Test' => '1'],
-        ]);
-
-        self::assertSame('Content-type: application/x-www-form-urlencoded', $modified->getHeaderLine('0'));
-        self::assertSame('', $modified->getHeaderLine('Content-Type'));
-        self::assertSame('1', $modified->getHeaderLine('X-Test'));
-    }
-
     public function testModifyServerRequestWithUploadedFiles(): void
     {
         $request = new Psr7\ServerRequest('GET', 'http://example.com/bla');


### PR DESCRIPTION
Fixes #666.

Utils::modifyRequest() was passing raw keys from getHeaders() into withoutHeader(). PHP converts numeric string header names to integer array keys, so an existing header like 123 could trigger a TypeError while replaying headers. This casts the key at the internal call site and adds regression coverage for numeric header names.