### PR TITLE
Normalize modifyRequest header values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.10.2 - TBD
+
+### Fixed
+
+- Normalize `Utils::modifyRequest()` header values before applying them to requests
+
 ## 2.10.1 - 2026-05-20
 
 ### Fixed

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -232,6 +232,7 @@ final class Utils
             $addedHeaders = [];
             foreach ($headers as $header => $value) {
                 $header = (string) $header;
+                $value = self::normalizeHeaderValue($value);
                 $normalized = strtolower($header);
 
                 if (isset($addedHeaders[$normalized])) {
@@ -256,6 +257,47 @@ final class Utils
         }
 
         return $new;
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return string[]
+     */
+    private static function normalizeHeaderValue($value): array
+    {
+        if (!is_array($value)) {
+            return self::trimAndValidateHeaderValues([$value]);
+        }
+
+        return self::trimAndValidateHeaderValues($value);
+    }
+
+    /**
+     * @param mixed[] $values
+     *
+     * @return string[]
+     */
+    private static function trimAndValidateHeaderValues(array $values): array
+    {
+        return array_map(static function ($value): string {
+            if (!is_scalar($value) && null !== $value) {
+                throw new \InvalidArgumentException(sprintf(
+                    'Header value must be scalar or null but %s provided.',
+                    is_object($value) ? get_class($value) : gettype($value)
+                ));
+            }
+
+            $trimmed = trim((string) $value, " \t");
+
+            if (!preg_match('/^[\x20\x09\x21-\x7E\x80-\xFF]*$/D', $trimmed)) {
+                throw new \InvalidArgumentException(
+                    sprintf('"%s" is not valid header value.', $trimmed)
+                );
+            }
+
+            return $trimmed;
+        }, array_values($values));
     }
 
     /**

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -8,6 +8,7 @@ use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\FnStream;
 use GuzzleHttp\Psr7\NoSeekStream;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
 
@@ -412,6 +413,47 @@ class UtilsTest extends TestCase
         $r2 = Psr7\Utils::modifyRequest($r1, ['set_headers' => ['User-agent' => 'bar']]);
         self::assertSame('bar', $r2->getHeaderLine('User-Agent'));
         self::assertSame('bar', $r2->getHeaderLine('User-agent'));
+    }
+
+    public function testModifyRequestNormalizesHeaderValuesBeforeApplyingThem(): void
+    {
+        $request = new class('GET', 'http://example.com') extends Psr7\Request {
+            public function withHeader($header, $value): MessageInterface
+            {
+                $this->assertStringHeaderValues($value);
+
+                return parent::withHeader($header, $value);
+            }
+
+            public function withAddedHeader($header, $value): MessageInterface
+            {
+                $this->assertStringHeaderValues($value);
+
+                return parent::withAddedHeader($header, $value);
+            }
+
+            private function assertStringHeaderValues($value): void
+            {
+                if (is_string($value)) {
+                    return;
+                }
+
+                if (!is_array($value) || $value !== array_filter($value, 'is_string')) {
+                    throw new \InvalidArgumentException('Header values must be strings.');
+                }
+            }
+        };
+
+        $modified = Psr7\Utils::modifyRequest($request, [
+            'set_headers' => [
+                'Content-Length' => 4,
+                'X-Test' => [1, " two\t"],
+                'x-test' => 3,
+            ],
+        ]);
+
+        self::assertSame('4', $modified->getHeaderLine('Content-Length'));
+        self::assertSame(['1', 'two', '3'], $modified->getHeader('X-Test'));
     }
 
     public function testReturnsAsIsWhenNoChanges(): void


### PR DESCRIPTION
Utils::modifyRequest() now normalizes header values before applying them to the request. This keeps the 2.x helper compatible with scalar header values that were previously normalized when a new Guzzle request was built, while still preserving the original request implementation.