### PR TITLE
Deprecate additional 3.0 changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Deprecated invalid PSR-7 arguments that guzzlehttp/psr7 3.0 will require native types for
 - Deprecated non-string header values that guzzlehttp/psr7 3.0 will reject
+- Deprecated empty header value arrays that guzzlehttp/psr7 3.0 will reject
+- Deprecated URI schemes that do not match guzzlehttp/psr7 3.0 syntax requirements
 
 ## 2.10.1 - 2026-05-20
 

--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -234,6 +234,14 @@ trait MessageTrait
      */
     private function normalizeHeaderValue($value): array
     {
+        if (is_array($value) && $value === []) {
+            \trigger_deprecation(
+                'guzzlehttp/psr7',
+                '2.11',
+                'Passing an empty array as a header value is deprecated; guzzlehttp/psr7 3.0 rejects empty header value arrays.'
+            );
+        }
+
         if (!is_array($value)) {
             return $this->trimAndValidateHeaderValues([$value]);
         }

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -613,7 +613,18 @@ class Uri implements UriInterface, \JsonSerializable
             throw new \InvalidArgumentException('Scheme must be a string');
         }
 
-        return \strtr($scheme, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz');
+        $scheme = \strtr($scheme, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz');
+
+        if ($scheme !== '' && !preg_match('/^[a-z][a-z0-9.+-]*$/D', $scheme)) {
+            \trigger_deprecation(
+                'guzzlehttp/psr7',
+                '2.11',
+                'Passing "%s" as a URI scheme is deprecated; guzzlehttp/psr7 3.0 requires URI schemes to match RFC 3986 syntax and begin with a letter.',
+                $scheme
+            );
+        }
+
+        return $scheme;
     }
 
     /**

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -188,14 +188,6 @@ class RequestTest extends TestCase
         ], $r->getHeaders());
     }
 
-    public function testEmptyListHeaderValue(): void
-    {
-        $r = new Request('GET', 'https://example.com/', ['Foo' => []]);
-        self::assertSame('', $r->getHeaderLine('Foo'));
-        self::assertSame([], $r->getHeader('Foo'));
-        self::assertSame(['Host' => ['example.com'], 'Foo' => []], $r->getHeaders());
-    }
-
     public function testCanGetHeaderAsCsv(): void
     {
         $r = new Request('GET', 'http://foo.com/baz?bar=bam', [

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -239,14 +239,6 @@ class ResponseTest extends TestCase
         self::assertSame('bar', $r->getHeaderLine('123'));
     }
 
-    public function testConstructResponseEmptyListHeaderValue(): void
-    {
-        $r = new Response(200, ['Foo' => []]);
-        self::assertSame('', $r->getHeaderLine('Foo'));
-        self::assertSame([], $r->getHeader('Foo'));
-        self::assertSame(['Foo' => []], $r->getHeaders());
-    }
-
     /**
      * @dataProvider invalidHeaderProvider
      */

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -232,38 +232,38 @@ class UriTest extends TestCase
         (new Uri())->withFragment([]);
     }
 
-    public function testCanParseFalseyUriParts(): void
+    public function testCanParseFalseyUriPartsExceptScheme(): void
     {
-        $uri = new Uri('0://0:0@0/0?0#0');
+        $uri = new Uri('x://0:0@0/0?0#0');
 
-        self::assertSame('0', $uri->getScheme());
+        self::assertSame('x', $uri->getScheme());
         self::assertSame('0:0@0', $uri->getAuthority());
         self::assertSame('0:0', $uri->getUserInfo());
         self::assertSame('0', $uri->getHost());
         self::assertSame('/0', $uri->getPath());
         self::assertSame('0', $uri->getQuery());
         self::assertSame('0', $uri->getFragment());
-        self::assertSame('0://0:0@0/0?0#0', (string) $uri);
+        self::assertSame('x://0:0@0/0?0#0', (string) $uri);
     }
 
-    public function testCanConstructFalseyUriParts(): void
+    public function testCanConstructFalseyUriPartsExceptScheme(): void
     {
         $uri = (new Uri())
-            ->withScheme('0')
+            ->withScheme('x')
             ->withUserInfo('0', '0')
             ->withHost('0')
             ->withPath('/0')
             ->withQuery('0')
             ->withFragment('0');
 
-        self::assertSame('0', $uri->getScheme());
+        self::assertSame('x', $uri->getScheme());
         self::assertSame('0:0@0', $uri->getAuthority());
         self::assertSame('0:0', $uri->getUserInfo());
         self::assertSame('0', $uri->getHost());
         self::assertSame('/0', $uri->getPath());
         self::assertSame('0', $uri->getQuery());
         self::assertSame('0', $uri->getFragment());
-        self::assertSame('0://0:0@0/0?0#0', (string) $uri);
+        self::assertSame('x://0:0@0/0?0#0', (string) $uri);
     }
 
     /**


### PR DESCRIPTION
Deprecates empty header value arrays and URI schemes that will be rejected in 3.0.