### PR TITLE
Update 3.0 upgrade guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ composer require guzzlehttp/psr7
 | 2.x     | Latest              | >=7.2.5,<8.6 |
 | 3.x     | Experimental        | >=7.4,<8.6   |
 
-See [UPGRADING.md](UPGRADING.md) for notes on upgrading from 1.x to 2.0.
+See [UPGRADING.md](UPGRADING.md) for package upgrade notes.
 
 
 ## AppendStream

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -209,6 +209,44 @@ $stream = Utils::streamFor(new ArrayIterator([false, 'body']));
 $stream = Utils::streamFor(new ArrayIterator(['body']));
 ```
 
+#### Multipart Content-Length Headers
+
+`MultipartStream` no longer adds default `Content-Length` headers to individual
+`multipart/form-data` parts. RFC 7578 section 4.8 says multipart form-data
+parts must not include `Content-*` headers other than the supported multipart
+part headers, so 3.0 stops generating per-part `Content-Length` by default.
+
+If your tests compare raw multipart payloads, remove the generated
+`Content-Length` lines from expected strings:
+
+```text
+// 2.x generated:
+--boundary\r\n
+Content-Disposition: form-data; name="foo"\r\n
+Content-Length: 3\r\n
+\r\n
+bar\r\n
+
+// 3.0 generates:
+--boundary\r\n
+Content-Disposition: form-data; name="foo"\r\n
+\r\n
+bar\r\n
+```
+
+Applications can still pass an explicit `Content-Length` header in a multipart
+element's `headers` array if a non-standard peer requires it:
+
+```php
+$body = new MultipartStream([
+    [
+        'name' => 'foo',
+        'contents' => 'bar',
+        'headers' => ['Content-Length' => '3'],
+    ],
+]);
+```
+
 1.x to 2.0
 ----------
 


### PR DESCRIPTION
This links the README to the package upgrade notes and documents the multipart Content-Length header change. It keeps the upgrade guide focused on behavior changes that may require code or test updates.