### PR TITLE
Improve PSR-7 spec compliance

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -44,3 +44,8 @@ jobs:
         env:
           TEST_SERVER: 127.0.0.1:10002
         run: vendor/bin/phpunit --testsuite "PSR-17 Integration Test Suite"
+
+      - name: Run PSR-7 integration tests
+        env:
+          TEST_SERVER: 127.0.0.1:10002
+        run: vendor/bin/phpunit --testsuite "PSR-7 Integration Test Suite" --exclude-group internet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Require `psr/http-message:^2.0` and add its native parameter types
 - Require `psr/http-factory:^1.1`
-- Reject non-string header values, invalid uploaded file trees, and invalid parsed body values
-- Harden URI host and scheme validation
+- Preserve HTTP request method casing instead of uppercasing methods automatically
+- Reject empty arrays and non-string values as header values
+- Reject invalid uploaded file trees and invalid parsed body values
+- Normalize multiple leading slashes to one slash in `Uri::getPath()` and URI-derived `Request::getRequestTarget()` values
+- Harden URI host and scheme validation, including rejecting schemes that do not begin with a letter
 - Ignore malformed `HTTP_HOST` values in `ServerRequest::getUriFromGlobals()`
 - Reject hosts with embedded ports in `Uri::withHost()`
 - Validate iterator chunks passed to `Utils::streamFor()`

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -56,16 +56,34 @@ $response = $response->withStatus(201);
 $uri = $uri->withPort(8080);
 ```
 
-Header values must now be strings or arrays of strings. Scalars and `null` are no
-longer cast to strings.
+Request methods are no longer uppercased by `Request` or `withMethod()`. If your
+application requires uppercase methods, normalize methods before constructing or
+modifying requests.
+
+```php
+// 2.x
+$request = new Request('get', '/');
+$request->getMethod(); // GET
+
+// 3.0
+$request = new Request('get', '/');
+$request->getMethod(); // get
+```
+
+Header values must now be strings or non-empty arrays of strings. Scalars, `null`,
+`false`, and empty arrays are no longer cast or accepted.
 
 ```php
 // 2.x, no longer accepted in 3.0
 $response = $response->withHeader('Api-Version', 1);
+$response = $response->withHeader('Empty-List', []);
 
 // 3.0
 $response = $response->withHeader('Api-Version', '1');
+$response = $response->withHeader('Empty-Value', '');
 ```
+
+Use `withoutHeader()` to remove a header.
 
 `ServerRequestInterface::withUploadedFiles()` now rejects invalid nested upload
 trees. Every leaf must be an `UploadedFileInterface` instance.
@@ -109,6 +127,16 @@ Common host forms such as `localhost`, single-label hosts, underscores, Unicode
 hosts, valid IPv6 literals, and normal host and port URI strings remain
 supported.
 
+URI schemes must now match RFC 3986 syntax and begin with a letter.
+
+```php
+// 2.x, no longer accepted in 3.0
+$uri = (new Uri())->withScheme('0');
+
+// 3.0
+$uri = (new Uri())->withScheme('https');
+```
+
 The stricter validation also applies when a request is created or modified from
 a custom `UriInterface` implementation and its host is used to generate or
 update a `Host` header.
@@ -120,6 +148,22 @@ host behavior.
 Applications that need to reject malformed inbound `Host` headers should
 validate the request host before calling `getUriFromGlobals()` or inspect the
 original server parameters.
+
+#### URI Paths and Request Targets
+
+`Uri::getPath()` now normalizes multiple leading slashes to one slash when
+returning the path in isolation. Casting the URI to string still preserves the
+original URI representation.
+
+```php
+$uri = new Uri('http://example.org//valid///path');
+
+$uri->getPath(); // /valid///path
+(string) $uri;   // http://example.org//valid///path
+```
+
+`Request::getRequestTarget()` applies the same normalization for URI-derived
+origin-form request targets.
 
 #### Query Builder Values
 

--- a/composer.json
+++ b/composer.json
@@ -58,6 +58,7 @@
         "bamarni/composer-bin-plugin": "^1.8.2",
         "http-interop/http-factory-tests": "1.1.0",
         "jshttp/mime-db": "1.54.0.1",
+        "php-http/psr7-integration-tests": "^1.5.1",
         "phpunit/phpunit": "^9.6.34"
     },
     "provide": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,12 +12,16 @@
         <testsuite name="Guzzle PSR-7 Unit Test Suite">
             <directory>tests</directory>
             <exclude>tests/Integration</exclude>
+            <exclude>tests/Psr7Integration</exclude>
         </testsuite>
         <testsuite name="Guzzle PSR-7 Integration Test Suite">
             <directory>tests/Integration</directory>
         </testsuite>
         <testsuite name="PSR-17 Integration Test Suite">
             <directory>./vendor/http-interop/http-factory-tests/test</directory>
+        </testsuite>
+        <testsuite name="PSR-7 Integration Test Suite">
+            <directory>tests/Psr7Integration</directory>
         </testsuite>
     </testsuites>
     <coverage>

--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -186,11 +186,7 @@ trait MessageTrait
     private function normalizeHeaderValue($value): array
     {
         if (is_array($value) && $value === []) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing an empty array as a header value is deprecated; guzzlehttp/psr7 3.0 rejects empty header value arrays.'
-            );
+            throw new \InvalidArgumentException('Header value must be a non-empty array or string.');
         }
 
         if (!is_array($value)) {

--- a/src/Request.php
+++ b/src/Request.php
@@ -44,7 +44,7 @@ class Request implements RequestInterface
             $uri = new Uri($uri);
         }
 
-        $this->method = strtoupper($method);
+        $this->method = $method;
         $this->uri = $uri;
         $this->setHeaders($headers);
         $this->protocol = $version;
@@ -64,7 +64,7 @@ class Request implements RequestInterface
             return $this->requestTarget;
         }
 
-        $target = $this->uri->getPath();
+        $target = self::normalizePathForOriginForm($this->uri->getPath());
         if ($target === '') {
             $target = '/';
         }
@@ -98,7 +98,7 @@ class Request implements RequestInterface
     {
         $this->assertMethod($method);
         $new = clone $this;
-        $new->method = strtoupper($method);
+        $new->method = $method;
 
         return $new;
     }
@@ -154,5 +154,14 @@ class Request implements RequestInterface
         if ($method === '') {
             throw new InvalidArgumentException('Method must be a non-empty string.');
         }
+    }
+
+    private static function normalizePathForOriginForm(string $path): string
+    {
+        if (isset($path[1]) && $path[0] === '/' && $path[1] === '/') {
+            return '/'.ltrim($path, '/');
+        }
+
+        return $path;
     }
 }

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -187,13 +187,21 @@ class ServerRequest extends Request implements ServerRequestInterface
     private static function getAllHeaders(): array
     {
         if (\function_exists('apache_request_headers')) {
-            $headers = \apache_request_headers();
+            $headers = self::getApacheRequestHeaders();
             if (is_array($headers)) {
                 return self::normalizeHeaderValues($headers);
             }
         }
 
         return self::getHeadersFromServer($_SERVER);
+    }
+
+    /**
+     * @return mixed
+     */
+    private static function getApacheRequestHeaders()
+    {
+        return \apache_request_headers();
     }
 
     /**

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -470,6 +470,10 @@ class Uri implements UriInterface, \JsonSerializable
 
     public function getPath(): string
     {
+        if (isset($this->path[1]) && $this->path[0] === '/' && $this->path[1] === '/') {
+            return '/'.ltrim($this->path, '/');
+        }
+
         return $this->path;
     }
 

--- a/tests/Psr7Integration/RequestTest.php
+++ b/tests/Psr7Integration/RequestTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GuzzleHttp\Tests\Psr7\Psr7Integration;
+
+use GuzzleHttp\Psr7\Request;
+use Http\Psr7Test\RequestIntegrationTest;
+
+final class RequestTest extends RequestIntegrationTest
+{
+    public function createSubject()
+    {
+        return new Request('GET', '/');
+    }
+}

--- a/tests/Psr7Integration/ResponseTest.php
+++ b/tests/Psr7Integration/ResponseTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GuzzleHttp\Tests\Psr7\Psr7Integration;
+
+use GuzzleHttp\Psr7\Response;
+use Http\Psr7Test\ResponseIntegrationTest;
+
+final class ResponseTest extends ResponseIntegrationTest
+{
+    public function createSubject()
+    {
+        return new Response();
+    }
+}

--- a/tests/Psr7Integration/ServerRequestTest.php
+++ b/tests/Psr7Integration/ServerRequestTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GuzzleHttp\Tests\Psr7\Psr7Integration;
+
+use GuzzleHttp\Psr7\ServerRequest;
+use Http\Psr7Test\ServerRequestIntegrationTest;
+
+final class ServerRequestTest extends ServerRequestIntegrationTest
+{
+    public function createSubject()
+    {
+        return new ServerRequest('GET', '/', [], null, '1.1', $_SERVER);
+    }
+}

--- a/tests/Psr7Integration/StreamTest.php
+++ b/tests/Psr7Integration/StreamTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GuzzleHttp\Tests\Psr7\Psr7Integration;
+
+use GuzzleHttp\Psr7\Utils;
+use Http\Psr7Test\StreamIntegrationTest;
+
+final class StreamTest extends StreamIntegrationTest
+{
+    public function createStream($data)
+    {
+        return Utils::streamFor($data);
+    }
+}

--- a/tests/Psr7Integration/UploadedFileTest.php
+++ b/tests/Psr7Integration/UploadedFileTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GuzzleHttp\Tests\Psr7\Psr7Integration;
+
+use GuzzleHttp\Psr7\UploadedFile;
+use GuzzleHttp\Psr7\Utils;
+use Http\Psr7Test\UploadedFileIntegrationTest;
+
+final class UploadedFileTest extends UploadedFileIntegrationTest
+{
+    public function createSubject()
+    {
+        $stream = Utils::streamFor('Foobar');
+
+        return new UploadedFile(
+            $stream,
+            $stream->getSize(),
+            UPLOAD_ERR_OK,
+            'filename.txt',
+            'text/plain'
+        );
+    }
+}

--- a/tests/Psr7Integration/UriTest.php
+++ b/tests/Psr7Integration/UriTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GuzzleHttp\Tests\Psr7\Psr7Integration;
+
+use GuzzleHttp\Psr7\Uri;
+use Http\Psr7Test\UriIntegrationTest;
+
+final class UriTest extends UriIntegrationTest
+{
+    public function createUri($uri)
+    {
+        return new Uri($uri);
+    }
+}

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -73,16 +73,16 @@ class RequestTest extends TestCase
         self::assertSame($body, $r->getBody());
     }
 
-    public function testCapitalizesMethod(): void
+    public function testPreservesMethodCase(): void
     {
         $r = new Request('get', '/');
-        self::assertSame('GET', $r->getMethod());
+        self::assertSame('get', $r->getMethod());
     }
 
-    public function testCapitalizesWithMethod(): void
+    public function testWithMethodPreservesMethodCase(): void
     {
         $r = new Request('GET', '/');
-        self::assertSame('PUT', $r->withMethod('put')->getMethod());
+        self::assertSame('put', $r->withMethod('put')->getMethod());
     }
 
     public function testWithUri(): void
@@ -140,6 +140,33 @@ class RequestTest extends TestCase
         self::assertSame('/baz?0', $r1->getRequestTarget());
     }
 
+    public function testRequestTargetNormalizesMultipleLeadingSlashesForGuzzleUri(): void
+    {
+        $request = new Request('GET', 'http://example.org//valid///path?x=1');
+
+        self::assertSame('/valid///path?x=1', $request->getRequestTarget());
+    }
+
+    public function testRequestTargetNormalizesMultipleLeadingSlashesForArbitraryUri(): void
+    {
+        $uri = $this->createMock(UriInterface::class);
+        $uri->method('getPath')->willReturn('//valid///path');
+        $uri->method('getQuery')->willReturn('x=1');
+        $uri->method('getHost')->willReturn('');
+        $uri->method('getPort')->willReturn(null);
+
+        $request = new Request('GET', $uri);
+
+        self::assertSame('/valid///path?x=1', $request->getRequestTarget());
+    }
+
+    public function testRequestTargetPreservesInternalRepeatedSlashes(): void
+    {
+        $request = new Request('GET', 'http://example.org/valid///path?x=1');
+
+        self::assertSame('/valid///path?x=1', $request->getRequestTarget());
+    }
+
     public function testHostIsAddedFirst(): void
     {
         $r = new Request('GET', 'http://foo.com/baz?bar=bam', ['Foo' => 'Bar']);
@@ -158,6 +185,14 @@ class RequestTest extends TestCase
             'Host' => ['example.com'],
             'User-Agent' => ['Linux f0f489981e90 5.10.104-linuxkit 1 SMP Wed Mar 9 19:05:23 UTC 2022 x86_64'],
         ], $r->getHeaders());
+    }
+
+    public function testEmptyListHeaderValueIsRejected(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Header value must be a non-empty array or string.');
+
+        new Request('GET', 'https://example.com/', ['Foo' => []]);
     }
 
     public function testCanGetHeaderAsCsv(): void

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -239,6 +239,14 @@ class ResponseTest extends TestCase
         self::assertSame('bar', $r->getHeaderLine('123'));
     }
 
+    public function testConstructResponseEmptyListHeaderValueIsRejected(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Header value must be a non-empty array or string.');
+
+        new Response(200, ['Foo' => []]);
+    }
+
     /**
      * @dataProvider invalidHeaderProvider
      */
@@ -253,6 +261,8 @@ class ResponseTest extends TestCase
     {
         return [
             ['', '', '"" is not valid header name'],
+            ['foo', [], 'Header value must be a non-empty array or string.'],
+            ['foo', false, 'Header value must be a string or array of strings but boolean provided.'],
             ['foo', new \stdClass(),  'Header value must be a string or array of strings but stdClass provided.'],
             ['foo', 1, 'Header value must be a string or array of strings but integer provided.'],
             ['foo', null, 'Header value must be a string or array of strings but NULL provided.'],
@@ -283,6 +293,17 @@ class ResponseTest extends TestCase
         yield ["\n", 'foo', "\"\n\" is not valid header name."];
         yield ["\r\n", 'foo', "\"\r\n\" is not valid header name."];
         yield ["\t", 'foo', "\"\t\" is not valid header name."];
+    }
+
+    /**
+     * @dataProvider invalidWithHeaderProvider
+     */
+    public function testWithInvalidAddedHeader($header, $headerValue, $expectedMessage): void
+    {
+        $r = new Response();
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage($expectedMessage);
+        $r->withAddedHeader($header, $headerValue);
     }
 
     public function testHeaderValuesAreTrimmed(): void

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -758,6 +758,52 @@ class ServerRequestTest extends TestCase
         self::assertSame($params, $request2->getParsedBody());
     }
 
+    /**
+     * @dataProvider validParsedBodyProvider
+     */
+    public function testWithParsedBodyAcceptsValidValues($value): void
+    {
+        $request = new ServerRequest('GET', '/');
+
+        $new = $request->withParsedBody($value);
+
+        self::assertNotSame($request, $new);
+        self::assertNull($request->getParsedBody());
+        self::assertSame($value, $new->getParsedBody());
+    }
+
+    public static function validParsedBodyProvider(): iterable
+    {
+        yield 'null' => [null];
+        yield 'array' => [['name' => 'value']];
+        yield 'object' => [(object) ['name' => 'value']];
+    }
+
+    /**
+     * @dataProvider invalidParsedBodyProvider
+     */
+    public function testWithParsedBodyRejectsInvalidValues($value): void
+    {
+        $request = (new ServerRequest('GET', '/'))->withParsedBody(['original' => 'value']);
+
+        try {
+            $request->withParsedBody($value);
+            self::fail('Parsed body value should have been rejected.');
+        } catch (\InvalidArgumentException $e) {
+            self::assertSame('Parsed body must be an array, object, or null.', $e->getMessage());
+            self::assertSame(['original' => 'value'], $request->getParsedBody());
+        }
+    }
+
+    public static function invalidParsedBodyProvider(): iterable
+    {
+        yield 'integer' => [1];
+        yield 'float' => [1.1];
+        yield 'string' => ['body'];
+        yield 'true' => [true];
+        yield 'false' => [false];
+    }
+
     public function testAttributes(): void
     {
         $request1 = new ServerRequest('GET', '/');

--- a/tests/UriResolverTest.php
+++ b/tests/UriResolverTest.php
@@ -249,9 +249,9 @@ class UriResolverTest extends TestCase
             // empty base path and relative-path reference
             ['//example.com',    'a',             '//example.com/a'],
             // path starting with two slashes
-            ['//example.com//two-slashes', './',  '//example.com//'],
-            ['//example.com',    './/',           '//example.com//'],
-            ['//example.com/',   './/',           '//example.com//'],
+            ['//example.com//two-slashes', './',  '//example.com/'],
+            ['//example.com',    './',            '//example.com/'],
+            ['//example.com/',   './',            '//example.com/'],
             // base URI has less components than relative URI
             ['/',                '//a/b?q#h',     '//a/b?q#h'],
             ['/',                'urn:/',         'urn:/'],

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -229,6 +229,8 @@ class UriTest extends TestCase
         }
 
         yield 'ascii 0x7F' => ['ht'.chr(0x7F).'tp'];
+        yield 'starts with digit' => ['0'];
+        yield 'contains underscore' => ['ht_tp'];
     }
 
     public function testFromPartsRejectsSchemeWithControlCharacter(): void
@@ -731,12 +733,35 @@ class UriTest extends TestCase
     public function testPathStartingWithTwoSlashes(): void
     {
         $uri = new Uri('http://example.org//path-not-host.com');
-        self::assertSame('//path-not-host.com', $uri->getPath());
+        self::assertSame('/path-not-host.com', $uri->getPath());
+        self::assertSame('http://example.org//path-not-host.com', (string) $uri);
 
         $uri = $uri->withScheme('');
         self::assertSame('//example.org//path-not-host.com', (string) $uri); // This is still valid
         $this->expectException(\InvalidArgumentException::class);
         $uri->withHost(''); // Now it becomes invalid
+    }
+
+    public function testGetPathNormalizesMultipleLeadingSlashes(): void
+    {
+        $uri = new Uri('http://example.org//valid///path');
+
+        self::assertSame('/valid///path', $uri->getPath());
+    }
+
+    public function testStringRepresentationPreservesMultipleLeadingSlashes(): void
+    {
+        $uri = new Uri('http://example.org//valid///path');
+
+        self::assertSame('http://example.org//valid///path', (string) $uri);
+    }
+
+    public function testGetPathPreservesInternalMultipleSlashes(): void
+    {
+        $uri = new Uri('http://example.org/valid///path');
+
+        self::assertSame('/valid///path', $uri->getPath());
+        self::assertSame('http://example.org/valid///path', (string) $uri);
     }
 
     public function testRelativeUriWithPathBeginngWithColonSegmentIsInvalid(): void


### PR DESCRIPTION
Adds the php-http PSR-7 integration suite with local adapters and CI coverage. Updates the remaining 3.0 compliance behavior for methods, headers, URI paths, request targets, and scheme validation.