### PR TITLE
Reject malformed uploaded file specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Preserve HTTP request method casing instead of uppercasing methods automatically
 - Reject empty arrays and non-string values as header values
 - Reject invalid uploaded file trees and invalid parsed body values
+- Reject malformed uploaded file specifications missing `tmp_name`, `size`, or `error`
 - Normalize multiple leading slashes to one slash in `Uri::getPath()` and URI-derived `Request::getRequestTarget()` values
 - Harden URI host and scheme validation, including rejecting schemes that do not begin with a letter
 - Ignore malformed `HTTP_HOST` values in `ServerRequest::getUriFromGlobals()`

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -91,7 +91,7 @@ class ServerRequest extends Request implements ServerRequestInterface
         foreach ($files as $key => $value) {
             if ($value instanceof UploadedFileInterface) {
                 $normalized[$key] = $value;
-            } elseif (is_array($value) && isset($value['tmp_name'])) {
+            } elseif (is_array($value) && array_key_exists('tmp_name', $value)) {
                 $normalized[$key] = self::createUploadedFileFromSpec($value);
             } elseif (is_array($value)) {
                 $normalized[$key] = self::normalizeFiles($value);
@@ -116,6 +116,8 @@ class ServerRequest extends Request implements ServerRequestInterface
      */
     private static function createUploadedFileFromSpec(array $value)
     {
+        self::assertFileSpec($value);
+
         if (is_array($value['tmp_name'])) {
             return self::normalizeNestedFileSpec($value);
         }
@@ -124,9 +126,18 @@ class ServerRequest extends Request implements ServerRequestInterface
             $value['tmp_name'],
             (int) $value['size'],
             (int) $value['error'],
-            $value['name'],
-            $value['type']
+            $value['name'] ?? null,
+            $value['type'] ?? null
         );
+    }
+
+    private static function assertFileSpec(array $value): void
+    {
+        if (!isset($value['tmp_name'], $value['size'], $value['error'])) {
+            throw new InvalidArgumentException(
+                'Invalid file specification; expected keys "tmp_name", "size", and "error".'
+            );
+        }
     }
 
     /**
@@ -139,13 +150,21 @@ class ServerRequest extends Request implements ServerRequestInterface
      */
     private static function normalizeNestedFileSpec(array $files = []): array
     {
+        self::assertNestedFileSpec($files);
+
         $normalizedFiles = [];
 
         foreach (array_keys($files['tmp_name']) as $key) {
+            if (!array_key_exists($key, $files['size']) || !array_key_exists($key, $files['error'])) {
+                throw new InvalidArgumentException(
+                    'Invalid nested file specification; expected "tmp_name", "size", and "error" arrays to have matching keys.'
+                );
+            }
+
             $spec = [
                 'tmp_name' => $files['tmp_name'][$key],
-                'size' => $files['size'][$key] ?? null,
-                'error' => $files['error'][$key] ?? null,
+                'size' => $files['size'][$key],
+                'error' => $files['error'][$key],
                 'name' => $files['name'][$key] ?? null,
                 'type' => $files['type'][$key] ?? null,
             ];
@@ -153,6 +172,26 @@ class ServerRequest extends Request implements ServerRequestInterface
         }
 
         return $normalizedFiles;
+    }
+
+    private static function assertNestedFileSpec(array $files): void
+    {
+        foreach (['tmp_name', 'size', 'error'] as $key) {
+            if (!isset($files[$key]) || !is_array($files[$key])) {
+                throw new InvalidArgumentException(
+                    'Invalid nested file specification; expected keys "tmp_name", "size", and "error" to be arrays.'
+                );
+            }
+        }
+
+        foreach (['name', 'type'] as $key) {
+            if (isset($files[$key]) && !is_array($files[$key])) {
+                throw new InvalidArgumentException(sprintf(
+                    'Invalid nested file specification; expected key "%s" to be an array when present.',
+                    $key
+                ));
+            }
+        }
     }
 
     /**

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -37,6 +37,22 @@ class ServerRequestTest extends TestCase
                     ),
                 ],
             ],
+            'Single file without optional metadata' => [
+                [
+                    'file' => [
+                        'tmp_name' => '/tmp/php/php1h4j1o',
+                        'error' => '0',
+                        'size' => '123',
+                    ],
+                ],
+                [
+                    'file' => new UploadedFile(
+                        '/tmp/php/php1h4j1o',
+                        123,
+                        UPLOAD_ERR_OK
+                    ),
+                ],
+            ],
             'Empty file' => [
                 [
                     'image_file' => [
@@ -163,7 +179,6 @@ class ServerRequestTest extends TestCase
                         'tmp_name' => [
                             0 => '/tmp/php/hp9hskjhf',
                             1 => '/tmp/php/php1h4j1o',
-                            2 => '/tmp/php/w0ensl4ar',
                         ],
                         'error' => [
                             0 => '0',
@@ -172,11 +187,6 @@ class ServerRequestTest extends TestCase
                         'size' => [
                             0 => '123',
                             1 => '7349',
-                        ],
-                    ],
-                    'minimum_data' => [
-                        'tmp_name' => [
-                            0 => '/tmp/php/hp9hskjhf',
                         ],
                     ],
                     'nested' => [
@@ -233,18 +243,6 @@ class ServerRequestTest extends TestCase
                             'Image.png',
                             'image/png'
                         ),
-                        2 => new UploadedFile(
-                            '/tmp/php/w0ensl4ar',
-                            null,
-                            UPLOAD_ERR_OK
-                        ),
-                    ],
-                    'minimum_data' => [
-                        0 => new UploadedFile(
-                            '/tmp/php/hp9hskjhf',
-                            0,
-                            UPLOAD_ERR_OK
-                        ),
                     ],
                     'nested' => [
                         'other' => new UploadedFile(
@@ -273,6 +271,30 @@ class ServerRequestTest extends TestCase
                     ],
                 ],
             ],
+            'Nested files without optional metadata' => [
+                [
+                    'file' => [
+                        'tmp_name' => [
+                            0 => '/tmp/php/hp9hskjhf',
+                        ],
+                        'error' => [
+                            0 => '0',
+                        ],
+                        'size' => [
+                            0 => '123',
+                        ],
+                    ],
+                ],
+                [
+                    'file' => [
+                        0 => new UploadedFile(
+                            '/tmp/php/hp9hskjhf',
+                            123,
+                            UPLOAD_ERR_OK
+                        ),
+                    ],
+                ],
+            ],
         ];
     }
 
@@ -286,11 +308,87 @@ class ServerRequestTest extends TestCase
         self::assertEquals($expected, $result);
     }
 
-    public function testNormalizeFilesRaisesException(): void
+    /**
+     * @dataProvider invalidFileSpecifications
+     */
+    public function testNormalizeFilesRaisesException(array $files, string $expectedMessage): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid value in files specification');
-        ServerRequest::normalizeFiles(['test' => 'something']);
+        $this->expectExceptionMessage($expectedMessage);
+
+        ServerRequest::normalizeFiles($files);
+    }
+
+    public static function invalidFileSpecifications(): iterable
+    {
+        yield 'invalid scalar' => [
+            ['test' => 'something'],
+            'Invalid value in files specification',
+        ];
+
+        yield 'single file missing size' => [
+            ['file' => ['tmp_name' => '/tmp/php123', 'error' => '0']],
+            'Invalid file specification',
+        ];
+
+        yield 'single file missing error' => [
+            ['file' => ['tmp_name' => '/tmp/php123', 'size' => '123']],
+            'Invalid file specification',
+        ];
+
+        yield 'nested file missing size array' => [
+            ['file' => ['tmp_name' => [0 => '/tmp/php123'], 'error' => [0 => '0']]],
+            'Invalid file specification',
+        ];
+
+        yield 'nested file missing error array' => [
+            ['file' => ['tmp_name' => [0 => '/tmp/php123'], 'size' => [0 => '123']]],
+            'Invalid file specification',
+        ];
+
+        yield 'nested file scalar size' => [
+            ['file' => ['tmp_name' => [0 => '/tmp/php123'], 'size' => '123', 'error' => [0 => '0']]],
+            'Invalid nested file specification',
+        ];
+
+        yield 'nested file scalar error' => [
+            ['file' => ['tmp_name' => [0 => '/tmp/php123'], 'size' => [0 => '123'], 'error' => '0']],
+            'Invalid nested file specification',
+        ];
+
+        yield 'nested file missing size key' => [
+            [
+                'file' => [
+                    'tmp_name' => [0 => '/tmp/a', 1 => '/tmp/b'],
+                    'size' => [0 => '123'],
+                    'error' => [0 => '0', 1 => '0'],
+                ],
+            ],
+            'matching keys',
+        ];
+
+        yield 'nested file missing error key' => [
+            [
+                'file' => [
+                    'tmp_name' => [0 => '/tmp/a', 1 => '/tmp/b'],
+                    'size' => [0 => '123', 1 => '456'],
+                    'error' => [0 => '0'],
+                ],
+            ],
+            'matching keys',
+        ];
+
+        yield 'nested file scalar name' => [
+            [
+                'file' => [
+                    'tmp_name' => [0 => '/tmp/a'],
+                    'size' => [0 => '123'],
+                    'error' => [0 => '0'],
+                    'name' => 'a.txt',
+                ],
+            ],
+            'expected key "name" to be an array',
+        ];
     }
 
     public static function dataGetUriFromGlobals(): iterable


### PR DESCRIPTION
This tightens uploaded file normalization in 3.0 so malformed specs missing tmp_name, size, or error are rejected instead of being treated as successful uploads. The optional client filename and media type values remain optional.