### PR TITLE
Document modifyRequest change shape

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -153,7 +153,15 @@ final class Utils
      * - version: (string) Set the protocol version.
      *
      * @param RequestInterface $request Request to clone and modify.
-     * @param array            $changes Changes to apply.
+     * @param array{
+     *     method?: string,
+     *     set_headers?: array<array-key, string|string[]>,
+     *     remove_headers?: array<array-key, string|int>,
+     *     body?: resource|string|int|float|bool|StreamInterface|callable|\Iterator|null,
+     *     uri?: UriInterface,
+     *     query?: string,
+     *     version?: string
+     * } $changes Changes to apply.
      */
     public static function modifyRequest(RequestInterface $request, array $changes): RequestInterface
     {


### PR DESCRIPTION
This documents the accepted shape of the changes array for Utils::modifyRequest(). It makes the stricter next-major expectations explicit, especially for set_headers values and supported body inputs.