### PR TITLE
Handle short stream writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 2.11.0 - TBD
 
+### Changed
+
+- Changed `Utils::copyToStream()` to retry short destination writes and throw when destination streams cannot make progress
+
 ### Deprecated
 
 - Deprecated invalid PSR-7 arguments that guzzlehttp/psr7 3.0 will require native types for

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -49,9 +49,12 @@ final class Utils
 
         if ($maxLen === -1) {
             while (!$source->eof()) {
-                if (!$dest->write($source->read($bufferSize))) {
+                $buf = $source->read($bufferSize);
+                if ($buf === '') {
                     break;
                 }
+
+                self::writeAll($dest, $buf);
             }
         } else {
             $remaining = $maxLen;
@@ -62,8 +65,23 @@ final class Utils
                     break;
                 }
                 $remaining -= $len;
-                $dest->write($buf);
+                self::writeAll($dest, $buf);
             }
+        }
+    }
+
+    private static function writeAll(StreamInterface $dest, string $buf): void
+    {
+        $written = 0;
+        $len = strlen($buf);
+
+        while ($written < $len) {
+            $result = $dest->write(substr($buf, $written));
+            if ($result <= 0) {
+                throw new \RuntimeException('Unable to write to stream');
+            }
+
+            $written += $result;
         }
     }
 

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -49,6 +49,46 @@ class UtilsTest extends TestCase
         self::assertSame('foobaz', (string) $s2);
     }
 
+    public function testCopyToStreamRetriesShortWrites(): void
+    {
+        $s1 = Psr7\Utils::streamFor('foobaz');
+        $sink = Psr7\Utils::streamFor('');
+        $writes = 0;
+
+        $s2 = FnStream::decorate($sink, [
+            'write' => function (string $string) use ($sink, &$writes): int {
+                ++$writes;
+
+                return $sink->write(substr($string, 0, 1));
+            },
+        ]);
+
+        Psr7\Utils::copyToStream($s1, $s2);
+
+        self::assertSame('foobaz', (string) $sink);
+        self::assertSame(6, $writes);
+    }
+
+    public function testCopyToStreamRetriesShortWritesWithMaxLen(): void
+    {
+        $s1 = Psr7\Utils::streamFor('foobaz');
+        $sink = Psr7\Utils::streamFor('');
+        $writes = 0;
+
+        $s2 = FnStream::decorate($sink, [
+            'write' => function (string $string) use ($sink, &$writes): int {
+                ++$writes;
+
+                return $sink->write(substr($string, 0, 1));
+            },
+        ]);
+
+        Psr7\Utils::copyToStream($s1, $s2, 3);
+
+        self::assertSame('foo', (string) $sink);
+        self::assertSame(3, $writes);
+    }
+
     public function testStopsCopyToStreamWhenWriteFails(): void
     {
         $s1 = Psr7\Utils::streamFor('foobaz');
@@ -58,11 +98,14 @@ class UtilsTest extends TestCase
                 return 0;
             },
         ]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Unable to write to stream');
+
         Psr7\Utils::copyToStream($s1, $s2);
-        self::assertSame('', (string) $s2);
     }
 
-    public function testStopsCopyToSteamWhenWriteFailsWithMaxLen(): void
+    public function testStopsCopyToStreamWhenWriteFailsWithMaxLen(): void
     {
         $s1 = Psr7\Utils::streamFor('foobaz');
         $s2 = Psr7\Utils::streamFor('');
@@ -71,8 +114,11 @@ class UtilsTest extends TestCase
                 return 0;
             },
         ]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Unable to write to stream');
+
         Psr7\Utils::copyToStream($s1, $s2, 10);
-        self::assertSame('', (string) $s2);
     }
 
     public function testCopyToStreamReadsInChunksInsteadOfAllInMemory(): void

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -89,7 +89,7 @@ class UtilsTest extends TestCase
         self::assertSame(3, $writes);
     }
 
-    public function testStopsCopyToStreamWhenWriteFails(): void
+    public function testCopyToStreamThrowsWhenWriteFails(): void
     {
         $s1 = Psr7\Utils::streamFor('foobaz');
         $s2 = Psr7\Utils::streamFor('');
@@ -105,7 +105,7 @@ class UtilsTest extends TestCase
         Psr7\Utils::copyToStream($s1, $s2);
     }
 
-    public function testStopsCopyToStreamWhenWriteFailsWithMaxLen(): void
+    public function testCopyToStreamThrowsWhenWriteFailsWithMaxLen(): void
     {
         $s1 = Psr7\Utils::streamFor('foobaz');
         $s2 = Psr7\Utils::streamFor('');


### PR DESCRIPTION
This changes Utils::copyToStream() to keep writing each buffer until the destination stream accepts all bytes. If a destination stream cannot make progress, it now throws instead of silently stopping.