### PR TITLE
Dropped support for PHP 7.2 and 7.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.2'
+          php-version: '7.4'
           ini-values: error_reporting=E_ALL
           coverage: 'none'
           extensions: mbstring
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+        php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
 
     steps:
       - name: Set up PHP

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+        php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
 
     steps:
       - name: Set up PHP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Validate unsupported values passed to `Query::build()`
 - Stop adding default `Content-Length` headers to `multipart/form-data` parts to comply with RFC 7578 section 4.8
 
+### Removed
+
+- Dropped support for PHP 7.2 and 7.3
+
 ## 2.10.1 - 2026-05-20
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ composer require guzzlehttp/psr7
 |---------|---------------------|--------------|
 | 1.x     | EOL (2024-06-30)    | >=5.4,<8.2   |
 | 2.x     | Latest              | >=7.2.5,<8.6 |
+| 3.x     | Experimental        | >=7.4,<8.6   |
 
 See [UPGRADING.md](UPGRADING.md) for notes on upgrading from 1.x to 2.0.
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -270,10 +270,10 @@ of depending on package internals.
 its high-water mark. This keeps the method compatible with the `int` return type
 from `StreamInterface::write()`.
 
-Several stream `__toString()` implementations now catch `Throwable`. On PHP 7.4
-and newer, exceptions thrown during stringification are rethrown. Avoid relying
-on `(string) $stream` to hide read failures; call `getContents()` or `read()` and
-handle exceptions when failures are possible.
+Several stream `__toString()` implementations now allow exceptions thrown during
+stringification to be rethrown. Avoid relying on `(string) $stream` to hide read
+failures; call `getContents()` or `read()` and handle exceptions when failures
+are possible.
 
 #### PSR-17 Factories
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,6 +4,14 @@ Guzzle PSR-7 Upgrade Guide
 2.x to 3.0
 ----------
 
+#### PHP Version and Dependencies
+
+Guzzle PSR-7 3.0 requires PHP `^7.4 || ^8.0`. Guzzle PSR-7 2.x supported PHP
+`^7.2.5 || ^8.0`.
+
+If your application still supports PHP 7.2 or 7.3, continue using Guzzle PSR-7
+2.x until your minimum PHP version is raised.
+
 #### URI Host and Scheme Validation
 
 URI hosts containing control characters, whitespace, URI delimiters, backslashes,

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^1.1 || ^2.0",
         "ralouphie/getallheaders": "^3.0"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,28 +1,10 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Unreachable statement \- code above always terminates\.$#'
-			identifier: deadCode.unreachable
-			count: 1
-			path: src/AppendStream.php
-
-		-
 			message: '#^Method GuzzleHttp\\Psr7\\BufferStream\:\:getSize\(\) never returns null so it can be removed from the return type\.$#'
 			identifier: return.unusedType
 			count: 1
 			path: src/BufferStream.php
-
-		-
-			message: '#^Unreachable statement \- code above always terminates\.$#'
-			identifier: deadCode.unreachable
-			count: 1
-			path: src/CachingStream.php
-
-		-
-			message: '#^Unreachable statement \- code above always terminates\.$#'
-			identifier: deadCode.unreachable
-			count: 1
-			path: src/DroppingStream.php
 
 		-
 			message: '#^Access to an undefined property GuzzleHttp\\Psr7\\FnStream\:\:\$_fn___toString\.$#'
@@ -115,34 +97,10 @@ parameters:
 			path: src/FnStream.php
 
 		-
-			message: '#^Unreachable statement \- code above always terminates\.$#'
-			identifier: deadCode.unreachable
-			count: 1
-			path: src/FnStream.php
-
-		-
 			message: '#^Call to function is_string\(\) with string will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
 			count: 1
 			path: src/Header.php
-
-		-
-			message: '#^Unreachable statement \- code above always terminates\.$#'
-			identifier: deadCode.unreachable
-			count: 1
-			path: src/InflateStream.php
-
-		-
-			message: '#^Unreachable statement \- code above always terminates\.$#'
-			identifier: deadCode.unreachable
-			count: 1
-			path: src/LazyOpenStream.php
-
-		-
-			message: '#^Unreachable statement \- code above always terminates\.$#'
-			identifier: deadCode.unreachable
-			count: 1
-			path: src/LimitStream.php
 
 		-
 			message: '#^PHPDoc tag @var with type array\<array\> is not subtype of native type list\<array\<string\>\>\.$#'
@@ -175,24 +133,6 @@ parameters:
 			path: src/Message.php
 
 		-
-			message: '#^Unreachable statement \- code above always terminates\.$#'
-			identifier: deadCode.unreachable
-			count: 1
-			path: src/MultipartStream.php
-
-		-
-			message: '#^Unreachable statement \- code above always terminates\.$#'
-			identifier: deadCode.unreachable
-			count: 1
-			path: src/NoSeekStream.php
-
-		-
-			message: '#^Unreachable statement \- code above always terminates\.$#'
-			identifier: deadCode.unreachable
-			count: 1
-			path: src/PumpStream.php
-
-		-
 			message: '#^Method GuzzleHttp\\Psr7\\ServerRequest\:\:normalizeNestedFileSpec\(\) should return array\<Psr\\Http\\Message\\UploadedFileInterface\> but returns array\<int\|string, array\<Psr\\Http\\Message\\UploadedFileInterface\>\|Psr\\Http\\Message\\UploadedFileInterface\>\.$#'
 			identifier: return.type
 			count: 1
@@ -208,12 +148,6 @@ parameters:
 			message: '#^Property GuzzleHttp\\Psr7\\Stream\:\:\$stream \(resource\) in isset\(\) is not nullable\.$#'
 			identifier: isset.property
 			count: 10
-			path: src/Stream.php
-
-		-
-			message: '#^Unreachable statement \- code above always terminates\.$#'
-			identifier: deadCode.unreachable
-			count: 1
 			path: src/Stream.php
 
 		-

--- a/src/AppendStream.php
+++ b/src/AppendStream.php
@@ -38,18 +38,9 @@ final class AppendStream implements StreamInterface
 
     public function __toString(): string
     {
-        try {
-            $this->rewind();
+        $this->rewind();
 
-            return $this->getContents();
-        } catch (\Throwable $e) {
-            if (\PHP_VERSION_ID >= 70400) {
-                throw $e;
-            }
-            trigger_error(sprintf('%s::__toString exception: %s', self::class, (string) $e), E_USER_ERROR);
-
-            return '';
-        }
+        return $this->getContents();
     }
 
     /**

--- a/src/FnStream.php
+++ b/src/FnStream.php
@@ -92,17 +92,8 @@ final class FnStream implements StreamInterface
 
     public function __toString(): string
     {
-        try {
-            /** @var string */
-            return ($this->_fn___toString)();
-        } catch (\Throwable $e) {
-            if (\PHP_VERSION_ID >= 70400) {
-                throw $e;
-            }
-            trigger_error(sprintf('%s::__toString exception: %s', self::class, (string) $e), E_USER_ERROR);
-
-            return '';
-        }
+        /** @var string */
+        return ($this->_fn___toString)();
     }
 
     public function close(): void

--- a/src/PumpStream.php
+++ b/src/PumpStream.php
@@ -53,16 +53,7 @@ final class PumpStream implements StreamInterface
 
     public function __toString(): string
     {
-        try {
-            return Utils::copyToString($this);
-        } catch (\Throwable $e) {
-            if (\PHP_VERSION_ID >= 70400) {
-                throw $e;
-            }
-            trigger_error(sprintf('%s::__toString exception: %s', self::class, (string) $e), E_USER_ERROR);
-
-            return '';
-        }
+        return Utils::copyToString($this);
     }
 
     public function close(): void

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -76,20 +76,11 @@ class Stream implements StreamInterface
 
     public function __toString(): string
     {
-        try {
-            if ($this->isSeekable()) {
-                $this->seek(0);
-            }
-
-            return $this->getContents();
-        } catch (\Throwable $e) {
-            if (\PHP_VERSION_ID >= 70400) {
-                throw $e;
-            }
-            trigger_error(sprintf('%s::__toString exception: %s', self::class, (string) $e), E_USER_ERROR);
-
-            return '';
+        if ($this->isSeekable()) {
+            $this->seek(0);
         }
+
+        return $this->getContents();
     }
 
     public function getContents(): string

--- a/src/StreamDecoratorTrait.php
+++ b/src/StreamDecoratorTrait.php
@@ -40,20 +40,11 @@ trait StreamDecoratorTrait
 
     public function __toString(): string
     {
-        try {
-            if ($this->isSeekable()) {
-                $this->seek(0);
-            }
-
-            return $this->getContents();
-        } catch (\Throwable $e) {
-            if (\PHP_VERSION_ID >= 70400) {
-                throw $e;
-            }
-            trigger_error(sprintf('%s::__toString exception: %s', self::class, (string) $e), E_USER_ERROR);
-
-            return '';
+        if ($this->isSeekable()) {
+            $this->seek(0);
         }
+
+        return $this->getContents();
     }
 
     public function getContents(): string

--- a/tests/AppendStreamTest.php
+++ b/tests/AppendStreamTest.php
@@ -176,10 +176,7 @@ class AppendStreamTest extends TestCase
         self::assertNull($a->getSize());
     }
 
-    /**
-     * @requires PHP < 7.4
-     */
-    public function testCatchesExceptionsWhenCastingToString(): void
+    public function testThrowsExceptionsWhenCastingToString(): void
     {
         $s = $this->createMock(StreamInterface::class);
         $s->expects(self::once())
@@ -197,19 +194,10 @@ class AppendStreamTest extends TestCase
         $a = new AppendStream([$s]);
         self::assertFalse($a->eof());
 
-        $errors = [];
-        set_error_handler(static function (int $errorNumber, string $errorMessage) use (&$errors): bool {
-            $errors[] = ['number' => $errorNumber, 'message' => $errorMessage];
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('foo');
 
-            return true;
-        });
         (string) $a;
-
-        restore_error_handler();
-
-        self::assertCount(1, $errors);
-        self::assertSame(E_USER_ERROR, $errors[0]['number']);
-        self::assertStringStartsWith('GuzzleHttp\Psr7\AppendStream::__toString exception:', $errors[0]['message']);
     }
 
     public function testReturnsEmptyMetadata(): void

--- a/tests/FnStreamTest.php
+++ b/tests/FnStreamTest.php
@@ -102,27 +102,17 @@ class FnStreamTest extends TestCase
         unserialize($b);
     }
 
-    /**
-     * @requires PHP < 7.4
-     */
-    public function testThatConvertingStreamToStringWillTriggerErrorAndWillReturnEmptyString(): void
+    public function testThatConvertingStreamToStringWillThrowException(): void
     {
         $a = new FnStream([
             '__toString' => function (): void {
-                throw new \Exception();
+                throw new \Exception('foo');
             },
         ]);
 
-        $errors = [];
-        set_error_handler(function (int $errorNumber, string $errorMessage) use (&$errors): void {
-            $errors[] = ['number' => $errorNumber, 'message' => $errorMessage];
-        });
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('foo');
+
         (string) $a;
-
-        restore_error_handler();
-
-        self::assertCount(1, $errors);
-        self::assertSame(E_USER_ERROR, $errors[0]['number']);
-        self::assertStringStartsWith('GuzzleHttp\Psr7\FnStream::__toString exception:', $errors[0]['message']);
     }
 }

--- a/tests/PumpStreamTest.php
+++ b/tests/PumpStreamTest.php
@@ -80,26 +80,16 @@ class PumpStreamTest extends TestCase
         }
     }
 
-    /**
-     * @requires PHP < 7.4
-     */
-    public function testThatConvertingStreamToStringWillTriggerErrorAndWillReturnEmptyString(): void
+    public function testThatConvertingStreamToStringWillThrowException(): void
     {
         $p = Psr7\Utils::streamFor(function ($size): void {
-            throw new \Exception();
+            throw new \Exception('foo');
         });
         self::assertInstanceOf(PumpStream::class, $p);
 
-        $errors = [];
-        set_error_handler(function (int $errorNumber, string $errorMessage) use (&$errors): void {
-            $errors[] = ['number' => $errorNumber, 'message' => $errorMessage];
-        });
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('foo');
+
         (string) $p;
-
-        restore_error_handler();
-
-        self::assertCount(1, $errors);
-        self::assertSame(E_USER_ERROR, $errors[0]['number']);
-        self::assertStringStartsWith('GuzzleHttp\Psr7\PumpStream::__toString exception:', $errors[0]['message']);
     }
 }

--- a/tests/StreamDecoratorTraitTest.php
+++ b/tests/StreamDecoratorTraitTest.php
@@ -38,22 +38,17 @@ class StreamDecoratorTraitTest extends TestCase
         $this->b = new Str($this->a);
     }
 
-    /**
-     * @requires PHP < 7.4
-     */
-    public function testCatchesExceptionsWhenCastingToString(): void
+    public function testThrowsExceptionsWhenCastingToString(): void
     {
         $s = $this->createMock(Str::class);
         $s->expects(self::once())
             ->method('read')
             ->willThrowException(new \RuntimeException('foo'));
-        $msg = '';
-        set_error_handler(function (int $errNo, string $str) use (&$msg): void {
-            $msg = $str;
-        });
-        echo new Str($s);
-        restore_error_handler();
-        self::assertStringContainsString('foo', $msg);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('foo');
+
+        (string) new Str($s);
     }
 
     public function testToString(): void

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -226,22 +226,9 @@ class StreamTest extends TestCase
             $stream->getContents();
         });
 
-        if (\PHP_VERSION_ID >= 70400) {
-            $throws(function () use ($stream): void {
-                (string) $stream;
-            });
-        } else {
-            $errors = [];
-            set_error_handler(function (int $errorNumber, string $errorMessage) use (&$errors): void {
-                $errors[] = ['message' => $errorMessage, 'number' => $errorNumber];
-            });
-            self::assertSame('', (string) $stream);
-            restore_error_handler();
-
-            self::assertCount(1, $errors);
-            self::assertStringStartsWith('GuzzleHttp\Psr7\Stream::__toString exception', $errors[0]['message']);
-            self::assertSame(E_USER_ERROR, $errors[0]['number']);
-        }
+        $throws(function () use ($stream): void {
+            (string) $stream;
+        });
     }
 
     public function testStreamReadingWithZeroLength(): void

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -211,9 +211,6 @@ class UtilsTest extends TestCase
         Psr7\Utils::tryFopen('', 'r');
     }
 
-    /**
-     * @requires PHP 7.4
-     */
     public function testGetsContentsThrowExceptionWhenNotReadable(): void
     {
         $r = fopen(tempnam(sys_get_temp_dir(), 'guzzle-psr7-'), 'w');


### PR DESCRIPTION
This drops PHP 7.2 and 7.3 support for the 3.0 branch, matching the baseline already used by guzzle/promises 3.0. It raises the Composer constraint to PHP 7.4 or newer, removes the old CI matrix entries, documents the 3.x PHP range in the README and upgrade guide, and removes the PHP below 7.4 stringification fallback code that is no longer reachable.