### PR TITLE
Require PSR-7 v2 interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Require `psr/http-message:^2.0` and add its native parameter types
+- Require `psr/http-factory:^1.1`
+- Reject non-string header values, invalid uploaded file trees, and invalid parsed body values
 - Harden URI host and scheme validation
 - Ignore malformed `HTTP_HOST` values in `ServerRequest::getUriFromGlobals()`
 - Reject hosts with embedded ports in `Uri::withHost()`

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -12,6 +12,69 @@ Guzzle PSR-7 3.0 requires PHP `^7.4 || ^8.0`. Guzzle PSR-7 2.x supported PHP
 If your application still supports PHP 7.2 or 7.3, continue using Guzzle PSR-7
 2.x until your minimum PHP version is raised.
 
+Guzzle PSR-7 3.0 requires `psr/http-message:^2.0` and `psr/http-factory:^1.1`.
+If your dependency constraints pin `psr/http-message` to v1, update them before
+upgrading.
+
+#### PSR-7 Argument Types and Values
+
+Guzzle PSR-7 3.0 requires the argument types documented by PSR-7 more strictly.
+It adds the native parameter types from `psr/http-message` v2 and rejects several
+values that 2.x previously cast or accepted. Code passing invalid argument types
+may now receive PHP `TypeError` exceptions instead of package-specific
+`InvalidArgumentException` exceptions or implicit casts.
+
+Native parameter type changes include:
+
+- `MessageInterface::withProtocolVersion()` now requires `string`.
+- Message header names now require `string`.
+- `RequestInterface::withRequestTarget()` and `withMethod()` now require `string`.
+- `RequestInterface::withUri()` now requires `bool` for `$preserveHost`.
+- `ResponseInterface::withStatus()` now requires `int` status codes and `string` reason phrases.
+- Server request attribute names now require `string`.
+- `UriInterface::withPort()` now requires `int|null`.
+- URI scheme, user info, host, path, query, and fragment mutators now require strings.
+- Stream `seek()`, `read()`, `write()`, and `getMetadata()` now require their PSR-7 v2 parameter types.
+- `UploadedFileInterface::moveTo()` now requires a string target path.
+
+Update callers to pass values of the documented type before calling these
+methods:
+
+```php
+// 2.x, no longer supported in 3.0
+$response = $response->withStatus('201');
+$uri = $uri->withPort('8080');
+
+// 3.0
+$response = $response->withStatus(201);
+$uri = $uri->withPort(8080);
+```
+
+Header values must now be strings or arrays of strings. Scalars and `null` are no
+longer cast to strings.
+
+```php
+// 2.x, no longer accepted in 3.0
+$response = $response->withHeader('Api-Version', 1);
+
+// 3.0
+$response = $response->withHeader('Api-Version', '1');
+```
+
+`ServerRequestInterface::withUploadedFiles()` now rejects invalid nested upload
+trees. Every leaf must be an `UploadedFileInterface` instance.
+
+`ServerRequestInterface::withParsedBody()` now rejects values other than
+`array`, `object`, or `null`.
+
+```php
+// 2.x, no longer accepted in 3.0
+$request = $request->withParsedBody('name=value');
+
+// 3.0
+$request = $request->withParsedBody(['name' => 'value']);
+```
+
 #### URI Host and Scheme Validation
 
 URI hosts containing control characters, whitespace, URI delimiters, backslashes,

--- a/composer.json
+++ b/composer.json
@@ -51,11 +51,9 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
-        "psr/http-factory": "^1.0",
-        "psr/http-message": "^1.1 || ^2.0",
-        "ralouphie/getallheaders": "^3.0",
-        "symfony/deprecation-contracts": "^2.5 || ^3.0",
-        "symfony/polyfill-php80": "^1.24"
+        "psr/http-factory": "^1.1",
+        "psr/http-message": "^2.0",
+        "ralouphie/getallheaders": "^3.0"
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.8.2",
@@ -64,8 +62,8 @@
         "phpunit/phpunit": "^8.5.52 || ^9.6.34"
     },
     "provide": {
-        "psr/http-factory-implementation": "1.0",
-        "psr/http-message-implementation": "1.0"
+        "psr/http-factory-implementation": "1.1",
+        "psr/http-message-implementation": "2.0"
     },
     "suggest": {
         "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,82 +1,10 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Call to function is_int\(\) with int will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 3
-			path: src/AppendStream.php
-
-		-
-			message: '#^Call to function is_string\(\) with string will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 2
-			path: src/AppendStream.php
-
-		-
-			message: '#^Result of && is always false\.$#'
-			identifier: booleanAnd.alwaysFalse
-			count: 1
-			path: src/AppendStream.php
-
-		-
-			message: '#^Call to function is_int\(\) with int will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 3
-			path: src/BufferStream.php
-
-		-
-			message: '#^Call to function is_string\(\) with string will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 2
-			path: src/BufferStream.php
-
-		-
 			message: '#^Method GuzzleHttp\\Psr7\\BufferStream\:\:getSize\(\) never returns null so it can be removed from the return type\.$#'
 			identifier: return.unusedType
 			count: 1
 			path: src/BufferStream.php
-
-		-
-			message: '#^Result of && is always false\.$#'
-			identifier: booleanAnd.alwaysFalse
-			count: 1
-			path: src/BufferStream.php
-
-		-
-			message: '#^Call to function is_int\(\) with int will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 3
-			path: src/CachingStream.php
-
-		-
-			message: '#^Call to function is_string\(\) with string will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 2
-			path: src/CachingStream.php
-
-		-
-			message: '#^Result of && is always false\.$#'
-			identifier: booleanAnd.alwaysFalse
-			count: 1
-			path: src/CachingStream.php
-
-		-
-			message: '#^Call to function is_int\(\) with int will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 3
-			path: src/DroppingStream.php
-
-		-
-			message: '#^Call to function is_string\(\) with string will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 2
-			path: src/DroppingStream.php
-
-		-
-			message: '#^Result of && is always false\.$#'
-			identifier: booleanAnd.alwaysFalse
-			count: 1
-			path: src/DroppingStream.php
 
 		-
 			message: '#^Access to an undefined property GuzzleHttp\\Psr7\\FnStream\:\:\$_fn___toString\.$#'
@@ -169,82 +97,10 @@ parameters:
 			path: src/FnStream.php
 
 		-
-			message: '#^Call to function is_int\(\) with int will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 3
-			path: src/FnStream.php
-
-		-
-			message: '#^Call to function is_string\(\) with string will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 2
-			path: src/FnStream.php
-
-		-
-			message: '#^Result of && is always false\.$#'
-			identifier: booleanAnd.alwaysFalse
-			count: 1
-			path: src/FnStream.php
-
-		-
 			message: '#^Call to function is_string\(\) with string will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
 			count: 1
 			path: src/Header.php
-
-		-
-			message: '#^Call to function is_int\(\) with int will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 3
-			path: src/InflateStream.php
-
-		-
-			message: '#^Call to function is_string\(\) with string will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 2
-			path: src/InflateStream.php
-
-		-
-			message: '#^Result of && is always false\.$#'
-			identifier: booleanAnd.alwaysFalse
-			count: 1
-			path: src/InflateStream.php
-
-		-
-			message: '#^Call to function is_int\(\) with int will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 3
-			path: src/LazyOpenStream.php
-
-		-
-			message: '#^Call to function is_string\(\) with string will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 2
-			path: src/LazyOpenStream.php
-
-		-
-			message: '#^Result of && is always false\.$#'
-			identifier: booleanAnd.alwaysFalse
-			count: 1
-			path: src/LazyOpenStream.php
-
-		-
-			message: '#^Call to function is_int\(\) with int will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 3
-			path: src/LimitStream.php
-
-		-
-			message: '#^Call to function is_string\(\) with string will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 2
-			path: src/LimitStream.php
-
-		-
-			message: '#^Result of && is always false\.$#'
-			identifier: booleanAnd.alwaysFalse
-			count: 1
-			path: src/LimitStream.php
 
 		-
 			message: '#^PHPDoc tag @var with type array\<array\> is not subtype of native type list\<array\<string\>\>\.$#'
@@ -277,138 +133,6 @@ parameters:
 			path: src/Message.php
 
 		-
-			message: '#^Call to function is_int\(\) with int will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 3
-			path: src/MultipartStream.php
-
-		-
-			message: '#^Call to function is_string\(\) with string will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 2
-			path: src/MultipartStream.php
-
-		-
-			message: '#^Result of && is always false\.$#'
-			identifier: booleanAnd.alwaysFalse
-			count: 1
-			path: src/MultipartStream.php
-
-		-
-			message: '#^Call to function is_int\(\) with int will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 3
-			path: src/NoSeekStream.php
-
-		-
-			message: '#^Call to function is_string\(\) with string will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 2
-			path: src/NoSeekStream.php
-
-		-
-			message: '#^Result of && is always false\.$#'
-			identifier: booleanAnd.alwaysFalse
-			count: 1
-			path: src/NoSeekStream.php
-
-		-
-			message: '#^Call to function is_int\(\) with int will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 3
-			path: src/PumpStream.php
-
-		-
-			message: '#^Call to function is_string\(\) with string will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 2
-			path: src/PumpStream.php
-
-		-
-			message: '#^Result of && is always false\.$#'
-			identifier: booleanAnd.alwaysFalse
-			count: 1
-			path: src/PumpStream.php
-
-		-
-			message: '#^Call to function is_bool\(\) with bool will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: src/Request.php
-
-		-
-			message: '#^Call to function is_scalar\(\) with \*NEVER\* will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 3
-			path: src/Request.php
-
-		-
-			message: '#^Call to function is_string\(\) with string will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 4
-			path: src/Request.php
-
-		-
-			message: '#^Result of && is always false\.$#'
-			identifier: booleanAnd.alwaysFalse
-			count: 3
-			path: src/Request.php
-
-		-
-			message: '#^Result of \|\| is always true\.$#'
-			identifier: booleanOr.alwaysTrue
-			count: 3
-			path: src/Request.php
-
-		-
-			message: '#^Strict comparison using \=\=\= between \*NEVER\* and null will always evaluate to false\.$#'
-			identifier: identical.alwaysFalse
-			count: 3
-			path: src/Request.php
-
-		-
-			message: '#^Call to function is_int\(\) with int will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: src/Response.php
-
-		-
-			message: '#^Call to function is_scalar\(\) with \*NEVER\* will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 3
-			path: src/Response.php
-
-		-
-			message: '#^Call to function is_string\(\) with string will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 5
-			path: src/Response.php
-
-		-
-			message: '#^Result of && is always false\.$#'
-			identifier: booleanAnd.alwaysFalse
-			count: 4
-			path: src/Response.php
-
-		-
-			message: '#^Result of \|\| is always true\.$#'
-			identifier: booleanOr.alwaysTrue
-			count: 3
-			path: src/Response.php
-
-		-
-			message: '#^Strict comparison using \!\=\= between false and false will always evaluate to false\.$#'
-			identifier: notIdentical.alwaysFalse
-			count: 1
-			path: src/Response.php
-
-		-
-			message: '#^Strict comparison using \=\=\= between \*NEVER\* and null will always evaluate to false\.$#'
-			identifier: identical.alwaysFalse
-			count: 3
-			path: src/Response.php
-
-		-
 			message: '#^Argument of an invalid type null supplied for foreach, only iterables are supported\.$#'
 			identifier: foreach.nonIterable
 			count: 1
@@ -418,12 +142,6 @@ parameters:
 			message: '#^Call to function is_object\(\) with object will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
 			count: 1
-			path: src/ServerRequest.php
-
-		-
-			message: '#^Call to function is_string\(\) with string will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 3
 			path: src/ServerRequest.php
 
 		-
@@ -439,18 +157,6 @@ parameters:
 			path: src/ServerRequest.php
 
 		-
-			message: '#^Call to function is_int\(\) with int will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 3
-			path: src/Stream.php
-
-		-
-			message: '#^Call to function is_string\(\) with string will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 2
-			path: src/Stream.php
-
-		-
 			message: '#^Offset ''size'' on array\{0\: int, 1\: int, 2\: int, 3\: int, 4\: int, 5\: int, 6\: int, 7\: int, \.\.\.\} in isset\(\) always exists and is not nullable\.$#'
 			identifier: isset.offset
 			count: 1
@@ -461,30 +167,6 @@ parameters:
 			identifier: isset.property
 			count: 10
 			path: src/Stream.php
-
-		-
-			message: '#^Result of && is always false\.$#'
-			identifier: booleanAnd.alwaysFalse
-			count: 1
-			path: src/Stream.php
-
-		-
-			message: '#^Method GuzzleHttp\\Psr7\\UploadedFile\:\:isStringNotEmpty\(\) has parameter \$param with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/UploadedFile.php
-
-		-
-			message: '#^Call to function is_int\(\) with int will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: src/Uri.php
-
-		-
-			message: '#^Cannot cast mixed to int\.$#'
-			identifier: cast.int
-			count: 1
-			path: src/Uri.php
 
 		-
 			message: '#^Method GuzzleHttp\\Psr7\\Uri\:\:filterPath\(\) should return string but returns string\|null\.$#'
@@ -507,12 +189,6 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$callback of function array_map expects \(callable\(int\<0, 65535\>\|string\)\: mixed\)\|null, ''urldecode'' given\.$#'
 			identifier: argument.type
-			count: 1
-			path: src/Uri.php
-
-		-
-			message: '#^Result of && is always false\.$#'
-			identifier: booleanAnd.alwaysFalse
 			count: 1
 			path: src/Uri.php
 

--- a/src/AppendStream.php
+++ b/src/AppendStream.php
@@ -144,26 +144,8 @@ final class AppendStream implements StreamInterface
     /**
      * Attempts to seek to the given position. Only supports SEEK_SET.
      */
-    public function seek($offset, $whence = SEEK_SET): void
+    public function seek(int $offset, int $whence = SEEK_SET): void
     {
-        if (!\is_int($offset)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing %s to StreamInterface::seek() is deprecated; guzzlehttp/psr7 3.0 requires int for $offset.',
-                \get_debug_type($offset)
-            );
-        }
-
-        if (!\is_int($whence)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing %s to StreamInterface::seek() is deprecated; guzzlehttp/psr7 3.0 requires int for $whence.',
-                \get_debug_type($whence)
-            );
-        }
-
         if (!$this->seekable) {
             throw new \RuntimeException('This AppendStream is not seekable');
         } elseif ($whence !== SEEK_SET) {
@@ -194,17 +176,8 @@ final class AppendStream implements StreamInterface
     /**
      * Reads from all of the appended streams until the length is met or EOF.
      */
-    public function read($length): string
+    public function read(int $length): string
     {
-        if (!\is_int($length)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing %s to StreamInterface::read() is deprecated; guzzlehttp/psr7 3.0 requires int for $length.',
-                \get_debug_type($length)
-            );
-        }
-
         $buffer = '';
         $total = count($this->streams) - 1;
         $remaining = $length;
@@ -251,34 +224,16 @@ final class AppendStream implements StreamInterface
         return $this->seekable;
     }
 
-    public function write($string): int
+    public function write(string $string): int
     {
-        if (!\is_string($string)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing %s to StreamInterface::write() is deprecated; guzzlehttp/psr7 3.0 requires string for $string.',
-                \get_debug_type($string)
-            );
-        }
-
         throw new \RuntimeException('Cannot write to an AppendStream');
     }
 
     /**
      * @return mixed
      */
-    public function getMetadata($key = null)
+    public function getMetadata(?string $key = null)
     {
-        if ($key !== null && !\is_string($key)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing %s to StreamInterface::getMetadata() is deprecated; guzzlehttp/psr7 3.0 requires string|null for $key.',
-                \get_debug_type($key)
-            );
-        }
-
-        return $key ? null : [];
+        return $key === null ? [] : null;
     }
 }

--- a/src/BufferStream.php
+++ b/src/BufferStream.php
@@ -84,26 +84,8 @@ final class BufferStream implements StreamInterface
         $this->seek(0);
     }
 
-    public function seek($offset, $whence = SEEK_SET): void
+    public function seek(int $offset, int $whence = SEEK_SET): void
     {
-        if (!\is_int($offset)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing %s to StreamInterface::seek() is deprecated; guzzlehttp/psr7 3.0 requires int for $offset.',
-                \get_debug_type($offset)
-            );
-        }
-
-        if (!\is_int($whence)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing %s to StreamInterface::seek() is deprecated; guzzlehttp/psr7 3.0 requires int for $whence.',
-                \get_debug_type($whence)
-            );
-        }
-
         throw new \RuntimeException('Cannot seek a BufferStream');
     }
 
@@ -120,17 +102,8 @@ final class BufferStream implements StreamInterface
     /**
      * Reads data from the buffer.
      */
-    public function read($length): string
+    public function read(int $length): string
     {
-        if (!\is_int($length)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing %s to StreamInterface::read() is deprecated; guzzlehttp/psr7 3.0 requires int for $length.',
-                \get_debug_type($length)
-            );
-        }
-
         $currentLength = strlen($this->buffer);
 
         if ($length >= $currentLength) {
@@ -149,17 +122,8 @@ final class BufferStream implements StreamInterface
     /**
      * Writes data to the buffer.
      */
-    public function write($string): int
+    public function write(string $string): int
     {
-        if (!\is_string($string)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing %s to StreamInterface::write() is deprecated; guzzlehttp/psr7 3.0 requires string for $string.',
-                \get_debug_type($string)
-            );
-        }
-
         $this->buffer .= $string;
 
         if (strlen($this->buffer) >= $this->hwm) {
@@ -172,21 +136,12 @@ final class BufferStream implements StreamInterface
     /**
      * @return mixed
      */
-    public function getMetadata($key = null)
+    public function getMetadata(?string $key = null)
     {
-        if ($key !== null && !\is_string($key)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing %s to StreamInterface::getMetadata() is deprecated; guzzlehttp/psr7 3.0 requires string|null for $key.',
-                \get_debug_type($key)
-            );
-        }
-
         if ($key === 'hwm') {
             return $this->hwm;
         }
 
-        return $key ? null : [];
+        return $key === null ? [] : null;
     }
 }

--- a/src/CachingStream.php
+++ b/src/CachingStream.php
@@ -62,26 +62,8 @@ final class CachingStream implements StreamInterface
         $this->seek(0);
     }
 
-    public function seek($offset, $whence = SEEK_SET): void
+    public function seek(int $offset, int $whence = SEEK_SET): void
     {
-        if (!\is_int($offset)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing %s to StreamInterface::seek() is deprecated; guzzlehttp/psr7 3.0 requires int for $offset.',
-                \get_debug_type($offset)
-            );
-        }
-
-        if (!\is_int($whence)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing %s to StreamInterface::seek() is deprecated; guzzlehttp/psr7 3.0 requires int for $whence.',
-                \get_debug_type($whence)
-            );
-        }
-
         if ($whence === SEEK_SET) {
             $byte = $offset;
         } elseif ($whence === SEEK_CUR) {
@@ -111,17 +93,8 @@ final class CachingStream implements StreamInterface
         }
     }
 
-    public function read($length): string
+    public function read(int $length): string
     {
-        if (!\is_int($length)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing %s to StreamInterface::read() is deprecated; guzzlehttp/psr7 3.0 requires int for $length.',
-                \get_debug_type($length)
-            );
-        }
-
         // Perform a regular read on any previously read data from the buffer
         $data = $this->stream->read($length);
         $remaining = $length - strlen($data);
@@ -149,17 +122,8 @@ final class CachingStream implements StreamInterface
         return $data;
     }
 
-    public function write($string): int
+    public function write(string $string): int
     {
-        if (!\is_string($string)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing %s to StreamInterface::write() is deprecated; guzzlehttp/psr7 3.0 requires string for $string.',
-                \get_debug_type($string)
-            );
-        }
-
         // When appending to the end of the currently read stream, you'll want
         // to skip bytes from being read from the remote stream to emulate
         // other stream wrappers. Basically replacing bytes of data of a fixed

--- a/src/DroppingStream.php
+++ b/src/DroppingStream.php
@@ -30,17 +30,8 @@ final class DroppingStream implements StreamInterface
         $this->maxLength = $maxLength;
     }
 
-    public function write($string): int
+    public function write(string $string): int
     {
-        if (!\is_string($string)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing %s to StreamInterface::write() is deprecated; guzzlehttp/psr7 3.0 requires string for $string.',
-                \get_debug_type($string)
-            );
-        }
-
         $diff = $this->maxLength - $this->stream->getSize();
 
         // Begin returning 0 when the underlying stream is too large.

--- a/src/FnStream.php
+++ b/src/FnStream.php
@@ -131,26 +131,8 @@ final class FnStream implements StreamInterface
         ($this->_fn_rewind)();
     }
 
-    public function seek($offset, $whence = SEEK_SET): void
+    public function seek(int $offset, int $whence = SEEK_SET): void
     {
-        if (!\is_int($offset)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing %s to StreamInterface::seek() is deprecated; guzzlehttp/psr7 3.0 requires int for $offset.',
-                \get_debug_type($offset)
-            );
-        }
-
-        if (!\is_int($whence)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing %s to StreamInterface::seek() is deprecated; guzzlehttp/psr7 3.0 requires int for $whence.',
-                \get_debug_type($whence)
-            );
-        }
-
         ($this->_fn_seek)($offset, $whence);
     }
 
@@ -159,17 +141,8 @@ final class FnStream implements StreamInterface
         return ($this->_fn_isWritable)();
     }
 
-    public function write($string): int
+    public function write(string $string): int
     {
-        if (!\is_string($string)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing %s to StreamInterface::write() is deprecated; guzzlehttp/psr7 3.0 requires string for $string.',
-                \get_debug_type($string)
-            );
-        }
-
         return ($this->_fn_write)($string);
     }
 
@@ -178,17 +151,8 @@ final class FnStream implements StreamInterface
         return ($this->_fn_isReadable)();
     }
 
-    public function read($length): string
+    public function read(int $length): string
     {
-        if (!\is_int($length)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing %s to StreamInterface::read() is deprecated; guzzlehttp/psr7 3.0 requires int for $length.',
-                \get_debug_type($length)
-            );
-        }
-
         return ($this->_fn_read)($length);
     }
 
@@ -200,17 +164,8 @@ final class FnStream implements StreamInterface
     /**
      * @return mixed
      */
-    public function getMetadata($key = null)
+    public function getMetadata(?string $key = null)
     {
-        if ($key !== null && !\is_string($key)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing %s to StreamInterface::getMetadata() is deprecated; guzzlehttp/psr7 3.0 requires string|null for $key.',
-                \get_debug_type($key)
-            );
-        }
-
         return ($this->_fn_getMetadata)($key);
     }
 }

--- a/src/LimitStream.php
+++ b/src/LimitStream.php
@@ -71,26 +71,8 @@ final class LimitStream implements StreamInterface
     /**
      * Allow for a bounded seek on the read limited stream
      */
-    public function seek($offset, $whence = SEEK_SET): void
+    public function seek(int $offset, int $whence = SEEK_SET): void
     {
-        if (!\is_int($offset)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing %s to StreamInterface::seek() is deprecated; guzzlehttp/psr7 3.0 requires int for $offset.',
-                \get_debug_type($offset)
-            );
-        }
-
-        if (!\is_int($whence)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing %s to StreamInterface::seek() is deprecated; guzzlehttp/psr7 3.0 requires int for $whence.',
-                \get_debug_type($whence)
-            );
-        }
-
         if ($whence !== SEEK_SET || $offset < 0) {
             throw new \RuntimeException(sprintf(
                 'Cannot seek to offset %s with whence %s',
@@ -155,17 +137,8 @@ final class LimitStream implements StreamInterface
         $this->limit = $limit;
     }
 
-    public function read($length): string
+    public function read(int $length): string
     {
-        if (!\is_int($length)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing %s to StreamInterface::read() is deprecated; guzzlehttp/psr7 3.0 requires int for $length.',
-                \get_debug_type($length)
-            );
-        }
-
         if ($this->limit === -1) {
             return $this->stream->read($length);
         }

--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -32,17 +32,8 @@ trait MessageTrait
     /**
      * @return static
      */
-    public function withProtocolVersion($version): MessageInterface
+    public function withProtocolVersion(string $version): MessageInterface
     {
-        if (!\is_string($version)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing %s to MessageInterface::withProtocolVersion() is deprecated; guzzlehttp/psr7 3.0 requires string.',
-                \get_debug_type($version)
-            );
-        }
-
         if ($this->protocol === $version) {
             return $this;
         }
@@ -58,14 +49,14 @@ trait MessageTrait
         return $this->headers;
     }
 
-    public function hasHeader($header): bool
+    public function hasHeader(string $name): bool
     {
-        return isset($this->headerNames[strtolower($header)]);
+        return isset($this->headerNames[strtolower($name)]);
     }
 
-    public function getHeader($header): array
+    public function getHeader(string $name): array
     {
-        $header = strtolower($header);
+        $header = strtolower($name);
 
         if (!isset($this->headerNames[$header])) {
             return [];
@@ -76,39 +67,26 @@ trait MessageTrait
         return $this->headers[$header];
     }
 
-    public function getHeaderLine($header): string
+    public function getHeaderLine(string $name): string
     {
-        return implode(', ', $this->getHeader($header));
+        return implode(', ', $this->getHeader($name));
     }
 
     /**
      * @return static
      */
-    public function withHeader($header, $value): MessageInterface
+    public function withHeader(string $name, $value): MessageInterface
     {
-        $this->assertHeader($header);
-        $values = \is_array($value) ? $value : [$value];
-        foreach ($values as $item) {
-            if (!\is_string($item) && (\is_scalar($item) || $item === null)) {
-                \trigger_deprecation(
-                    'guzzlehttp/psr7',
-                    '2.11',
-                    'Passing %s to MessageInterface::withHeader() is deprecated; guzzlehttp/psr7 3.0 requires string|string[].',
-                    \get_debug_type($item)
-                );
-
-                break;
-            }
-        }
+        $this->assertHeader($name);
         $value = $this->normalizeHeaderValue($value);
-        $normalized = strtolower($header);
+        $normalized = strtolower($name);
 
         $new = clone $this;
         if (isset($new->headerNames[$normalized])) {
             unset($new->headers[$new->headerNames[$normalized]]);
         }
-        $new->headerNames[$normalized] = $header;
-        $new->headers[$header] = $value;
+        $new->headerNames[$normalized] = $name;
+        $new->headers[$name] = $value;
 
         return $new;
     }
@@ -116,32 +94,19 @@ trait MessageTrait
     /**
      * @return static
      */
-    public function withAddedHeader($header, $value): MessageInterface
+    public function withAddedHeader(string $name, $value): MessageInterface
     {
-        $this->assertHeader($header);
-        $values = \is_array($value) ? $value : [$value];
-        foreach ($values as $item) {
-            if (!\is_string($item) && (\is_scalar($item) || $item === null)) {
-                \trigger_deprecation(
-                    'guzzlehttp/psr7',
-                    '2.11',
-                    'Passing %s to MessageInterface::withAddedHeader() is deprecated; guzzlehttp/psr7 3.0 requires string|string[].',
-                    \get_debug_type($item)
-                );
-
-                break;
-            }
-        }
+        $this->assertHeader($name);
         $value = $this->normalizeHeaderValue($value);
-        $normalized = strtolower($header);
+        $normalized = strtolower($name);
 
         $new = clone $this;
         if (isset($new->headerNames[$normalized])) {
-            $header = $this->headerNames[$normalized];
-            $new->headers[$header] = array_merge($this->headers[$header], $value);
+            $name = $this->headerNames[$normalized];
+            $new->headers[$name] = array_merge($this->headers[$name], $value);
         } else {
-            $new->headerNames[$normalized] = $header;
-            $new->headers[$header] = $value;
+            $new->headerNames[$normalized] = $name;
+            $new->headers[$name] = $value;
         }
 
         return $new;
@@ -150,18 +115,18 @@ trait MessageTrait
     /**
      * @return static
      */
-    public function withoutHeader($header): MessageInterface
+    public function withoutHeader(string $name): MessageInterface
     {
-        $normalized = strtolower($header);
+        $normalized = strtolower($name);
 
         if (!isset($this->headerNames[$normalized])) {
             return $this;
         }
 
-        $header = $this->headerNames[$normalized];
+        $name = $this->headerNames[$normalized];
 
         $new = clone $this;
-        unset($new->headers[$header], $new->headerNames[$normalized]);
+        unset($new->headers[$name], $new->headerNames[$normalized]);
 
         return $new;
     }
@@ -201,20 +166,6 @@ trait MessageTrait
             $header = (string) $header;
 
             $this->assertHeader($header);
-            $values = \is_array($value) ? $value : [$value];
-            foreach ($values as $item) {
-                if (!\is_string($item) && (\is_scalar($item) || $item === null)) {
-                    \trigger_deprecation(
-                        'guzzlehttp/psr7',
-                        '2.11',
-                        'Passing %s to %s::__construct() is deprecated; guzzlehttp/psr7 3.0 requires string|string[].',
-                        \get_debug_type($item),
-                        static::class
-                    );
-
-                    break;
-                }
-            }
             $value = $this->normalizeHeaderValue($value);
             $normalized = strtolower($header);
             if (isset($this->headerNames[$normalized])) {
@@ -258,14 +209,14 @@ trait MessageTrait
     private function trimAndValidateHeaderValues(array $values): array
     {
         return array_map(function ($value) {
-            if (!is_scalar($value) && null !== $value) {
+            if (!is_string($value)) {
                 throw new \InvalidArgumentException(sprintf(
-                    'Header value must be scalar or null but %s provided.',
+                    'Header value must be a string or array of strings but %s provided.',
                     is_object($value) ? get_class($value) : gettype($value)
                 ));
             }
 
-            $trimmed = trim((string) $value, " \t");
+            $trimmed = trim($value, " \t");
             $this->assertValue($trimmed);
 
             return $trimmed;

--- a/src/NoSeekStream.php
+++ b/src/NoSeekStream.php
@@ -16,26 +16,8 @@ final class NoSeekStream implements StreamInterface
     /** @var StreamInterface */
     private $stream;
 
-    public function seek($offset, $whence = SEEK_SET): void
+    public function seek(int $offset, int $whence = SEEK_SET): void
     {
-        if (!\is_int($offset)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing %s to StreamInterface::seek() is deprecated; guzzlehttp/psr7 3.0 requires int for $offset.',
-                \get_debug_type($offset)
-            );
-        }
-
-        if (!\is_int($whence)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing %s to StreamInterface::seek() is deprecated; guzzlehttp/psr7 3.0 requires int for $whence.',
-                \get_debug_type($whence)
-            );
-        }
-
         throw new \RuntimeException('Cannot seek a NoSeekStream');
     }
 

--- a/src/PumpStream.php
+++ b/src/PumpStream.php
@@ -94,26 +94,8 @@ final class PumpStream implements StreamInterface
         $this->seek(0);
     }
 
-    public function seek($offset, $whence = SEEK_SET): void
+    public function seek(int $offset, int $whence = SEEK_SET): void
     {
-        if (!\is_int($offset)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing %s to StreamInterface::seek() is deprecated; guzzlehttp/psr7 3.0 requires int for $offset.',
-                \get_debug_type($offset)
-            );
-        }
-
-        if (!\is_int($whence)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing %s to StreamInterface::seek() is deprecated; guzzlehttp/psr7 3.0 requires int for $whence.',
-                \get_debug_type($whence)
-            );
-        }
-
         throw new \RuntimeException('Cannot seek a PumpStream');
     }
 
@@ -122,17 +104,8 @@ final class PumpStream implements StreamInterface
         return false;
     }
 
-    public function write($string): int
+    public function write(string $string): int
     {
-        if (!\is_string($string)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing %s to StreamInterface::write() is deprecated; guzzlehttp/psr7 3.0 requires string for $string.',
-                \get_debug_type($string)
-            );
-        }
-
         throw new \RuntimeException('Cannot write to a PumpStream');
     }
 
@@ -141,17 +114,8 @@ final class PumpStream implements StreamInterface
         return true;
     }
 
-    public function read($length): string
+    public function read(int $length): string
     {
-        if (!\is_int($length)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing %s to StreamInterface::read() is deprecated; guzzlehttp/psr7 3.0 requires int for $length.',
-                \get_debug_type($length)
-            );
-        }
-
         $data = $this->buffer->read($length);
         $readLen = strlen($data);
         $this->tellPos += $readLen;
@@ -179,18 +143,9 @@ final class PumpStream implements StreamInterface
     /**
      * @return mixed
      */
-    public function getMetadata($key = null)
+    public function getMetadata(?string $key = null)
     {
-        if ($key !== null && !\is_string($key)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing %s to StreamInterface::getMetadata() is deprecated; guzzlehttp/psr7 3.0 requires string|null for $key.',
-                \get_debug_type($key)
-            );
-        }
-
-        if (!$key) {
+        if ($key === null) {
             return $this->metadata;
         }
 

--- a/src/Request.php
+++ b/src/Request.php
@@ -75,7 +75,7 @@ class Request implements RequestInterface
         return $target;
     }
 
-    public function withRequestTarget($requestTarget): RequestInterface
+    public function withRequestTarget(string $requestTarget): RequestInterface
     {
         if (preg_match('#\s#', $requestTarget)) {
             throw new InvalidArgumentException(
@@ -94,7 +94,7 @@ class Request implements RequestInterface
         return $this->method;
     }
 
-    public function withMethod($method): RequestInterface
+    public function withMethod(string $method): RequestInterface
     {
         $this->assertMethod($method);
         $new = clone $this;
@@ -108,17 +108,8 @@ class Request implements RequestInterface
         return $this->uri;
     }
 
-    public function withUri(UriInterface $uri, $preserveHost = false): RequestInterface
+    public function withUri(UriInterface $uri, bool $preserveHost = false): RequestInterface
     {
-        if (!\is_bool($preserveHost)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing %s to RequestInterface::withUri() is deprecated; guzzlehttp/psr7 3.0 requires bool for $preserveHost.',
-                \get_debug_type($preserveHost)
-            );
-        }
-
         if ($uri === $this->uri) {
             return $this;
         }
@@ -158,12 +149,9 @@ class Request implements RequestInterface
         $this->headers = [$header => [$host]] + $this->headers;
     }
 
-    /**
-     * @param mixed $method
-     */
-    private function assertMethod($method): void
+    private function assertMethod(string $method): void
     {
-        if (!is_string($method) || $method === '') {
+        if ($method === '') {
             throw new InvalidArgumentException('Method must be a non-empty string.');
         }
     }

--- a/src/Response.php
+++ b/src/Response.php
@@ -126,48 +126,18 @@ class Response implements ResponseInterface
         return $this->reasonPhrase;
     }
 
-    public function withStatus($code, $reasonPhrase = ''): ResponseInterface
+    public function withStatus(int $code, string $reasonPhrase = ''): ResponseInterface
     {
-        if (!\is_int($code) && \filter_var($code, \FILTER_VALIDATE_INT) !== false) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing %s to ResponseInterface::withStatus() is deprecated; guzzlehttp/psr7 3.0 requires int for $code.',
-                \get_debug_type($code)
-            );
-        }
-
-        if (!\is_string($reasonPhrase)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing %s to ResponseInterface::withStatus() is deprecated; guzzlehttp/psr7 3.0 requires string for $reasonPhrase.',
-                \get_debug_type($reasonPhrase)
-            );
-        }
-
-        $this->assertStatusCodeIsInteger($code);
-        $code = (int) $code;
         $this->assertStatusCodeRange($code);
 
         $new = clone $this;
         $new->statusCode = $code;
-        if ($reasonPhrase == '' && isset(self::PHRASES[$new->statusCode])) {
+        if ($reasonPhrase === '' && isset(self::PHRASES[$new->statusCode])) {
             $reasonPhrase = self::PHRASES[$new->statusCode];
         }
-        $new->reasonPhrase = (string) $reasonPhrase;
+        $new->reasonPhrase = $reasonPhrase;
 
         return $new;
-    }
-
-    /**
-     * @param mixed $statusCode
-     */
-    private function assertStatusCodeIsInteger($statusCode): void
-    {
-        if (filter_var($statusCode, FILTER_VALIDATE_INT) === false) {
-            throw new \InvalidArgumentException('Status code must be an integer value.');
-        }
     }
 
     private function assertStatusCodeRange(int $statusCode): void

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -348,8 +348,6 @@ class ServerRequest extends Request implements ServerRequestInterface
 
     public function withUploadedFiles(array $uploadedFiles): ServerRequestInterface
     {
-        $invalidUploadedFileFound = false;
-        $invalidUploadedFile = null;
         $stack = [$uploadedFiles];
 
         while ($stack !== []) {
@@ -363,20 +361,11 @@ class ServerRequest extends Request implements ServerRequestInterface
                     continue;
                 }
 
-                $invalidUploadedFileFound = true;
-                $invalidUploadedFile = $uploadedFile;
-
-                break 2;
+                throw new InvalidArgumentException(sprintf(
+                    'Invalid uploaded file tree; expected UploadedFileInterface instances but %s provided.',
+                    is_object($uploadedFile) ? get_class($uploadedFile) : gettype($uploadedFile)
+                ));
             }
-        }
-
-        if ($invalidUploadedFileFound) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing %s inside ServerRequestInterface::withUploadedFiles() is deprecated; guzzlehttp/psr7 3.0 requires an UploadedFileInterface[] tree.',
-                \get_debug_type($invalidUploadedFile)
-            );
         }
 
         $new = clone $this;
@@ -422,12 +411,7 @@ class ServerRequest extends Request implements ServerRequestInterface
     public function withParsedBody($data): ServerRequestInterface
     {
         if ($data !== null && !\is_array($data) && !\is_object($data)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing %s to ServerRequestInterface::withParsedBody() is deprecated; guzzlehttp/psr7 3.0 requires array|object|null.',
-                \get_debug_type($data)
-            );
+            throw new InvalidArgumentException('Parsed body must be an array, object, or null.');
         }
 
         $new = clone $this;
@@ -444,58 +428,31 @@ class ServerRequest extends Request implements ServerRequestInterface
     /**
      * @return mixed
      */
-    public function getAttribute($attribute, $default = null)
+    public function getAttribute(string $name, $default = null)
     {
-        if (!\is_string($attribute)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing %s to ServerRequestInterface::getAttribute() is deprecated; guzzlehttp/psr7 3.0 requires string for $attribute.',
-                \get_debug_type($attribute)
-            );
-        }
-
-        if (false === array_key_exists($attribute, $this->attributes)) {
+        if (false === array_key_exists($name, $this->attributes)) {
             return $default;
         }
 
-        return $this->attributes[$attribute];
+        return $this->attributes[$name];
     }
 
-    public function withAttribute($attribute, $value): ServerRequestInterface
+    public function withAttribute(string $name, $value): ServerRequestInterface
     {
-        if (!\is_string($attribute)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing %s to ServerRequestInterface::withAttribute() is deprecated; guzzlehttp/psr7 3.0 requires string for $attribute.',
-                \get_debug_type($attribute)
-            );
-        }
-
         $new = clone $this;
-        $new->attributes[$attribute] = $value;
+        $new->attributes[$name] = $value;
 
         return $new;
     }
 
-    public function withoutAttribute($attribute): ServerRequestInterface
+    public function withoutAttribute(string $name): ServerRequestInterface
     {
-        if (!\is_string($attribute)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing %s to ServerRequestInterface::withoutAttribute() is deprecated; guzzlehttp/psr7 3.0 requires string for $attribute.',
-                \get_debug_type($attribute)
-            );
-        }
-
-        if (false === array_key_exists($attribute, $this->attributes)) {
+        if (false === array_key_exists($name, $this->attributes)) {
             return $this;
         }
 
         $new = clone $this;
-        unset($new->attributes[$attribute]);
+        unset($new->attributes[$name]);
 
         return $new;
     }

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -189,28 +189,8 @@ class Stream implements StreamInterface
         $this->seek(0);
     }
 
-    public function seek($offset, $whence = SEEK_SET): void
+    public function seek(int $offset, int $whence = SEEK_SET): void
     {
-        if (!\is_int($offset)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing %s to StreamInterface::seek() is deprecated; guzzlehttp/psr7 3.0 requires int for $offset.',
-                \get_debug_type($offset)
-            );
-        }
-
-        if (!\is_int($whence)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing %s to StreamInterface::seek() is deprecated; guzzlehttp/psr7 3.0 requires int for $whence.',
-                \get_debug_type($whence)
-            );
-        }
-
-        $whence = (int) $whence;
-
         if (!isset($this->stream)) {
             throw new \RuntimeException('Stream is detached');
         }
@@ -223,17 +203,8 @@ class Stream implements StreamInterface
         }
     }
 
-    public function read($length): string
+    public function read(int $length): string
     {
-        if (!\is_int($length)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing %s to StreamInterface::read() is deprecated; guzzlehttp/psr7 3.0 requires int for $length.',
-                \get_debug_type($length)
-            );
-        }
-
         if (!isset($this->stream)) {
             throw new \RuntimeException('Stream is detached');
         }
@@ -261,17 +232,8 @@ class Stream implements StreamInterface
         return $string;
     }
 
-    public function write($string): int
+    public function write(string $string): int
     {
-        if (!\is_string($string)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing %s to StreamInterface::write() is deprecated; guzzlehttp/psr7 3.0 requires string for $string.',
-                \get_debug_type($string)
-            );
-        }
-
         if (!isset($this->stream)) {
             throw new \RuntimeException('Stream is detached');
         }
@@ -293,20 +255,11 @@ class Stream implements StreamInterface
     /**
      * @return mixed
      */
-    public function getMetadata($key = null)
+    public function getMetadata(?string $key = null)
     {
-        if ($key !== null && !\is_string($key)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing %s to StreamInterface::getMetadata() is deprecated; guzzlehttp/psr7 3.0 requires string|null for $key.',
-                \get_debug_type($key)
-            );
-        }
-
         if (!isset($this->stream)) {
-            return $key ? null : [];
-        } elseif (!$key) {
+            return $key === null ? [] : null;
+        } elseif ($key === null) {
             return $this->customMetadata + stream_get_meta_data($this->stream);
         } elseif (isset($this->customMetadata[$key])) {
             return $this->customMetadata[$key];

--- a/src/StreamDecoratorTrait.php
+++ b/src/StreamDecoratorTrait.php
@@ -75,17 +75,8 @@ trait StreamDecoratorTrait
     /**
      * @return mixed
      */
-    public function getMetadata($key = null)
+    public function getMetadata(?string $key = null)
     {
-        if ($key !== null && !\is_string($key)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing %s to StreamInterface::getMetadata() is deprecated; guzzlehttp/psr7 3.0 requires string|null for $key.',
-                \get_debug_type($key)
-            );
-        }
-
         return $this->stream->getMetadata($key);
     }
 
@@ -129,54 +120,18 @@ trait StreamDecoratorTrait
         $this->seek(0);
     }
 
-    public function seek($offset, $whence = SEEK_SET): void
+    public function seek(int $offset, int $whence = SEEK_SET): void
     {
-        if (!\is_int($offset)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing %s to StreamInterface::seek() is deprecated; guzzlehttp/psr7 3.0 requires int for $offset.',
-                \get_debug_type($offset)
-            );
-        }
-
-        if (!\is_int($whence)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing %s to StreamInterface::seek() is deprecated; guzzlehttp/psr7 3.0 requires int for $whence.',
-                \get_debug_type($whence)
-            );
-        }
-
         $this->stream->seek($offset, $whence);
     }
 
-    public function read($length): string
+    public function read(int $length): string
     {
-        if (!\is_int($length)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing %s to StreamInterface::read() is deprecated; guzzlehttp/psr7 3.0 requires int for $length.',
-                \get_debug_type($length)
-            );
-        }
-
         return $this->stream->read($length);
     }
 
-    public function write($string): int
+    public function write(string $string): int
     {
-        if (!\is_string($string)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing %s to StreamInterface::write() is deprecated; guzzlehttp/psr7 3.0 requires string for $string.',
-                \get_debug_type($string)
-            );
-        }
-
         return $this->stream->write($string);
     }
 

--- a/src/UploadedFile.php
+++ b/src/UploadedFile.php
@@ -113,11 +113,6 @@ class UploadedFile implements UploadedFileInterface
         $this->error = $error;
     }
 
-    private static function isStringNotEmpty($param): bool
-    {
-        return is_string($param) && false === empty($param);
-    }
-
     /**
      * Return true if there is no upload error
      */
@@ -159,11 +154,11 @@ class UploadedFile implements UploadedFileInterface
         return new LazyOpenStream($file, 'r+');
     }
 
-    public function moveTo($targetPath): void
+    public function moveTo(string $targetPath): void
     {
         $this->validateActive();
 
-        if (false === self::isStringNotEmpty($targetPath)) {
+        if ($targetPath === '') {
             throw new InvalidArgumentException(
                 'Invalid path provided for move operation; must be a non-empty string'
             );

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -483,7 +483,7 @@ class Uri implements UriInterface, \JsonSerializable
         return $this->fragment;
     }
 
-    public function withScheme($scheme): UriInterface
+    public function withScheme(string $scheme): UriInterface
     {
         $scheme = $this->filterScheme($scheme);
 
@@ -499,7 +499,7 @@ class Uri implements UriInterface, \JsonSerializable
         return $new;
     }
 
-    public function withUserInfo($user, $password = null): UriInterface
+    public function withUserInfo(string $user, ?string $password = null): UriInterface
     {
         $info = $this->filterUserInfoComponent($user);
         if ($password !== null) {
@@ -517,7 +517,7 @@ class Uri implements UriInterface, \JsonSerializable
         return $new;
     }
 
-    public function withHost($host): UriInterface
+    public function withHost(string $host): UriInterface
     {
         $host = $this->filterHost($host);
 
@@ -532,17 +532,8 @@ class Uri implements UriInterface, \JsonSerializable
         return $new;
     }
 
-    public function withPort($port): UriInterface
+    public function withPort(?int $port): UriInterface
     {
-        if ($port !== null && !\is_int($port)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing %s to UriInterface::withPort() is deprecated; guzzlehttp/psr7 3.0 requires int|null.',
-                \get_debug_type($port)
-            );
-        }
-
         $port = $this->filterPort($port);
 
         if ($this->port === $port) {
@@ -557,7 +548,7 @@ class Uri implements UriInterface, \JsonSerializable
         return $new;
     }
 
-    public function withPath($path): UriInterface
+    public function withPath(string $path): UriInterface
     {
         $path = $this->filterPath($path);
 
@@ -572,7 +563,7 @@ class Uri implements UriInterface, \JsonSerializable
         return $new;
     }
 
-    public function withQuery($query): UriInterface
+    public function withQuery(string $query): UriInterface
     {
         $query = $this->filterQueryAndFragment($query);
 
@@ -586,7 +577,7 @@ class Uri implements UriInterface, \JsonSerializable
         return $new;
     }
 
-    public function withFragment($fragment): UriInterface
+    public function withFragment(string $fragment): UriInterface
     {
         $fragment = $this->filterQueryAndFragment($fragment);
 
@@ -622,7 +613,7 @@ class Uri implements UriInterface, \JsonSerializable
             ? $this->filterHost($parts['host'])
             : '';
         $this->port = isset($parts['port'])
-            ? $this->filterPort($parts['port'])
+            ? $this->filterPort((int) $parts['port'])
             : null;
         $this->path = isset($parts['path'])
             ? $this->filterPath($parts['path'])
@@ -641,16 +632,10 @@ class Uri implements UriInterface, \JsonSerializable
     }
 
     /**
-     * @param mixed $scheme
-     *
      * @throws \InvalidArgumentException If the scheme is invalid.
      */
-    private function filterScheme($scheme): string
+    private function filterScheme(string $scheme): string
     {
-        if (!is_string($scheme)) {
-            throw new \InvalidArgumentException('Scheme must be a string');
-        }
-
         $scheme = \strtr($scheme, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz');
         if (preg_match('/[\x00-\x20\x7F]/', $scheme)) {
             throw new \InvalidArgumentException(sprintf('Invalid scheme: "%s"', $scheme));
@@ -660,16 +645,10 @@ class Uri implements UriInterface, \JsonSerializable
     }
 
     /**
-     * @param mixed $component
-     *
      * @throws \InvalidArgumentException If the user info is invalid.
      */
-    private function filterUserInfoComponent($component): string
+    private function filterUserInfoComponent(string $component): string
     {
-        if (!is_string($component)) {
-            throw new \InvalidArgumentException('User info must be a string');
-        }
-
         return preg_replace_callback(
             '/(?:[^%'.self::CHAR_UNRESERVED.self::CHAR_SUB_DELIMS.']+|%(?![A-Fa-f0-9]{2}))/',
             [$this, 'rawurlencodeMatchZero'],
@@ -678,16 +657,10 @@ class Uri implements UriInterface, \JsonSerializable
     }
 
     /**
-     * @param mixed $host
-     *
      * @throws \InvalidArgumentException If the host is invalid.
      */
-    private function filterHost($host): string
+    private function filterHost(string $host): string
     {
-        if (!is_string($host)) {
-            throw new \InvalidArgumentException('Host must be a string');
-        }
-
         $host = \strtr($host, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz');
         self::assertValidHost($host);
 
@@ -713,17 +686,14 @@ class Uri implements UriInterface, \JsonSerializable
     }
 
     /**
-     * @param mixed $port
-     *
      * @throws \InvalidArgumentException If the port is invalid.
      */
-    private function filterPort($port): ?int
+    private function filterPort(?int $port): ?int
     {
         if ($port === null) {
             return null;
         }
 
-        $port = (int) $port;
         if (0 > $port || 0xFFFF < $port) {
             throw new \InvalidArgumentException(
                 sprintf('Invalid port: %d. Must be between 0 and 65535', $port)
@@ -780,16 +750,10 @@ class Uri implements UriInterface, \JsonSerializable
     /**
      * Filters the path of a URI
      *
-     * @param mixed $path
-     *
      * @throws \InvalidArgumentException If the path is invalid.
      */
-    private function filterPath($path): string
+    private function filterPath(string $path): string
     {
-        if (!is_string($path)) {
-            throw new \InvalidArgumentException('Path must be a string');
-        }
-
         return preg_replace_callback(
             '/(?:[^'.self::CHAR_UNRESERVED.self::CHAR_SUB_DELIMS.'%:@\/]++|%(?![A-Fa-f0-9]{2}))/',
             [$this, 'rawurlencodeMatchZero'],
@@ -800,16 +764,10 @@ class Uri implements UriInterface, \JsonSerializable
     /**
      * Filters the query string or fragment of a URI.
      *
-     * @param mixed $str
-     *
      * @throws \InvalidArgumentException If the query or fragment is invalid.
      */
-    private function filterQueryAndFragment($str): string
+    private function filterQueryAndFragment(string $str): string
     {
-        if (!is_string($str)) {
-            throw new \InvalidArgumentException('Query and fragment must be a string');
-        }
-
         return preg_replace_callback(
             '/(?:[^'.self::CHAR_UNRESERVED.self::CHAR_SUB_DELIMS.'%:@\/\?]++|%(?![A-Fa-f0-9]{2}))/',
             [$this, 'rawurlencodeMatchZero'],

--- a/tests/HeaderTest.php
+++ b/tests/HeaderTest.php
@@ -158,25 +158,4 @@ class HeaderTest extends TestCase
     {
         self::assertSame($result, Psr7\Header::splitList($header));
     }
-
-    public function testSplitListRejectsNestedArrays(): void
-    {
-        $this->expectException(\TypeError::class);
-
-        Psr7\Header::splitList([['foo']]);
-    }
-
-    public function testSplitListArrayContainingNonStrings(): void
-    {
-        $this->expectException(\TypeError::class);
-
-        Psr7\Header::splitList(['foo', 'bar', 1, false]);
-    }
-
-    public function testSplitListRejectsNonStrings(): void
-    {
-        $this->expectException(\TypeError::class);
-
-        Psr7\Header::splitList(false);
-    }
 }

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -111,7 +111,7 @@ class RequestTest extends TestCase
     public function testWithInvalidMethods($method): void
     {
         $r = new Request('get', '/');
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(\TypeError::class);
         $r->withMethod($method);
     }
 

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -96,35 +96,6 @@ class RequestTest extends TestCase
         self::assertSame($u1, $r1->getUri());
     }
 
-    /**
-     * @dataProvider invalidMethodsProvider
-     */
-    public function testConstructWithInvalidMethods($method): void
-    {
-        $this->expectException(\TypeError::class);
-        new Request($method, '/');
-    }
-
-    /**
-     * @dataProvider invalidMethodsProvider
-     */
-    public function testWithInvalidMethods($method): void
-    {
-        $r = new Request('get', '/');
-        $this->expectException(\TypeError::class);
-        $r->withMethod($method);
-    }
-
-    public static function invalidMethodsProvider(): iterable
-    {
-        return [
-            [null],
-            [false],
-            [['foo']],
-            [new \stdClass()],
-        ];
-    }
-
     public function testSameInstanceWhenSameUri(): void
     {
         $r1 = new Request('GET', 'http://foo.com');

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -293,23 +293,6 @@ class ResponseTest extends TestCase
         yield ["\t", 'foo', "\"\t\" is not valid header name."];
     }
 
-    /**
-     * @dataProvider invalidHeaderNameTypeProvider
-     */
-    public function testWithInvalidHeaderNameType($header): void
-    {
-        $this->expectException(\TypeError::class);
-
-        (new Response())->withHeader($header, 'foo');
-    }
-
-    public static function invalidHeaderNameTypeProvider(): iterable
-    {
-        yield [[]];
-        yield [false];
-        yield [new \stdClass()];
-    }
-
     public function testHeaderValuesAreTrimmed(): void
     {
         $r1 = new Response(200, ['OWS' => " \t \tFoo\t \t "]);
@@ -330,39 +313,6 @@ class ResponseTest extends TestCase
 
         $headerLine = $message->getHeaderLine('list');
         self::assertSame('one, two, three', $headerLine);
-    }
-
-    /**
-     * @dataProvider nonIntegerStatusCodeProvider
-     *
-     * @param mixed $invalidValues
-     */
-    public function testConstructResponseWithNonIntegerStatusCode($invalidValues): void
-    {
-        $this->expectException(\TypeError::class);
-        new Response($invalidValues);
-    }
-
-    /**
-     * @dataProvider nonIntegerStatusCodeProvider
-     *
-     * @param mixed $invalidValues
-     */
-    public function testResponseChangeStatusCodeWithNonInteger($invalidValues): void
-    {
-        $response = new Response();
-        $this->expectException(\TypeError::class);
-        $response->withStatus($invalidValues);
-    }
-
-    public static function nonIntegerStatusCodeProvider(): iterable
-    {
-        return [
-            ['whatever'],
-            ['1.01'],
-            [1.01],
-            [new \stdClass()],
-        ];
     }
 
     /**

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -261,7 +261,10 @@ class ResponseTest extends TestCase
     {
         return [
             ['', '', '"" is not valid header name'],
-            ['foo', new \stdClass(),  'Header value must be scalar or null but stdClass provided.'],
+            ['foo', new \stdClass(),  'Header value must be a string or array of strings but stdClass provided.'],
+            ['foo', 1, 'Header value must be a string or array of strings but integer provided.'],
+            ['foo', null, 'Header value must be a string or array of strings but NULL provided.'],
+            ['foo', [1], 'Header value must be a string or array of strings but integer provided.'],
         ];
     }
 
@@ -279,9 +282,6 @@ class ResponseTest extends TestCase
     public static function invalidWithHeaderProvider(): iterable
     {
         yield from self::invalidHeaderProvider();
-        yield [[], 'foo', 'Header name must be a string but array provided.'];
-        yield [false, 'foo', 'Header name must be a string but boolean provided.'];
-        yield [new \stdClass(), 'foo', 'Header name must be a string but stdClass provided.'];
         yield ['', 'foo', '"" is not valid header name.'];
         yield ["Content-Type\r\n\r\n", 'foo', "\"Content-Type\r\n\r\n\" is not valid header name."];
         yield ["Content-Type\r\n", 'foo', "\"Content-Type\r\n\" is not valid header name."];
@@ -291,6 +291,23 @@ class ResponseTest extends TestCase
         yield ["\n", 'foo', "\"\n\" is not valid header name."];
         yield ["\r\n", 'foo', "\"\r\n\" is not valid header name."];
         yield ["\t", 'foo', "\"\t\" is not valid header name."];
+    }
+
+    /**
+     * @dataProvider invalidHeaderNameTypeProvider
+     */
+    public function testWithInvalidHeaderNameType($header): void
+    {
+        $this->expectException(\TypeError::class);
+
+        (new Response())->withHeader($header, 'foo');
+    }
+
+    public static function invalidHeaderNameTypeProvider(): iterable
+    {
+        yield [[]];
+        yield [false];
+        yield [new \stdClass()];
     }
 
     public function testHeaderValuesAreTrimmed(): void
@@ -334,8 +351,7 @@ class ResponseTest extends TestCase
     public function testResponseChangeStatusCodeWithNonInteger($invalidValues): void
     {
         $response = new Response();
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Status code must be an integer value.');
+        $this->expectException(\TypeError::class);
         $response->withStatus($invalidValues);
     }
 

--- a/tests/UploadedFileTest.php
+++ b/tests/UploadedFileTest.php
@@ -99,31 +99,6 @@ class UploadedFileTest extends TestCase
         self::assertSame($stream->__toString(), file_get_contents($to));
     }
 
-    public static function invalidMovePaths(): iterable
-    {
-        return [
-            'null' => [null],
-            'true' => [true],
-            'false' => [false],
-            'int' => [1],
-            'float' => [1.1],
-            'array' => [['filename']],
-            'object' => [(object) ['filename']],
-        ];
-    }
-
-    /**
-     * @dataProvider invalidMovePaths
-     */
-    public function testMoveRaisesExceptionForInvalidPath($path): void
-    {
-        $stream = \GuzzleHttp\Psr7\Utils::streamFor('Foo bar!');
-        $upload = new UploadedFile($stream, 0, UPLOAD_ERR_OK);
-
-        $this->expectException(\TypeError::class);
-        $upload->moveTo($path);
-    }
-
     public function testMoveRaisesExceptionForEmptyPath(): void
     {
         $stream = \GuzzleHttp\Psr7\Utils::streamFor('Foo bar!');

--- a/tests/UploadedFileTest.php
+++ b/tests/UploadedFileTest.php
@@ -107,7 +107,6 @@ class UploadedFileTest extends TestCase
             'false' => [false],
             'int' => [1],
             'float' => [1.1],
-            'empty' => [''],
             'array' => [['filename']],
             'object' => [(object) ['filename']],
         ];
@@ -121,9 +120,18 @@ class UploadedFileTest extends TestCase
         $stream = \GuzzleHttp\Psr7\Utils::streamFor('Foo bar!');
         $upload = new UploadedFile($stream, 0, UPLOAD_ERR_OK);
 
+        $this->expectException(\TypeError::class);
+        $upload->moveTo($path);
+    }
+
+    public function testMoveRaisesExceptionForEmptyPath(): void
+    {
+        $stream = \GuzzleHttp\Psr7\Utils::streamFor('Foo bar!');
+        $upload = new UploadedFile($stream, 0, UPLOAD_ERR_OK);
+
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('path');
-        $upload->moveTo($path);
+        $upload->moveTo('');
     }
 
     public function testMoveCannotBeCalledMoreThanOnce(): void

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -214,7 +214,7 @@ class UriTest extends TestCase
 
     public function testSchemeMustHaveCorrectType(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(\TypeError::class);
         (new Uri())->withScheme([]);
     }
 
@@ -246,7 +246,7 @@ class UriTest extends TestCase
 
     public function testHostMustHaveCorrectType(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(\TypeError::class);
         (new Uri())->withHost([]);
     }
 
@@ -282,19 +282,19 @@ class UriTest extends TestCase
 
     public function testPathMustHaveCorrectType(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(\TypeError::class);
         (new Uri())->withPath([]);
     }
 
     public function testQueryMustHaveCorrectType(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(\TypeError::class);
         (new Uri())->withQuery([]);
     }
 
     public function testFragmentMustHaveCorrectType(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(\TypeError::class);
         (new Uri())->withFragment([]);
     }
 

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -212,12 +212,6 @@ class UriTest extends TestCase
         new Uri('//example.com:-1');
     }
 
-    public function testSchemeMustHaveCorrectType(): void
-    {
-        $this->expectException(\TypeError::class);
-        (new Uri())->withScheme([]);
-    }
-
     /**
      * @dataProvider getInvalidSchemes
      */
@@ -242,12 +236,6 @@ class UriTest extends TestCase
         $this->expectException(MalformedUriException::class);
 
         Uri::fromParts(['scheme' => "ht\ntp", 'host' => 'example.com']);
-    }
-
-    public function testHostMustHaveCorrectType(): void
-    {
-        $this->expectException(\TypeError::class);
-        (new Uri())->withHost([]);
     }
 
     /**
@@ -278,24 +266,6 @@ class UriTest extends TestCase
         yield 'unterminated bracketed IPv6' => ['[::1'];
         yield 'unbalanced opening bracket' => ['example[com'];
         yield 'unbalanced closing bracket' => ['example]com'];
-    }
-
-    public function testPathMustHaveCorrectType(): void
-    {
-        $this->expectException(\TypeError::class);
-        (new Uri())->withPath([]);
-    }
-
-    public function testQueryMustHaveCorrectType(): void
-    {
-        $this->expectException(\TypeError::class);
-        (new Uri())->withQuery([]);
-    }
-
-    public function testFragmentMustHaveCorrectType(): void
-    {
-        $this->expectException(\TypeError::class);
-        (new Uri())->withFragment([]);
     }
 
     public function testCanParseFalseyUriParts(): void


### PR DESCRIPTION
This updates 3.0 to require psr/http-message:^2.0 and psr/http-factory:^1.1, and updates the provided implementation metadata to psr/http-message 2.0 and psr/http-factory 1.1. It removes the 2.11 deprecation shims, adds the native parameter types from PSR-7 v2 across messages, requests, responses, URIs, streams, and uploaded files, and keeps the stricter 3.0 validation for header values, uploaded file trees, and parsed bodies. The upgrade guide and changelog now group the dependency, native type, and invalid value changes together for easier review.