### PR TITLE
Reject malformed SERVER_PORT values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reject malformed uploaded file specifications missing `tmp_name`, `size`, or `error`
 - Normalize multiple leading slashes to one slash in `Uri::getPath()` and URI-derived `Request::getRequestTarget()` values
 - Harden URI host and scheme validation, including rejecting schemes that do not begin with a letter
-- Ignore malformed `HTTP_HOST` values in `ServerRequest::getUriFromGlobals()`
+- Tighten `ServerRequest::getUriFromGlobals()` validation for malformed `HTTP_HOST` and `SERVER_PORT` values
 - Reject hosts with embedded ports in `Uri::withHost()`
 - Validate iterator chunks passed to `Utils::streamFor()`
 - Validate unsupported values passed to `Query::build()`

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -380,11 +380,29 @@ class ServerRequest extends Request implements ServerRequestInterface
 
         $port = ltrim($port, '0');
         if ($port === '') {
-            return 0;
+            return null;
         }
 
         if (strlen($port) > 5 || (int) $port > 0xFFFF) {
             return null;
+        }
+
+        return (int) $port;
+    }
+
+    private static function parseServerPort(string $port): int
+    {
+        if ($port === '' || !ctype_digit($port)) {
+            throw new InvalidArgumentException('Invalid SERVER_PORT; expected an integer between 1 and 65535.');
+        }
+
+        $port = ltrim($port, '0');
+        if ($port === '') {
+            throw new InvalidArgumentException('Invalid SERVER_PORT; expected an integer between 1 and 65535.');
+        }
+
+        if (strlen($port) > 5 || (int) $port > 0xFFFF) {
+            throw new InvalidArgumentException('Invalid SERVER_PORT; expected an integer between 1 and 65535.');
         }
 
         return (int) $port;
@@ -448,8 +466,8 @@ class ServerRequest extends Request implements ServerRequestInterface
         }
 
         $serverPort = self::getServerParam('SERVER_PORT');
-        if (!$hasPort && $serverPort !== null && preg_match('/^[+-]?\d+$/', $serverPort) === 1) {
-            $uri = $uri->withPort((int) $serverPort);
+        if (!$hasPort && $serverPort !== null) {
+            $uri = $uri->withPort(self::parseServerPort($serverPort));
         }
 
         $hasQuery = false;

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -444,6 +444,14 @@ class ServerRequestTest extends TestCase
                 'https://www.example.org:8324/blog/article.php?id=10&user=foo',
                 array_merge($server, ['HTTP_HOST' => 'www.example.org:8324']),
             ],
+            'Host header with zero port falls back to SERVER_NAME' => [
+                'https://www.example.org/blog/article.php?id=10&user=foo',
+                array_merge($server, ['HTTP_HOST' => 'bad.example.org:0']),
+            ],
+            'Host header with zero padded zero port falls back to SERVER_NAME' => [
+                'https://www.example.org/blog/article.php?id=10&user=foo',
+                array_merge($server, ['HTTP_HOST' => 'bad.example.org:0000']),
+            ],
             'IPv6 local loopback address' => [
                 'https://[::1]:8000/blog/article.php?id=10&user=foo',
                 array_merge($server, ['HTTP_HOST' => '[::1]:8000']),
@@ -468,9 +476,17 @@ class ServerRequestTest extends TestCase
                 'https://www.example.org:8324/blog/article.php?id=10&user=foo',
                 array_merge($server, ['SERVER_PORT' => '8324']),
             ],
-            'Invalid SERVER_PORT is ignored instead of coerced to zero' => [
-                'https://www.example.org/blog/article.php?id=10&user=foo',
-                array_merge($server, ['SERVER_PORT' => 'not-a-port']),
+            'SERVER_PORT with leading zeroes' => [
+                'https://www.example.org:8324/blog/article.php?id=10&user=foo',
+                array_merge($server, ['SERVER_PORT' => '008324']),
+            ],
+            'SERVER_PORT with maximum valid port' => [
+                'https://www.example.org:65535/blog/article.php?id=10&user=foo',
+                array_merge($server, ['SERVER_PORT' => '65535']),
+            ],
+            'HTTP_HOST port takes precedence over malformed SERVER_PORT' => [
+                'https://www.example.org:8324/blog/article.php?id=10&user=foo',
+                array_merge($server, ['HTTP_HOST' => 'www.example.org:8324', 'SERVER_PORT' => '+443']),
             ],
             'Non-string SERVER_PORT is ignored' => [
                 'https://www.example.org/blog/article.php?id=10&user=foo',
@@ -511,6 +527,44 @@ class ServerRequestTest extends TestCase
         $_SERVER = $serverParams;
 
         self::assertEquals(new Uri($expected), ServerRequest::getUriFromGlobals());
+    }
+
+    public static function dataInvalidServerPort(): iterable
+    {
+        yield 'empty' => [''];
+        yield 'zero' => ['0'];
+        yield 'zero padded zero' => ['0000'];
+        yield 'negative' => ['-1'];
+        yield 'leading plus' => ['+443'];
+        yield 'out of range' => ['65536'];
+        yield 'too large' => ['999999'];
+        yield 'non numeric' => ['not-a-port'];
+        yield 'trailing junk' => ['443abc'];
+        yield 'leading whitespace' => [' 443'];
+        yield 'decimal' => ['4.5'];
+    }
+
+    /**
+     * @dataProvider dataInvalidServerPort
+     */
+    public function testGetUriFromGlobalsRejectsInvalidServerPort(string $serverPort): void
+    {
+        $_SERVER = [
+            'REQUEST_URI' => '/blog/article.php?id=10&user=foo',
+            'SERVER_PORT' => $serverPort,
+            'SERVER_ADDR' => '217.112.82.20',
+            'SERVER_NAME' => 'www.example.org',
+            'SERVER_PROTOCOL' => 'HTTP/1.1',
+            'REQUEST_METHOD' => 'POST',
+            'QUERY_STRING' => 'id=10&user=foo',
+            'HTTP_HOST' => 'www.example.org',
+            'HTTPS' => 'on',
+        ];
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid SERVER_PORT');
+
+        ServerRequest::getUriFromGlobals();
     }
 
     public function testFromGlobals(): void


### PR DESCRIPTION
This tightens URI construction from server globals so malformed SERVER_PORT values are rejected during request creation. Malformed zero-valued ports in HTTP_HOST are ignored for URI construction, while valid HTTP_HOST ports continue to take precedence over SERVER_PORT.