### PR TITLE
Harden server request URI reconstruction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Harden URI host and scheme validation, including rejecting schemes that do not begin with a letter
 - Tighten `ServerRequest::getUriFromGlobals()` validation for malformed `HTTP_HOST` and `SERVER_PORT` values
 - Stop preserving malformed `Host` headers when building server requests from globals
-- Normalize server request URI reconstruction for origin-form, absolute-form, authority-form, and asterisk-form request targets
+- Normalize server request URI reconstruction from globals
 - Reject hosts with embedded ports in `Uri::withHost()`
 - Validate iterator chunks passed to `Utils::streamFor()`
 - Validate unsupported values passed to `Query::build()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Harden URI host and scheme validation, including rejecting schemes that do not begin with a letter
 - Tighten `ServerRequest::getUriFromGlobals()` validation for malformed `HTTP_HOST` and `SERVER_PORT` values
 - Stop preserving malformed `Host` headers when building server requests from globals
+- Normalize server request URI reconstruction for origin-form, absolute-form, authority-form, and asterisk-form request targets
 - Reject hosts with embedded ports in `Uri::withHost()`
 - Validate iterator chunks passed to `Utils::streamFor()`
 - Validate unsupported values passed to `Query::build()`

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -206,12 +206,16 @@ class ServerRequest extends Request implements ServerRequestInterface
     {
         $method = self::getServerParam('REQUEST_METHOD') ?? 'GET';
         $headers = self::removeInvalidHostHeader(self::getAllHeaders());
-        $uri = self::getUriFromGlobals();
+        [$uri, $requestTarget] = self::getUriAndRequestTargetFromGlobals($method);
         $body = new CachingStream(new LazyOpenStream('php://input', 'r+'));
         $serverProtocol = self::getServerParam('SERVER_PROTOCOL');
         $protocol = $serverProtocol !== null ? str_replace('HTTP/', '', $serverProtocol) : '1.1';
 
         $serverRequest = new ServerRequest($method, $uri, $headers, $body, $protocol, $_SERVER);
+        if ($requestTarget !== null) {
+            /** @var ServerRequestInterface $serverRequest */
+            $serverRequest = $serverRequest->withRequestTarget($requestTarget);
+        }
 
         return $serverRequest
             ->withCookieParams($_COOKIE)
@@ -445,10 +449,7 @@ class ServerRequest extends Request implements ServerRequestInterface
         }
     }
 
-    /**
-     * Get a Uri populated with values from $_SERVER.
-     */
-    public static function getUriFromGlobals(): UriInterface
+    private static function getAuthorityUriFromGlobals(): UriInterface
     {
         $uri = new Uri('');
 
@@ -491,23 +492,129 @@ class ServerRequest extends Request implements ServerRequestInterface
             $uri = $uri->withPort(self::parseServerPort($serverPort));
         }
 
-        $hasQuery = false;
+        return $uri;
+    }
+
+    /**
+     * @return array{0: UriInterface, 1: string|null}
+     */
+    private static function getUriAndRequestTargetFromGlobals(string $method): array
+    {
+        $uri = self::getAuthorityUriFromGlobals();
         $requestUri = self::getServerParam('REQUEST_URI');
-        if ($requestUri !== null) {
-            $requestUriParts = explode('?', $requestUri, 2);
-            $uri = $uri->withPath($requestUriParts[0]);
-            if (isset($requestUriParts[1])) {
-                $hasQuery = true;
-                $uri = $uri->withQuery($requestUriParts[1]);
+        $queryString = self::getServerParam('QUERY_STRING');
+
+        if ($requestUri === null) {
+            if ($queryString !== null) {
+                $uri = $uri->withQuery($queryString);
+            }
+
+            return [$uri, null];
+        }
+
+        if (self::isAsteriskFormRequestTarget($method, $requestUri)) {
+            return [$uri->withPath('')->withQuery(''), '*'];
+        }
+
+        $connectAuthority = self::parseConnectAuthorityFormRequestTarget($method, $requestUri);
+        if ($connectAuthority !== null) {
+            [$host, $port] = $connectAuthority;
+
+            return [
+                $uri->withHost($host)->withPort($port)->withPath('')->withQuery(''),
+                $requestUri,
+            ];
+        }
+
+        if (self::isAbsoluteFormRequestTarget($requestUri)) {
+            try {
+                $targetUri = (new Uri($requestUri))->withFragment('');
+            } catch (InvalidArgumentException $e) {
+                $targetUri = null;
+            }
+
+            if ($targetUri !== null && $targetUri->getHost() !== '') {
+                $requestTarget = self::removeRequestTargetFragment($requestUri);
+                if (strpos($requestTarget, '?') === false && $queryString !== null) {
+                    $targetUri = $targetUri->withQuery($queryString);
+                    $requestTarget .= '?'.$queryString;
+                }
+
+                return [$targetUri, preg_match('#\s#', $requestTarget) ? (string) $targetUri : $requestTarget];
             }
         }
 
-        $queryString = self::getServerParam('QUERY_STRING');
-        if (!$hasQuery && $queryString !== null) {
+        [$path, $query, $hasQuery] = self::splitRequestTargetQuery($requestUri);
+        $uri = $uri->withPath(self::normalizeOriginFormPathFromGlobals($path));
+
+        if ($hasQuery) {
+            $uri = $uri->withQuery($query);
+        } elseif ($queryString !== null) {
             $uri = $uri->withQuery($queryString);
         }
 
-        return $uri;
+        return [$uri, null];
+    }
+
+    private static function isAbsoluteFormRequestTarget(string $target): bool
+    {
+        return preg_match('/^[A-Za-z][A-Za-z0-9+.-]*:\/\//D', $target) === 1;
+    }
+
+    private static function isAsteriskFormRequestTarget(string $method, string $target): bool
+    {
+        return strcasecmp($method, 'OPTIONS') === 0 && $target === '*';
+    }
+
+    /**
+     * @return array{0: string, 1: int}|null
+     */
+    private static function parseConnectAuthorityFormRequestTarget(string $method, string $target): ?array
+    {
+        if (strcasecmp($method, 'CONNECT') !== 0 || strpbrk($target, '/?#') !== false) {
+            return null;
+        }
+
+        [$host, $port] = self::extractHostAndPortFromAuthority($target);
+        if ($host === null || $port === null) {
+            return null;
+        }
+
+        return [$host, $port];
+    }
+
+    private static function removeRequestTargetFragment(string $target): string
+    {
+        return explode('#', $target, 2)[0];
+    }
+
+    /**
+     * @return array{0: string, 1: string, 2: bool}
+     */
+    private static function splitRequestTargetQuery(string $target): array
+    {
+        $parts = explode('?', $target, 2);
+
+        return [$parts[0], $parts[1] ?? '', isset($parts[1])];
+    }
+
+    private static function normalizeOriginFormPathFromGlobals(string $path): string
+    {
+        if ($path === '' || $path[0] === '/') {
+            return $path;
+        }
+
+        return '/'.$path;
+    }
+
+    /**
+     * Get a Uri populated with values from $_SERVER.
+     */
+    public static function getUriFromGlobals(): UriInterface
+    {
+        $method = self::getServerParam('REQUEST_METHOD') ?? 'GET';
+
+        return self::getUriAndRequestTargetFromGlobals($method)[0];
     }
 
     public function getServerParams(): array

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -535,11 +535,13 @@ class ServerRequest extends Request implements ServerRequestInterface
 
             if ($targetUri !== null && $targetUri->getHost() !== '') {
                 $requestTarget = self::removeRequestTargetFragment($requestUri);
-                if (strpos($requestTarget, '?') === false && $queryString !== null) {
+                if (strpos($requestTarget, '?') === false && $queryString !== null && $queryString !== '') {
                     $targetUri = $targetUri->withQuery($queryString);
                     $requestTarget .= '?'.$queryString;
                 }
 
+                // Preserve the received absolute-form target unless it cannot be used
+                // as a PSR-7 request target without normalization.
                 return [$targetUri, preg_match('#\s#', $requestTarget) ? (string) $targetUri : $requestTarget];
             }
         }

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -576,6 +576,15 @@ class ServerRequestTest extends TestCase
             'x=1',
         ];
 
+        yield 'absolute-form ignores empty QUERY_STRING when request uri has no query' => [
+            ['REQUEST_URI' => 'http://up.example/admin', 'QUERY_STRING' => '', 'HTTP_HOST' => 'good.example'],
+            'http://up.example/admin',
+            'up.example',
+            null,
+            '/admin',
+            '',
+        ];
+
         yield 'asterisk-form has no uri path' => [
             ['REQUEST_METHOD' => 'OPTIONS', 'REQUEST_URI' => '*', 'HTTP_HOST' => 'good.example'],
             'http://good.example',
@@ -659,6 +668,12 @@ class ServerRequestTest extends TestCase
             ['REQUEST_METHOD' => 'GET', 'REQUEST_URI' => 'http://up.example/admin', 'QUERY_STRING' => 'x=1', 'HTTP_HOST' => 'good.example'],
             'http://up.example/admin?x=1',
             'http://up.example/admin?x=1',
+        ];
+
+        yield 'absolute-form target ignores empty query string fallback' => [
+            ['REQUEST_METHOD' => 'GET', 'REQUEST_URI' => 'http://up.example/admin', 'QUERY_STRING' => '', 'HTTP_HOST' => 'good.example'],
+            'http://up.example/admin',
+            'http://up.example/admin',
         ];
 
         yield 'asterisk-form target is preserved' => [

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -529,6 +529,191 @@ class ServerRequestTest extends TestCase
         self::assertEquals(new Uri($expected), ServerRequest::getUriFromGlobals());
     }
 
+    public static function dataGetUriFromGlobalsRequestTargetForms(): iterable
+    {
+        yield 'origin-form' => [
+            ['REQUEST_URI' => '/admin?x=1', 'HTTP_HOST' => 'good.example'],
+            'http://good.example/admin?x=1',
+            'good.example',
+            null,
+            '/admin',
+            'x=1',
+        ];
+
+        yield 'slashless origin-form is recovered' => [
+            ['REQUEST_URI' => 'admin?x=1', 'HTTP_HOST' => 'good.example'],
+            'http://good.example/admin?x=1',
+            'good.example',
+            null,
+            '/admin',
+            'x=1',
+        ];
+
+        yield 'query-only origin-form is recovered' => [
+            ['REQUEST_URI' => '?x=1', 'HTTP_HOST' => 'good.example'],
+            'http://good.example?x=1',
+            'good.example',
+            null,
+            '',
+            'x=1',
+        ];
+
+        yield 'absolute-form target supplies authority' => [
+            ['REQUEST_URI' => 'http://up.example:8080/admin?x=1', 'HTTP_HOST' => 'good.example'],
+            'http://up.example:8080/admin?x=1',
+            'up.example',
+            8080,
+            '/admin',
+            'x=1',
+        ];
+
+        yield 'absolute-form uses QUERY_STRING when request uri has no query' => [
+            ['REQUEST_URI' => 'http://up.example/admin', 'QUERY_STRING' => 'x=1', 'HTTP_HOST' => 'good.example'],
+            'http://up.example/admin?x=1',
+            'up.example',
+            null,
+            '/admin',
+            'x=1',
+        ];
+
+        yield 'asterisk-form has no uri path' => [
+            ['REQUEST_METHOD' => 'OPTIONS', 'REQUEST_URI' => '*', 'HTTP_HOST' => 'good.example'],
+            'http://good.example',
+            'good.example',
+            null,
+            '',
+            '',
+        ];
+
+        yield 'connect authority-form supplies authority' => [
+            ['REQUEST_METHOD' => 'CONNECT', 'REQUEST_URI' => 'up.example:443', 'HTTP_HOST' => 'good.example'],
+            'http://up.example:443',
+            'up.example',
+            443,
+            '',
+            '',
+        ];
+
+        yield 'request uri query wins over query string' => [
+            ['REQUEST_URI' => '/admin?from_uri=1', 'QUERY_STRING' => 'from_query=1', 'HTTP_HOST' => 'good.example'],
+            'http://good.example/admin?from_uri=1',
+            'good.example',
+            null,
+            '/admin',
+            'from_uri=1',
+        ];
+
+        yield 'explicit empty request uri query wins over query string' => [
+            ['REQUEST_URI' => '/admin?', 'QUERY_STRING' => 'from_query=1', 'HTTP_HOST' => 'good.example'],
+            'http://good.example/admin',
+            'good.example',
+            null,
+            '/admin',
+            '',
+        ];
+    }
+
+    /**
+     * @dataProvider dataGetUriFromGlobalsRequestTargetForms
+     */
+    public function testGetUriFromGlobalsRequestTargetForms(
+        array $serverParams,
+        string $expectedUri,
+        string $expectedHost,
+        ?int $expectedPort,
+        string $expectedPath,
+        string $expectedQuery
+    ): void {
+        $_SERVER = $serverParams;
+
+        $uri = ServerRequest::getUriFromGlobals();
+
+        self::assertSame($expectedUri, (string) $uri);
+        self::assertSame($expectedHost, $uri->getHost());
+        self::assertSame($expectedPort, $uri->getPort());
+        self::assertSame($expectedPath, $uri->getPath());
+        self::assertSame($expectedQuery, $uri->getQuery());
+    }
+
+    public static function dataFromGlobalsRequestTargetForms(): iterable
+    {
+        yield 'slashless origin-form is normalized' => [
+            ['REQUEST_METHOD' => 'GET', 'REQUEST_URI' => 'admin?x=1', 'HTTP_HOST' => 'good.example'],
+            '/admin?x=1',
+            'http://good.example/admin?x=1',
+        ];
+
+        yield 'query-only origin-form is normalized' => [
+            ['REQUEST_METHOD' => 'GET', 'REQUEST_URI' => '?x=1', 'HTTP_HOST' => 'good.example'],
+            '/?x=1',
+            'http://good.example?x=1',
+        ];
+
+        yield 'absolute-form target is preserved' => [
+            ['REQUEST_METHOD' => 'GET', 'REQUEST_URI' => 'http://up.example:8080/admin?x=1', 'HTTP_HOST' => 'good.example'],
+            'http://up.example:8080/admin?x=1',
+            'http://up.example:8080/admin?x=1',
+        ];
+
+        yield 'absolute-form target uses query string fallback' => [
+            ['REQUEST_METHOD' => 'GET', 'REQUEST_URI' => 'http://up.example/admin', 'QUERY_STRING' => 'x=1', 'HTTP_HOST' => 'good.example'],
+            'http://up.example/admin?x=1',
+            'http://up.example/admin?x=1',
+        ];
+
+        yield 'asterisk-form target is preserved' => [
+            ['REQUEST_METHOD' => 'OPTIONS', 'REQUEST_URI' => '*', 'HTTP_HOST' => 'good.example'],
+            '*',
+            'http://good.example',
+        ];
+
+        yield 'connect authority-form target is preserved' => [
+            ['REQUEST_METHOD' => 'CONNECT', 'REQUEST_URI' => 'up.example:443', 'HTTP_HOST' => 'good.example'],
+            'up.example:443',
+            'http://up.example:443',
+        ];
+
+        yield 'query string is used when request uri is missing' => [
+            ['REQUEST_METHOD' => 'GET', 'QUERY_STRING' => 'x=1', 'HTTP_HOST' => 'good.example'],
+            '/?x=1',
+            'http://good.example?x=1',
+        ];
+    }
+
+    /**
+     * @dataProvider dataFromGlobalsRequestTargetForms
+     */
+    public function testFromGlobalsRequestTargetForms(array $serverParams, string $expectedRequestTarget, string $expectedUri): void
+    {
+        $_SERVER = $serverParams;
+        $_COOKIE = $_POST = $_GET = $_FILES = [];
+
+        $request = ServerRequest::fromGlobals();
+
+        self::assertSame($expectedRequestTarget, $request->getRequestTarget());
+        self::assertSame($expectedUri, (string) $request->getUri());
+    }
+
+    public function testFromGlobalsKeepsValidHostHeaderWhenAbsoluteFormAuthorityDiffers(): void
+    {
+        if (\function_exists('apache_request_headers')) {
+            self::markTestSkipped('apache_request_headers() is available.');
+        }
+
+        $_SERVER = [
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI' => 'http://up.example:8080/admin?x=1',
+            'HTTP_HOST' => 'good.example',
+        ];
+        $_COOKIE = $_POST = $_GET = $_FILES = [];
+
+        $request = ServerRequest::fromGlobals();
+
+        self::assertSame('up.example', $request->getUri()->getHost());
+        self::assertSame('good.example', $request->getHeaderLine('Host'));
+        self::assertSame('http://up.example:8080/admin?x=1', $request->getRequestTarget());
+    }
+
     public static function dataInvalidServerPort(): iterable
     {
         yield 'empty' => [''];


### PR DESCRIPTION
This updates server request construction from globals so REQUEST_URI is handled according to its request-target form. Slashless origin-form paths are normalized, absolute-form targets populate the URI authority, and CONNECT authority-form and OPTIONS asterisk-form targets are preserved.