### PR TITLE
Drop malformed Host headers from globals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Normalize multiple leading slashes to one slash in `Uri::getPath()` and URI-derived `Request::getRequestTarget()` values
 - Harden URI host and scheme validation, including rejecting schemes that do not begin with a letter
 - Tighten `ServerRequest::getUriFromGlobals()` validation for malformed `HTTP_HOST` and `SERVER_PORT` values
+- Stop preserving malformed `Host` headers when building server requests from globals
 - Reject hosts with embedded ports in `Uri::withHost()`
 - Validate iterator chunks passed to `Utils::streamFor()`
 - Validate unsupported values passed to `Query::build()`

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -205,7 +205,7 @@ class ServerRequest extends Request implements ServerRequestInterface
     public static function fromGlobals(): ServerRequestInterface
     {
         $method = self::getServerParam('REQUEST_METHOD') ?? 'GET';
-        $headers = self::getAllHeaders();
+        $headers = self::removeInvalidHostHeader(self::getAllHeaders());
         $uri = self::getUriFromGlobals();
         $body = new CachingStream(new LazyOpenStream('php://input', 'r+'));
         $serverProtocol = self::getServerParam('SERVER_PROTOCOL');
@@ -310,6 +310,27 @@ class ServerRequest extends Request implements ServerRequestInterface
                 $headers['Authorization'] = 'Basic '.base64_encode($server['PHP_AUTH_USER'].':'.$password);
             } elseif (isset($server['PHP_AUTH_DIGEST']) && is_string($server['PHP_AUTH_DIGEST'])) {
                 $headers['Authorization'] = $server['PHP_AUTH_DIGEST'];
+            }
+        }
+
+        return $headers;
+    }
+
+    /**
+     * @param array<string, string> $headers
+     *
+     * @return array<string, string>
+     */
+    private static function removeInvalidHostHeader(array $headers): array
+    {
+        foreach ($headers as $name => $value) {
+            if (strtolower($name) !== 'host') {
+                continue;
+            }
+
+            [$host] = self::extractHostAndPortFromAuthority($value);
+            if ($host === null) {
+                unset($headers[$name]);
             }
         }
 

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -653,6 +653,85 @@ class ServerRequestTest extends TestCase
         self::assertEquals($expectedFiles, $server->getUploadedFiles());
     }
 
+    public static function dataInvalidHostHeaderFromGlobals(): iterable
+    {
+        yield 'empty' => [''];
+        yield 'space' => ['bad host'];
+        yield 'newline' => ["bad.example\r\nX-Evil: yes"];
+        yield 'multiple ports' => ['bad.example:443:8443'];
+        yield 'zero port' => ['bad.example:0'];
+        yield 'zero padded zero port' => ['bad.example:0000'];
+    }
+
+    /**
+     * @dataProvider dataInvalidHostHeaderFromGlobals
+     */
+    public function testFromGlobalsDropsInvalidHostHeaderWhenUriFallsBack(string $host): void
+    {
+        if (\function_exists('apache_request_headers')) {
+            self::markTestSkipped('apache_request_headers() is available.');
+        }
+
+        $_SERVER = [
+            'REQUEST_URI' => '/',
+            'HTTP_HOST' => $host,
+            'SERVER_NAME' => 'good.example',
+            'SERVER_PORT' => '443',
+            'HTTPS' => 'on',
+        ];
+
+        $_COOKIE = $_POST = $_GET = $_FILES = [];
+
+        $request = ServerRequest::fromGlobals();
+
+        self::assertSame('good.example', $request->getUri()->getHost());
+        self::assertSame('good.example', $request->getHeaderLine('Host'));
+    }
+
+    public function testFromGlobalsPreservesValidHostHeader(): void
+    {
+        if (\function_exists('apache_request_headers')) {
+            self::markTestSkipped('apache_request_headers() is available.');
+        }
+
+        $_SERVER = [
+            'REQUEST_URI' => '/',
+            'HTTP_HOST' => 'www.example.org:8324',
+            'SERVER_NAME' => 'good.example',
+            'SERVER_PORT' => '443',
+            'HTTPS' => 'on',
+        ];
+
+        $_COOKIE = $_POST = $_GET = $_FILES = [];
+
+        $request = ServerRequest::fromGlobals();
+
+        self::assertSame('www.example.org', $request->getUri()->getHost());
+        self::assertSame(8324, $request->getUri()->getPort());
+        self::assertSame('www.example.org:8324', $request->getHeaderLine('Host'));
+    }
+
+    public function testFromGlobalsDerivesHostHeaderWhenHostHeaderMissing(): void
+    {
+        if (\function_exists('apache_request_headers')) {
+            self::markTestSkipped('apache_request_headers() is available.');
+        }
+
+        $_SERVER = [
+            'REQUEST_URI' => '/',
+            'SERVER_NAME' => 'good.example',
+            'SERVER_PORT' => '443',
+            'HTTPS' => 'on',
+        ];
+
+        $_COOKIE = $_POST = $_GET = $_FILES = [];
+
+        $request = ServerRequest::fromGlobals();
+
+        self::assertSame('good.example', $request->getUri()->getHost());
+        self::assertSame('good.example', $request->getHeaderLine('Host'));
+    }
+
     public function testFromGlobalsBuildsHeadersFromServerWhenApacheRequestHeadersUnavailable(): void
     {
         if (\function_exists('apache_request_headers')) {
@@ -803,6 +882,36 @@ class ServerRequestTest extends TestCase
 
         self::assertSame(['native'], $server->getHeader('X-Native'));
         self::assertFalse($server->hasHeader('X-Fallback'));
+    }
+
+    /**
+     * @runInSeparateProcess
+     *
+     * @preserveGlobalState disabled
+     */
+    public function testFromGlobalsDropsInvalidApacheHostHeaderWhenUriFallsBack(): void
+    {
+        if (\function_exists('apache_request_headers')) {
+            self::markTestSkipped('apache_request_headers() is already available.');
+        }
+
+        eval('function apache_request_headers(): array { return ["Host" => "bad.example:443:8443", "X-Native" => "native"]; }');
+
+        $_SERVER = [
+            'REQUEST_URI' => '/',
+            'HTTP_HOST' => 'bad.example:443:8443',
+            'SERVER_NAME' => 'good.example',
+            'SERVER_PORT' => '443',
+            'HTTPS' => 'on',
+        ];
+
+        $_COOKIE = $_POST = $_GET = $_FILES = [];
+
+        $server = ServerRequest::fromGlobals();
+
+        self::assertSame('good.example', $server->getUri()->getHost());
+        self::assertSame('good.example', $server->getHeaderLine('Host'));
+        self::assertSame(['native'], $server->getHeader('X-Native'));
     }
 
     /**


### PR DESCRIPTION
This updates server request construction from globals so malformed Host headers are not preserved when URI construction falls back to a sanitized host. Valid Host headers continue to be preserved.