### PR TITLE
Harden HTTP start-line validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tighten `ServerRequest::getUriFromGlobals()` validation for malformed `HTTP_HOST` and `SERVER_PORT` values
 - Stop preserving malformed `Host` headers when building server requests from globals
 - Normalize server request URI reconstruction from globals
+- Reject malformed HTTP start-line fields
 - Reject hosts with embedded ports in `Uri::withHost()`
 - Validate iterator chunks passed to `Utils::streamFor()`
 - Validate unsupported values passed to `Query::build()`

--- a/src/Message.php
+++ b/src/Message.php
@@ -261,21 +261,19 @@ final class Message
     {
         $data = self::parseMessage($message);
         $matches = [];
-        if (!preg_match('/^[\S]+\s+([a-zA-Z]+:\/\/|\/).*/', $data['start-line'], $matches)) {
+        if (!preg_match('/^(?P<method>[!#$%&\'*+.^_`|~0-9A-Za-z-]+) (?P<target>(?:[A-Za-z][A-Za-z0-9+.-]*:\/\/|\/)[^\x00-\x20\x7F]*) HTTP\/(?P<version>\d+(?:\.\d+)?)$/D', $data['start-line'], $matches)) {
             throw new \InvalidArgumentException('Invalid request string');
         }
-        $parts = explode(' ', $data['start-line'], 3);
-        $version = isset($parts[2]) ? explode('/', $parts[2])[1] : '1.1';
 
         $request = new Request(
-            $parts[0],
-            $matches[1] === '/' ? self::parseRequestUri($parts[1], $data['headers']) : $parts[1],
+            $matches['method'],
+            $matches['target'][0] === '/' ? self::parseRequestUri($matches['target'], $data['headers']) : $matches['target'],
             $data['headers'],
             $data['body'],
-            $version
+            $matches['version']
         );
 
-        return $matches[1] === '/' ? $request : $request->withRequestTarget($parts[1]);
+        return $matches['target'][0] === '/' ? $request : $request->withRequestTarget($matches['target']);
     }
 
     /**
@@ -289,17 +287,16 @@ final class Message
         // According to https://datatracker.ietf.org/doc/html/rfc7230#section-3.1.2
         // the space between status-code and reason-phrase is required. But
         // browsers accept responses without space and reason as well.
-        if (!preg_match('/^HTTP\/.* [0-9]{3}( .*|$)/', $data['start-line'])) {
+        if (!preg_match('/^HTTP\/(?P<version>\d+(?:\.\d+)?) (?P<status>[1-5][0-9]{2})(?: (?P<reason>[\x09\x20-\x7E\x80-\xFF]*))?$/D', $data['start-line'], $matches)) {
             throw new \InvalidArgumentException('Invalid response string: '.$data['start-line']);
         }
-        $parts = explode(' ', $data['start-line'], 3);
 
         return new Response(
-            (int) $parts[1],
+            (int) $matches['status'],
             $data['headers'],
             $data['body'],
-            explode('/', $parts[0])[1],
-            $parts[2] ?? null
+            $matches['version'],
+            $matches['reason'] ?? null
         );
     }
 }

--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -34,6 +34,8 @@ trait MessageTrait
      */
     public function withProtocolVersion(string $version): MessageInterface
     {
+        $this->assertProtocolVersion($version);
+
         if ($this->protocol === $version) {
             return $this;
         }
@@ -245,6 +247,13 @@ trait MessageTrait
             throw new \InvalidArgumentException(
                 sprintf('"%s" is not valid header name.', $header)
             );
+        }
+    }
+
+    private function assertProtocolVersion(string $version): void
+    {
+        if (!preg_match('/^\d+(?:\.\d+)?$/D', $version)) {
+            throw new \InvalidArgumentException('Protocol version must be a valid HTTP version number.');
         }
     }
 

--- a/src/Request.php
+++ b/src/Request.php
@@ -40,9 +40,12 @@ class Request implements RequestInterface
         string $version = '1.1'
     ) {
         $this->assertMethod($method);
+        $this->assertProtocolVersion($version);
+
         if (!$uri instanceof UriInterface) {
             $uri = new Uri($uri);
         }
+        self::getRequestTargetFromUri($uri);
 
         $this->method = $method;
         $this->uri = $uri;
@@ -64,24 +67,12 @@ class Request implements RequestInterface
             return $this->requestTarget;
         }
 
-        $target = self::normalizePathForOriginForm($this->uri->getPath());
-        if ($target === '') {
-            $target = '/';
-        }
-        if ($this->uri->getQuery() != '') {
-            $target .= '?'.$this->uri->getQuery();
-        }
-
-        return $target;
+        return self::getRequestTargetFromUri($this->uri);
     }
 
     public function withRequestTarget(string $requestTarget): RequestInterface
     {
-        if (preg_match('#\s#', $requestTarget)) {
-            throw new InvalidArgumentException(
-                'Invalid request target provided; cannot contain whitespace'
-            );
-        }
+        self::assertRequestTarget($requestTarget);
 
         $new = clone $this;
         $new->requestTarget = $requestTarget;
@@ -112,6 +103,10 @@ class Request implements RequestInterface
     {
         if ($uri === $this->uri) {
             return $this;
+        }
+
+        if ($this->requestTarget === null) {
+            self::getRequestTargetFromUri($uri);
         }
 
         $new = clone $this;
@@ -151,8 +146,32 @@ class Request implements RequestInterface
 
     private function assertMethod(string $method): void
     {
-        if ($method === '') {
-            throw new InvalidArgumentException('Method must be a non-empty string.');
+        if (!preg_match('/^[!#$%&\'*+.^_`|~0-9A-Za-z-]+$/D', $method)) {
+            throw new InvalidArgumentException('Method must be a valid HTTP token.');
+        }
+    }
+
+    private static function getRequestTargetFromUri(UriInterface $uri): string
+    {
+        $target = self::normalizePathForOriginForm($uri->getPath());
+        if ($target === '') {
+            $target = '/';
+        }
+        if ($uri->getQuery() != '') {
+            $target .= '?'.$uri->getQuery();
+        }
+
+        self::assertRequestTarget($target);
+
+        return $target;
+    }
+
+    private static function assertRequestTarget(string $requestTarget): void
+    {
+        if ($requestTarget === '' || preg_match('/[\x00-\x20\x7F]/', $requestTarget)) {
+            throw new InvalidArgumentException(
+                'Invalid request target provided; cannot be empty or contain whitespace or control characters'
+            );
         }
     }
 

--- a/src/Response.php
+++ b/src/Response.php
@@ -99,6 +99,7 @@ class Response implements ResponseInterface
         ?string $reason = null
     ) {
         $this->assertStatusCodeRange($status);
+        $this->assertProtocolVersion($version);
 
         $this->statusCode = $status;
 
@@ -108,10 +109,13 @@ class Response implements ResponseInterface
 
         $this->setHeaders($headers);
         if ($reason == '' && isset(self::PHRASES[$this->statusCode])) {
-            $this->reasonPhrase = self::PHRASES[$this->statusCode];
+            $reasonPhrase = self::PHRASES[$this->statusCode];
         } else {
-            $this->reasonPhrase = (string) $reason;
+            $reasonPhrase = (string) $reason;
         }
+
+        $this->assertReasonPhrase($reasonPhrase);
+        $this->reasonPhrase = $reasonPhrase;
 
         $this->protocol = $version;
     }
@@ -135,6 +139,7 @@ class Response implements ResponseInterface
         if ($reasonPhrase === '' && isset(self::PHRASES[$new->statusCode])) {
             $reasonPhrase = self::PHRASES[$new->statusCode];
         }
+        $this->assertReasonPhrase($reasonPhrase);
         $new->reasonPhrase = $reasonPhrase;
 
         return $new;
@@ -144,6 +149,13 @@ class Response implements ResponseInterface
     {
         if ($statusCode < 100 || $statusCode >= 600) {
             throw new \InvalidArgumentException('Status code must be an integer value between 1xx and 5xx.');
+        }
+    }
+
+    private function assertReasonPhrase(string $reasonPhrase): void
+    {
+        if (!preg_match('/^[\x09\x20-\x7E\x80-\xFF]*$/D', $reasonPhrase)) {
+            throw new \InvalidArgumentException('Reason phrase must not contain invalid control characters.');
         }
     }
 }

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -209,7 +209,10 @@ class ServerRequest extends Request implements ServerRequestInterface
         [$uri, $requestTarget] = self::getUriAndRequestTargetFromGlobals($method);
         $body = new CachingStream(new LazyOpenStream('php://input', 'r+'));
         $serverProtocol = self::getServerParam('SERVER_PROTOCOL');
-        $protocol = $serverProtocol !== null ? str_replace('HTTP/', '', $serverProtocol) : '1.1';
+        $protocol = '1.1';
+        if ($serverProtocol !== null) {
+            $protocol = strpos($serverProtocol, 'HTTP/') === 0 ? substr($serverProtocol, 5) : $serverProtocol;
+        }
 
         $serverRequest = new ServerRequest($method, $uri, $headers, $body, $protocol, $_SERVER);
         if ($requestTarget !== null) {
@@ -542,7 +545,7 @@ class ServerRequest extends Request implements ServerRequestInterface
 
                 // Preserve the received absolute-form target unless it cannot be used
                 // as a PSR-7 request target without normalization.
-                return [$targetUri, preg_match('#\s#', $requestTarget) ? (string) $targetUri : $requestTarget];
+                return [$targetUri, preg_match('/[\x00-\x20\x7F]/', $requestTarget) ? (string) $targetUri : $requestTarget];
             }
         }
 

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -175,6 +175,28 @@ class MessageTest extends TestCase
         Psr7\Message::parseRequest("HTTP/1.1 200 OK\r\n\r\n");
     }
 
+    /**
+     * @dataProvider invalidRequestStartLineProvider
+     */
+    public function testParseRequestRejectsInvalidStartLine(string $startLine): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        Psr7\Message::parseRequest($startLine."\r\nHost: foo.com\r\n\r\n");
+    }
+
+    public static function invalidRequestStartLineProvider(): iterable
+    {
+        yield 'invalid method' => ['GET/ / HTTP/1.1'];
+        yield 'target space' => ['GET /foo bar HTTP/1.1'];
+        yield 'target tab' => ["GET /foo\tbar HTTP/1.1"];
+        yield 'target nul' => ["GET /foo\0bar HTTP/1.1"];
+        yield 'target delete' => ["GET /foo\x7Fbar HTTP/1.1"];
+        yield 'invalid protocol text' => ['GET / HTTP/foo'];
+        yield 'invalid protocol segments' => ['GET / HTTP/1.1.1'];
+        yield 'missing version' => ['GET /'];
+    }
+
     public function testParsesResponseMessages(): void
     {
         $res = "HTTP/1.0 200 OK\r\nFoo: Bar\r\nBaz: Bam\r\nBaz: Qux\r\n\r\nTest";
@@ -251,6 +273,46 @@ class MessageTest extends TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
         Psr7\Message::parseResponse("GET / HTTP/1.1\r\n\r\n");
+    }
+
+    public function testParsesResponseWithAllowedCustomReasonPhraseCharacters(): void
+    {
+        $response = Psr7\Message::parseResponse("HTTP/1.1 200 OK\tFine\x80\r\n\r\n");
+
+        self::assertSame("OK\tFine\x80", $response->getReasonPhrase());
+    }
+
+    public function testParsesBoundaryResponseStatusCodes(): void
+    {
+        $informationalResponse = Psr7\Message::parseResponse("HTTP/1.1 100 Continue\r\n\r\n");
+        $customServerErrorResponse = Psr7\Message::parseResponse("HTTP/1.1 599 Custom\r\n\r\n");
+
+        self::assertSame(100, $informationalResponse->getStatusCode());
+        self::assertSame(599, $customServerErrorResponse->getStatusCode());
+    }
+
+    /**
+     * @dataProvider invalidResponseStartLineProvider
+     */
+    public function testParseResponseRejectsInvalidStartLine(string $startLine): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        Psr7\Message::parseResponse($startLine."\r\n\r\n");
+    }
+
+    public static function invalidResponseStartLineProvider(): iterable
+    {
+        yield 'invalid protocol text' => ['HTTP/foo 200 OK'];
+        yield 'invalid protocol segments' => ['HTTP/1.1.1 200 OK'];
+        yield 'status below range' => ['HTTP/1.1 099 OK'];
+        yield 'status above range' => ['HTTP/1.1 600 OK'];
+        yield 'status 700' => ['HTTP/1.1 700 OK'];
+        yield 'status 999' => ['HTTP/1.1 999 OK'];
+        yield 'non-numeric status' => ['HTTP/1.1 20x OK'];
+        yield 'tab before reason' => ["HTTP/1.1 200\tOK"];
+        yield 'reason nul' => ["HTTP/1.1 200 OK\0"];
+        yield 'reason delete' => ["HTTP/1.1 200 OK\x7F"];
     }
 
     public function testMessageBodySummaryWithSmallBody(): void

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -85,6 +85,82 @@ class RequestTest extends TestCase
         self::assertSame('put', $r->withMethod('put')->getMethod());
     }
 
+    /**
+     * @dataProvider validCustomMethodProvider
+     */
+    public function testAcceptsValidCustomMethodTokens(string $method): void
+    {
+        $request = new Request($method, '/');
+
+        self::assertSame($method, $request->getMethod());
+    }
+
+    /**
+     * @dataProvider validCustomMethodProvider
+     */
+    public function testWithMethodAcceptsValidCustomMethodTokens(string $method): void
+    {
+        $request = new Request('GET', '/');
+
+        self::assertSame($method, $request->withMethod($method)->getMethod());
+    }
+
+    public static function validCustomMethodProvider(): iterable
+    {
+        yield 'hyphen' => ['M-SEARCH'];
+        yield 'underscore' => ['GET_DATA'];
+        yield 'dot' => ['custom.method'];
+        yield 'plus' => ['foo+bar'];
+    }
+
+    /**
+     * @dataProvider invalidMethodProvider
+     */
+    public function testConstructorRejectsInvalidMethod(string $method): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new Request($method, '/');
+    }
+
+    /**
+     * @dataProvider invalidMethodProvider
+     */
+    public function testWithMethodRejectsInvalidMethod(string $method): void
+    {
+        $request = new Request('GET', '/');
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $request->withMethod($method);
+    }
+
+    public static function invalidMethodProvider(): iterable
+    {
+        yield 'empty' => [''];
+        yield 'space' => ['GET POST'];
+        yield 'newline' => ["GET\r\nX-Injected: yes"];
+        yield 'slash' => ['GET/'];
+        yield 'colon' => ['GET:'];
+        yield 'nul' => ["GET\0"];
+    }
+
+    public function testConstructorRejectsInvalidProtocolVersion(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new Request('GET', '/', [], null, "1.1\r\nX-Injected: yes");
+    }
+
+    public function testWithProtocolVersionRejectsInvalidProtocolVersion(): void
+    {
+        $request = new Request('GET', '/');
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $request->withProtocolVersion("1.1\r\nX-Injected: yes");
+    }
+
     public function testWithUri(): void
     {
         $r1 = new Request('GET', '/');
@@ -116,6 +192,73 @@ class RequestTest extends TestCase
         $r1 = new Request('GET', '/');
         $this->expectException(\InvalidArgumentException::class);
         $r1->withRequestTarget('/foo bar');
+    }
+
+    public function testRequestTargetDoesNotAllowEmptyString(): void
+    {
+        $r1 = new Request('GET', '/');
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $r1->withRequestTarget('');
+    }
+
+    /**
+     * @dataProvider invalidRequestTargetProvider
+     */
+    public function testRequestTargetDoesNotAllowControlCharacters(string $requestTarget): void
+    {
+        $r1 = new Request('GET', '/');
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $r1->withRequestTarget($requestTarget);
+    }
+
+    public static function invalidRequestTargetProvider(): iterable
+    {
+        yield 'nul' => ["/foo\0bar"];
+        yield 'delete' => ["/foo\x7Fbar"];
+        yield 'newline' => ["/foo\r\nbar"];
+        yield 'tab' => ["/foo\tbar"];
+    }
+
+    public function testConstructorRejectsInvalidRequestTargetFromUriPath(): void
+    {
+        $uri = $this->createMock(UriInterface::class);
+        $uri->method('getPath')->willReturn("/foo\r\nbar");
+        $uri->method('getQuery')->willReturn('');
+        $uri->method('getHost')->willReturn('');
+        $uri->method('getPort')->willReturn(null);
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        new Request('GET', $uri);
+    }
+
+    public function testConstructorRejectsInvalidRequestTargetFromUriQuery(): void
+    {
+        $uri = $this->createMock(UriInterface::class);
+        $uri->method('getPath')->willReturn('/foo');
+        $uri->method('getQuery')->willReturn("x=1\0");
+        $uri->method('getHost')->willReturn('');
+        $uri->method('getPort')->willReturn(null);
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        new Request('GET', $uri);
+    }
+
+    public function testWithUriRejectsInvalidDerivedRequestTarget(): void
+    {
+        $request = new Request('GET', '/');
+        $uri = $this->createMock(UriInterface::class);
+        $uri->method('getPath')->willReturn("/foo\x7Fbar");
+        $uri->method('getQuery')->willReturn('');
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $request->withUri($uri);
     }
 
     public function testRequestTargetDefaultsToSlash(): void

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -95,12 +95,35 @@ class ResponseTest extends TestCase
 
         $r = new Response(200, [], null, '1.1', '0');
         self::assertSame('0', $r->getReasonPhrase(), 'Falsey reason works');
+
+        $r = new Response(200, [], null, '1.1', "OK\tFine\x80");
+        self::assertSame("OK\tFine\x80", $r->getReasonPhrase());
     }
 
     public function testCanConstructWithProtocolVersion(): void
     {
         $r = new Response(200, [], null, '1000');
         self::assertSame('1000', $r->getProtocolVersion());
+    }
+
+    /**
+     * @dataProvider invalidProtocolVersionProvider
+     */
+    public function testConstructorRejectsInvalidProtocolVersion(string $version): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new Response(200, [], null, $version);
+    }
+
+    /**
+     * @dataProvider invalidReasonPhraseProvider
+     */
+    public function testConstructorRejectsInvalidReasonPhrase(string $reasonPhrase): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new Response(200, [], null, '1.1', $reasonPhrase);
     }
 
     public function testWithStatusCodeAndNoReason(): void
@@ -119,12 +142,62 @@ class ResponseTest extends TestCase
         $r = (new Response())->withStatus(201, '0');
         self::assertSame(201, $r->getStatusCode());
         self::assertSame('0', $r->getReasonPhrase(), 'Falsey reason works');
+
+        $r = (new Response())->withStatus(201, "Fine\t\x80");
+        self::assertSame(201, $r->getStatusCode());
+        self::assertSame("Fine\t\x80", $r->getReasonPhrase());
     }
 
     public function testWithProtocolVersion(): void
     {
         $r = (new Response())->withProtocolVersion('1000');
         self::assertSame('1000', $r->getProtocolVersion());
+    }
+
+    /**
+     * @dataProvider invalidProtocolVersionProvider
+     */
+    public function testWithProtocolVersionRejectsInvalidVersion(string $version): void
+    {
+        $response = new Response();
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $response->withProtocolVersion($version);
+    }
+
+    /**
+     * @dataProvider invalidReasonPhraseProvider
+     */
+    public function testWithStatusRejectsInvalidReasonPhrase(string $reasonPhrase): void
+    {
+        $response = new Response();
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $response->withStatus(200, $reasonPhrase);
+    }
+
+    public static function invalidProtocolVersionProvider(): iterable
+    {
+        yield 'empty' => [''];
+        yield 'with prefix' => ['HTTP/1.1'];
+        yield 'trailing space' => ['1.1 '];
+        yield 'text suffix' => ['1.1foo'];
+        yield 'newline' => ["1.1\r\nX-Injected: yes"];
+        yield 'missing minor' => ['1.'];
+        yield 'missing major' => ['.1'];
+        yield 'too many segments' => ['1.1.1'];
+        yield 'leading plus' => ['+1.1'];
+    }
+
+    public static function invalidReasonPhraseProvider(): iterable
+    {
+        yield 'newline' => ["OK\r\nX-Injected: yes"];
+        yield 'line feed' => ["OK\nX-Injected: yes"];
+        yield 'carriage return' => ["OK\rX-Injected: yes"];
+        yield 'nul' => ["OK\0"];
+        yield 'delete' => ["OK\x7F"];
     }
 
     public function testSameInstanceWhenSameProtocol(): void

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -729,6 +729,25 @@ class ServerRequestTest extends TestCase
         self::assertSame('http://up.example:8080/admin?x=1', $request->getRequestTarget());
     }
 
+    public function testFromGlobalsNormalizesAbsoluteFormRequestTargetWithControlCharacter(): void
+    {
+        if (\function_exists('apache_request_headers')) {
+            self::markTestSkipped('apache_request_headers() is available.');
+        }
+
+        $_SERVER = [
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI' => "http://up.example/admin\x7Fpath",
+            'HTTP_HOST' => 'good.example',
+        ];
+        $_COOKIE = $_POST = $_GET = $_FILES = [];
+
+        $request = ServerRequest::fromGlobals();
+
+        self::assertSame('http://up.example/admin%7Fpath', (string) $request->getUri());
+        self::assertSame('http://up.example/admin%7Fpath', $request->getRequestTarget());
+    }
+
     public static function dataInvalidServerPort(): iterable
     {
         yield 'empty' => [''];
@@ -1155,6 +1174,58 @@ class ServerRequestTest extends TestCase
 
         self::assertSame('GET', $server->getMethod());
         self::assertSame('1.1', $server->getProtocolVersion());
+    }
+
+    /**
+     * @dataProvider invalidRequestMethodFromGlobalsProvider
+     */
+    public function testFromGlobalsRejectsInvalidStringMethod(string $method): void
+    {
+        $_SERVER = [
+            'REQUEST_METHOD' => $method,
+            'REQUEST_URI' => '/',
+            'SERVER_PORT' => '80',
+        ];
+        $_COOKIE = $_POST = $_GET = $_FILES = [];
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        ServerRequest::fromGlobals();
+    }
+
+    public static function invalidRequestMethodFromGlobalsProvider(): iterable
+    {
+        yield 'empty' => [''];
+        yield 'space' => ['GET POST'];
+        yield 'newline' => ["GET\r\nX-Injected: yes"];
+        yield 'slash' => ['GET/'];
+    }
+
+    /**
+     * @dataProvider invalidServerProtocolFromGlobalsProvider
+     */
+    public function testFromGlobalsRejectsInvalidStringServerProtocol(string $serverProtocol): void
+    {
+        $_SERVER = [
+            'REQUEST_METHOD' => 'GET',
+            'SERVER_PROTOCOL' => $serverProtocol,
+            'REQUEST_URI' => '/',
+            'SERVER_PORT' => '80',
+        ];
+        $_COOKIE = $_POST = $_GET = $_FILES = [];
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        ServerRequest::fromGlobals();
+    }
+
+    public static function invalidServerProtocolFromGlobalsProvider(): iterable
+    {
+        yield 'empty' => [''];
+        yield 'text' => ['HTTP/foo'];
+        yield 'trailing space' => ['HTTP/1.1 '];
+        yield 'newline' => ["HTTP/1.1\r\nX-Injected: yes"];
+        yield 'repeated prefix' => ['HTTP/HTTP/1.1'];
     }
 
     public function testUploadedFiles(): void


### PR DESCRIPTION
This validates HTTP start-line fields before storing or parsing messages. It rejects malformed methods, request targets, protocol versions, response status lines, and reason phrases while keeping valid custom method tokens and printable custom reasons working.