### PR TITLE
Harden multipart metadata serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Validate iterator chunks passed to `Utils::streamFor()`
 - Validate unsupported values passed to `Query::build()`
 - Stop adding default `Content-Length` headers to `multipart/form-data` parts to comply with RFC 7578 section 4.8
+- Escape generated multipart `Content-Disposition` parameters and reject unsafe multipart boundary and part header metadata
 
 ### Removed
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -271,7 +271,7 @@ boundary.
 
 Custom multipart part header names and values are also validated before
 serialization. Header names must be valid HTTP tokens, and header values must be
-strings without control characters.
+strings without CR, LF, or other invalid control bytes.
 
 1.x to 2.0
 ----------

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -209,7 +209,7 @@ $stream = Utils::streamFor(new ArrayIterator([false, 'body']));
 $stream = Utils::streamFor(new ArrayIterator(['body']));
 ```
 
-#### Multipart Content-Length Headers
+#### Multipart Part Headers and Metadata
 
 `MultipartStream` no longer adds default `Content-Length` headers to individual
 `multipart/form-data` parts. RFC 7578 section 4.8 says multipart form-data
@@ -246,6 +246,32 @@ $body = new MultipartStream([
     ],
 ]);
 ```
+
+`MultipartStream` now escapes generated `Content-Disposition` `name` and
+`filename` parameters before serializing multipart part headers. Double quotes,
+carriage returns, and line feeds are encoded as `%22`, `%0D`, and `%0A`.
+
+```php
+// Before: these values were interpolated into the generated part header.
+$body = new MultipartStream([
+    [
+        'name' => "field\"\r\nname",
+        'filename' => "avatar\"\r\n.txt",
+        'contents' => 'body',
+    ],
+]);
+
+// After: the generated Content-Disposition parameters contain
+// field%22%0D%0Aname and avatar%22%0D%0A.txt.
+```
+
+Explicit custom boundaries are now validated using RFC 2046 multipart boundary
+syntax. Omit the boundary or pass `null` to continue using a generated random
+boundary.
+
+Custom multipart part header names and values are also validated before
+serialization. Header names must be valid HTTP tokens, and header values must be
+strings without control characters.
 
 1.x to 2.0
 ----------

--- a/src/MultipartStream.php
+++ b/src/MultipartStream.php
@@ -43,15 +43,11 @@ final class MultipartStream implements StreamInterface
      */
     public function __construct(array $elements = [], ?string $boundary = null)
     {
-        if ($boundary !== null && !self::isValidBoundary($boundary)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing an invalid multipart boundary to MultipartStream::__construct() is deprecated; guzzlehttp/psr7 3.0 rejects invalid multipart boundaries.'
-            );
+        if ($boundary !== null) {
+            self::validateBoundary($boundary);
         }
 
-        $this->boundary = $boundary ?: bin2hex(random_bytes(20));
+        $this->boundary = $boundary ?? bin2hex(random_bytes(20));
         $this->stream = $this->createStream($elements);
     }
 
@@ -75,6 +71,10 @@ final class MultipartStream implements StreamInterface
         $str = '';
         foreach ($headers as $key => $value) {
             $key = (string) $key;
+
+            self::validatePartHeaderName($key);
+            self::validatePartHeaderValue($value);
+
             $str .= "{$key}: {$value}\r\n";
         }
 
@@ -176,13 +176,14 @@ final class MultipartStream implements StreamInterface
         // Set a default content-disposition header if one was no provided
         $disposition = self::getHeader($headers, 'content-disposition');
         if (!$disposition) {
+            $escapedName = self::escapeContentDispositionParameter($name);
             $headers['Content-Disposition'] = ($filename === '0' || $filename)
                 ? sprintf(
                     'form-data; name="%s"; filename="%s"',
-                    $name,
-                    basename($filename)
+                    $escapedName,
+                    self::escapeContentDispositionParameter(basename($filename))
                 )
-                : "form-data; name=\"{$name}\"";
+                : sprintf('form-data; name="%s"', $escapedName);
         }
 
         // Set a default Content-Type if one was not supplied
@@ -209,15 +210,17 @@ final class MultipartStream implements StreamInterface
         return null;
     }
 
-    private static function isValidBoundary(string $boundary): bool
+    private static function validateBoundary(string $boundary): void
     {
         $length = strlen($boundary);
 
         if ($length < 1 || $length > 70 || $boundary[$length - 1] === ' ') {
-            return false;
+            throw new \InvalidArgumentException('Invalid multipart boundary.');
         }
 
-        return strspn($boundary, self::BOUNDARY_CHARS) === $length;
+        if (strspn($boundary, self::BOUNDARY_CHARS) !== $length) {
+            throw new \InvalidArgumentException('Invalid multipart boundary.');
+        }
     }
 
     /**
@@ -230,27 +233,15 @@ final class MultipartStream implements StreamInterface
         $normalized = [];
 
         foreach ($headers as $key => $value) {
-            self::deprecateInvalidPartHeaderName((string) $key);
+            $key = (string) $key;
+
+            self::validatePartHeaderName($key);
 
             if (!is_string($value)) {
-                if (!is_scalar($value) && $value !== null && !(is_object($value) && method_exists($value, '__toString'))) {
-                    throw new \InvalidArgumentException(sprintf(
-                        'Multipart part header value must be a string or stringable value but %s provided.',
-                        is_object($value) ? get_class($value) : gettype($value)
-                    ));
-                }
-
-                \trigger_deprecation(
-                    'guzzlehttp/psr7',
-                    '2.11',
-                    'Passing %s as a multipart part header value is deprecated; guzzlehttp/psr7 3.0 requires string multipart part header values.',
-                    \get_debug_type($value)
-                );
+                throw new \InvalidArgumentException('Multipart part header value must be a string.');
             }
 
-            $value = (string) $value;
-
-            self::deprecateInvalidPartHeaderValue($value);
+            self::validatePartHeaderValue($value);
 
             $normalized[$key] = $value;
         }
@@ -258,25 +249,22 @@ final class MultipartStream implements StreamInterface
         return $normalized;
     }
 
-    private static function deprecateInvalidPartHeaderName(string $name): void
+    private static function validatePartHeaderName(string $name): void
     {
         if (!preg_match('/^[a-zA-Z0-9\'`#$%&*+.^_|~!-]+$/D', $name)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing an invalid multipart part header name to MultipartStream is deprecated; guzzlehttp/psr7 3.0 rejects invalid multipart part header names.'
-            );
+            throw new \InvalidArgumentException(sprintf('"%s" is not valid multipart part header name.', $name));
         }
     }
 
-    private static function deprecateInvalidPartHeaderValue(string $value): void
+    private static function validatePartHeaderValue(string $value): void
     {
         if (!preg_match('/^[\x20\x09\x21-\x7E\x80-\xFF]*$/D', $value)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.11',
-                'Passing an invalid multipart part header value to MultipartStream is deprecated; guzzlehttp/psr7 3.0 rejects invalid multipart part header values.'
-            );
+            throw new \InvalidArgumentException(sprintf('"%s" is not valid multipart part header value.', $value));
         }
+    }
+
+    private static function escapeContentDispositionParameter(string $value): string
+    {
+        return str_replace(["\r", "\n", '"'], ['%0D', '%0A', '%22'], $value);
     }
 }

--- a/tests/MultipartStreamTest.php
+++ b/tests/MultipartStreamTest.php
@@ -779,7 +779,7 @@ class MultipartStreamTest extends TestCase
     public function testRejectsUnstringableCustomHeaderValues($value): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Multipart part header value must be a string or stringable value');
+        $this->expectExceptionMessage('Multipart part header value must be a string.');
 
         new MultipartStream([
             [
@@ -802,7 +802,7 @@ class MultipartStreamTest extends TestCase
         self::assertIsResource($resource);
 
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Multipart part header value must be a string or stringable value');
+        $this->expectExceptionMessage('Multipart part header value must be a string.');
 
         try {
             new MultipartStream([
@@ -815,6 +815,28 @@ class MultipartStreamTest extends TestCase
         } finally {
             fclose($resource);
         }
+    }
+
+    public function testSerializesNumericCustomHeaderNames(): void
+    {
+        $b = new MultipartStream([
+            [
+                'name' => 'field',
+                'contents' => 'body',
+                'headers' => [123 => 'value'],
+            ],
+        ], 'boundary');
+
+        $expected = \implode('', [
+            "--boundary\r\n",
+            "123: value\r\n",
+            "Content-Disposition: form-data; name=\"field\"\r\n",
+            "\r\n",
+            "body\r\n",
+            "--boundary--\r\n",
+        ]);
+
+        self::assertSame($expected, (string) $b);
     }
 
     public function testSerializesFilesWithCustomHeadersAndMultipleValues(): void

--- a/tests/MultipartStreamTest.php
+++ b/tests/MultipartStreamTest.php
@@ -22,6 +22,59 @@ class MultipartStreamTest extends TestCase
         self::assertSame('foo', $b->getBoundary());
     }
 
+    /**
+     * @dataProvider validCustomBoundaryProvider
+     */
+    public function testCanProvideRfc2046Boundary(string $boundary): void
+    {
+        $b = new MultipartStream([], $boundary);
+        self::assertSame($boundary, $b->getBoundary());
+    }
+
+    public static function validCustomBoundaryProvider(): iterable
+    {
+        yield 'letters and digits' => ['abc123'];
+        yield 'zero' => ['0'];
+        yield 'apostrophe' => ["abc'def"];
+        yield 'parentheses' => ['abc(def)'];
+        yield 'plus' => ['abc+def'];
+        yield 'underscore' => ['abc_def'];
+        yield 'comma' => ['abc,def'];
+        yield 'hyphen' => ['abc-def'];
+        yield 'period' => ['abc.def'];
+        yield 'slash' => ['abc/def'];
+        yield 'colon' => ['abc:def'];
+        yield 'equals' => ['abc=def'];
+        yield 'question mark' => ['abc?def'];
+        yield 'internal space' => ['abc def'];
+        yield 'seventy bytes' => [str_repeat('a', 70)];
+    }
+
+    /**
+     * @dataProvider invalidCustomBoundaryProvider
+     */
+    public function testRejectsInvalidCustomBoundary(string $boundary): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid multipart boundary.');
+
+        new MultipartStream([], $boundary);
+    }
+
+    public static function invalidCustomBoundaryProvider(): iterable
+    {
+        yield 'empty' => [''];
+        yield 'seventy one bytes' => [str_repeat('a', 71)];
+        yield 'trailing space' => ['abc '];
+        yield 'carriage return' => ["abc\rdef"];
+        yield 'line feed' => ["abc\ndef"];
+        yield 'nul' => ["abc\0def"];
+        yield 'quote' => ['abc"def'];
+        yield 'backslash' => ['abc\\def'];
+        yield 'semicolon' => ['abc;def'];
+        yield 'non ascii' => ["abc\xC3\xA9def"];
+    }
+
     public function testIsNotWritable(): void
     {
         $b = new MultipartStream();
@@ -87,6 +140,39 @@ class MultipartStreamTest extends TestCase
         ]);
 
         self::assertSame($expected, (string) $b);
+    }
+
+    public function testEscapesGeneratedContentDispositionName(): void
+    {
+        $b = new MultipartStream([
+            [
+                'name' => "field\"\r\nname",
+                'contents' => 'value',
+            ],
+        ], 'boundary');
+
+        $expected = \implode('', [
+            "--boundary\r\n",
+            "Content-Disposition: form-data; name=\"field%22%0D%0Aname\"\r\n",
+            "\r\n",
+            "value\r\n",
+            "--boundary--\r\n",
+        ]);
+
+        self::assertSame($expected, (string) $b);
+    }
+
+    public function testRejectsGeneratedContentDispositionNameWithNul(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('is not valid multipart part header value.');
+
+        new MultipartStream([
+            [
+                'name' => "field\0name",
+                'contents' => 'value',
+            ],
+        ], 'boundary');
     }
 
     public function testSerializesNonStringFields(): void
@@ -561,6 +647,69 @@ class MultipartStreamTest extends TestCase
         self::assertSame($expected, (string) $b);
     }
 
+    public function testEscapesGeneratedContentDispositionFilename(): void
+    {
+        $b = new MultipartStream([
+            [
+                'name' => 'upload',
+                'contents' => 'body',
+                'filename' => "avatar\"\r\n.txt",
+            ],
+        ], 'boundary');
+
+        $expected = \implode('', [
+            "--boundary\r\n",
+            "Content-Disposition: form-data; name=\"upload\"; filename=\"avatar%22%0D%0A.txt\"\r\n",
+            "Content-Type: text/plain\r\n",
+            "\r\n",
+            "body\r\n",
+            "--boundary--\r\n",
+        ]);
+
+        self::assertSame($expected, (string) $b);
+    }
+
+    public function testEscapesUriDerivedContentDispositionFilename(): void
+    {
+        $file = Psr7\FnStream::decorate(Psr7\Utils::streamFor('body'), [
+            'getMetadata' => static function (): string {
+                return "/foo/avatar\"\r\n.txt";
+            },
+        ]);
+
+        $b = new MultipartStream([
+            [
+                'name' => 'upload',
+                'contents' => $file,
+            ],
+        ], 'boundary');
+
+        $expected = \implode('', [
+            "--boundary\r\n",
+            "Content-Disposition: form-data; name=\"upload\"; filename=\"avatar%22%0D%0A.txt\"\r\n",
+            "Content-Type: text/plain\r\n",
+            "\r\n",
+            "body\r\n",
+            "--boundary--\r\n",
+        ]);
+
+        self::assertSame($expected, (string) $b);
+    }
+
+    public function testRejectsGeneratedContentDispositionFilenameWithNul(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('is not valid multipart part header value.');
+
+        new MultipartStream([
+            [
+                'name' => 'upload',
+                'contents' => 'body',
+                'filename' => "avatar\0.txt",
+            ],
+        ], 'boundary');
+    }
+
     public function testSerializesFilesWithMixedNewlines(): void
     {
         $content = "LF\nCRLF\r\nCR\r";
@@ -714,6 +863,69 @@ class MultipartStreamTest extends TestCase
         ]);
 
         self::assertSame($expected, (string) $b);
+    }
+
+    /**
+     * @dataProvider invalidCustomPartHeaderNameProvider
+     */
+    public function testRejectsInvalidCustomPartHeaderNames(string $header): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('is not valid multipart part header name.');
+
+        new MultipartStream([
+            [
+                'name' => 'field',
+                'contents' => 'body',
+                'headers' => [$header => 'value'],
+            ],
+        ], 'boundary');
+    }
+
+    public static function invalidCustomPartHeaderNameProvider(): iterable
+    {
+        yield 'empty' => [''];
+        yield 'space' => ['Bad Header'];
+        yield 'carriage return' => ["Bad\rHeader"];
+        yield 'line feed' => ["Bad\nHeader"];
+    }
+
+    /**
+     * @dataProvider invalidCustomPartHeaderValueProvider
+     */
+    public function testRejectsInvalidCustomPartHeaderValues(string $value): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('is not valid multipart part header value.');
+
+        new MultipartStream([
+            [
+                'name' => 'field',
+                'contents' => 'body',
+                'headers' => ['X-Test' => $value],
+            ],
+        ], 'boundary');
+    }
+
+    public static function invalidCustomPartHeaderValueProvider(): iterable
+    {
+        yield 'carriage return' => ["ok\rX-Injected: yes"];
+        yield 'line feed' => ["ok\nX-Injected: yes"];
+        yield 'nul' => ["ok\0bad"];
+    }
+
+    public function testRejectsNonStringCustomPartHeaderValue(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Multipart part header value must be a string.');
+
+        new MultipartStream([
+            [
+                'name' => 'field',
+                'contents' => 'body',
+                'headers' => ['X-Test' => 123],
+            ],
+        ], 'boundary');
     }
 
     public function testCanCreateWithNoneMetadataStreamField(): void


### PR DESCRIPTION
This escapes generated multipart Content-Disposition parameters and validates custom multipart boundary and part header metadata. It also documents the resulting 3.0 upgrade-guide behavior changes.