### PR TITLE
Change Header parameter splitting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Changed `Utils::copyToStream()` to retry short destination writes and throw when destination streams cannot make progress
+- Changed `Header::parse()` to split semicolon-separated parameters without repeated regular expression lookaheads
 
 ### Deprecated
 

--- a/src/Header.php
+++ b/src/Header.php
@@ -22,7 +22,7 @@ final class Header
         foreach ((array) $header as $value) {
             foreach (self::splitList($value) as $val) {
                 $part = [];
-                foreach (preg_split('/;(?=([^"]*"[^"]*")*[^"]*$)/', $val) ?: [] as $kvp) {
+                foreach (self::splitParameters($val) as $kvp) {
                     if (preg_match_all('/<[^>]+>|[^=]+/', $kvp, $matches)) {
                         $m = $matches[0];
                         if (isset($m[1])) {
@@ -39,6 +39,35 @@ final class Header
         }
 
         return $params;
+    }
+
+    /**
+     * Split a header value into semicolon-separated parameters.
+     *
+     * @return string[]
+     */
+    private static function splitParameters(string $value): array
+    {
+        $values = [];
+        $start = 0;
+        $quotesRemaining = \substr_count($value, '"');
+
+        for ($i = 0, $max = \strlen($value); $i < $max; ++$i) {
+            if ($value[$i] === '"') {
+                --$quotesRemaining;
+
+                continue;
+            }
+
+            if ($value[$i] === ';' && $quotesRemaining % 2 === 0) {
+                $values[] = \substr($value, $start, $i - $start);
+                $start = $i + 1;
+            }
+        }
+
+        $values[] = \substr($value, $start);
+
+        return $values;
     }
 
     /**

--- a/tests/HeaderTest.php
+++ b/tests/HeaderTest.php
@@ -53,6 +53,24 @@ class HeaderTest extends TestCase
                 '',
                 [],
             ],
+            [
+                'foo="a;b"; bar=baz',
+                [
+                    ['foo' => 'a;b', 'bar' => 'baz'],
+                ],
+            ],
+            [
+                'foo=bar;;baz=qux',
+                [
+                    ['foo' => 'bar', 'baz' => 'qux'],
+                ],
+            ],
+            [
+                'foo=bar; ;baz=qux',
+                [
+                    ['foo' => 'bar', 0 => '', 'baz' => 'qux'],
+                ],
+            ],
         ];
     }
 
@@ -62,6 +80,19 @@ class HeaderTest extends TestCase
     public function testParseParams($header, $result): void
     {
         self::assertSame($result, Psr7\Header::parse($header));
+    }
+
+    public function testParseManyQuotedSemicolonParameters(): void
+    {
+        $parameters = [];
+        $expected = [];
+
+        for ($i = 0; $i < 200; ++$i) {
+            $parameters[] = 'p'.$i.'="v'.$i.';x"';
+            $expected['p'.$i] = 'v'.$i.';x';
+        }
+
+        self::assertSame([$expected], Psr7\Header::parse(\implode('; ', $parameters)));
     }
 
     public static function normalizeProvider(): array


### PR DESCRIPTION
This changes Header::parse() to split semicolon-separated parameters without repeated regex lookaheads.