### PR TITLE
Deprecate invalid multipart metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deprecated non-string header values that guzzlehttp/psr7 3.0 will reject
 - Deprecated empty header value arrays that guzzlehttp/psr7 3.0 will reject
 - Deprecated URI schemes that do not match guzzlehttp/psr7 3.0 syntax requirements
-- Deprecated multipart boundary and part header metadata that guzzlehttp/psr7 3.0 will reject
+- Deprecated multipart boundary and custom part header metadata that guzzlehttp/psr7 3.0 will reject
 
 ## 2.10.1 - 2026-05-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deprecated non-string header values that guzzlehttp/psr7 3.0 will reject
 - Deprecated empty header value arrays that guzzlehttp/psr7 3.0 will reject
 - Deprecated URI schemes that do not match guzzlehttp/psr7 3.0 syntax requirements
+- Deprecated multipart boundary and part header metadata that guzzlehttp/psr7 3.0 will reject
 
 ## 2.10.1 - 2026-05-20
 

--- a/src/MultipartStream.php
+++ b/src/MultipartStream.php
@@ -183,16 +183,6 @@ final class MultipartStream implements StreamInterface
                     basename($filename)
                 )
                 : "form-data; name=\"{$name}\"";
-
-            $contentDisposition3 = ($filename === '0' || $filename)
-                ? sprintf(
-                    'form-data; name="%s"; filename="%s"',
-                    self::escapeContentDispositionParameter($name),
-                    self::escapeContentDispositionParameter(basename($filename))
-                )
-                : sprintf('form-data; name="%s"', self::escapeContentDispositionParameter($name));
-
-            self::deprecateInvalidPartHeaderValue($contentDisposition3);
         }
 
         // Set a default content-length header if one was no provided
@@ -296,10 +286,5 @@ final class MultipartStream implements StreamInterface
                 'Passing an invalid multipart part header value to MultipartStream is deprecated; guzzlehttp/psr7 3.0 rejects invalid multipart part header values.'
             );
         }
-    }
-
-    private static function escapeContentDispositionParameter(string $value): string
-    {
-        return str_replace(["\r", "\n", '"'], ['%0D', '%0A', '%22'], $value);
     }
 }

--- a/src/MultipartStream.php
+++ b/src/MultipartStream.php
@@ -20,27 +20,37 @@ final class MultipartStream implements StreamInterface
     /** @var StreamInterface */
     private $stream;
 
+    private const BOUNDARY_CHARS = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'()+_,-./:=? ";
+
     /**
-     * @param array  $elements Array of associative arrays, each containing a
-     *                         required "name" key mapping to the form field,
-     *                         name, a required "contents" key mapping to any
-     *                         value accepted by Utils::streamFor() (scalar,
-     *                         null, resource, StreamInterface, Iterator, or
-     *                         callable), or an array for nested expansion.
-     *                         Optional keys include "headers" (associative
-     *                         array of custom headers) and "filename" (string
-     *                         to send as the filename in the part).
-     *                         When "contents" is an array, it is recursively
-     *                         expanded into multiple fields using bracket notation
-     *                         (e.g., name[0][key]). Empty arrays produce no fields.
-     *                         The "filename" and "headers" options cannot be used
-     *                         with array contents.
-     * @param string $boundary You can optionally provide a specific boundary
+     * @param array       $elements Array of associative arrays, each containing a
+     *                              required "name" key mapping to the form field,
+     *                              name, a required "contents" key mapping to any
+     *                              value accepted by Utils::streamFor() (scalar,
+     *                              null, resource, StreamInterface, Iterator, or
+     *                              callable), or an array for nested expansion.
+     *                              Optional keys include "headers" (associative
+     *                              array of custom headers) and "filename" (string
+     *                              to send as the filename in the part).
+     *                              When "contents" is an array, it is recursively
+     *                              expanded into multiple fields using bracket notation
+     *                              (e.g., name[0][key]). Empty arrays produce no fields.
+     *                              The "filename" and "headers" options cannot be used
+     *                              with array contents.
+     * @param string|null $boundary You can optionally provide a specific boundary
      *
      * @throws \InvalidArgumentException
      */
     public function __construct(array $elements = [], ?string $boundary = null)
     {
+        if ($boundary !== null && !self::isValidBoundary($boundary)) {
+            \trigger_deprecation(
+                'guzzlehttp/psr7',
+                '2.11',
+                'Passing an invalid multipart boundary to MultipartStream::__construct() is deprecated; guzzlehttp/psr7 3.0 rejects invalid multipart boundaries.'
+            );
+        }
+
         $this->boundary = $boundary ?: bin2hex(random_bytes(20));
         $this->stream = $this->createStream($elements);
     }
@@ -58,12 +68,13 @@ final class MultipartStream implements StreamInterface
     /**
      * Get the headers needed before transferring the content of a POST file
      *
-     * @param string[] $headers
+     * @param array<array-key, string> $headers
      */
     private function getHeaders(array $headers): string
     {
         $str = '';
         foreach ($headers as $key => $value) {
+            $key = (string) $key;
             $str .= "{$key}: {$value}\r\n";
         }
 
@@ -154,12 +165,14 @@ final class MultipartStream implements StreamInterface
     }
 
     /**
-     * @param string[] $headers
+     * @param array<array-key, mixed> $headers
      *
-     * @return array{0: StreamInterface, 1: string[]}
+     * @return array{0: StreamInterface, 1: array<array-key, string>}
      */
     private function createElement(string $name, StreamInterface $stream, ?string $filename, array $headers): array
     {
+        $headers = self::normalizePartHeaders($headers);
+
         // Set a default content-disposition header if one was no provided
         $disposition = self::getHeader($headers, 'content-disposition');
         if (!$disposition) {
@@ -170,6 +183,16 @@ final class MultipartStream implements StreamInterface
                     basename($filename)
                 )
                 : "form-data; name=\"{$name}\"";
+
+            $contentDisposition3 = ($filename === '0' || $filename)
+                ? sprintf(
+                    'form-data; name="%s"; filename="%s"',
+                    self::escapeContentDispositionParameter($name),
+                    self::escapeContentDispositionParameter(basename($filename))
+                )
+                : sprintf('form-data; name="%s"', self::escapeContentDispositionParameter($name));
+
+            self::deprecateInvalidPartHeaderValue($contentDisposition3);
         }
 
         // Set a default content-length header if one was no provided
@@ -190,7 +213,7 @@ final class MultipartStream implements StreamInterface
     }
 
     /**
-     * @param string[] $headers
+     * @param array<array-key, string> $headers
      */
     private static function getHeader(array $headers, string $key): ?string
     {
@@ -202,5 +225,81 @@ final class MultipartStream implements StreamInterface
         }
 
         return null;
+    }
+
+    private static function isValidBoundary(string $boundary): bool
+    {
+        $length = strlen($boundary);
+
+        if ($length < 1 || $length > 70 || $boundary[$length - 1] === ' ') {
+            return false;
+        }
+
+        return strspn($boundary, self::BOUNDARY_CHARS) === $length;
+    }
+
+    /**
+     * @param array<array-key, mixed> $headers
+     *
+     * @return array<array-key, string>
+     */
+    private static function normalizePartHeaders(array $headers): array
+    {
+        $normalized = [];
+
+        foreach ($headers as $key => $value) {
+            self::deprecateInvalidPartHeaderName((string) $key);
+
+            if (!is_string($value)) {
+                if (!is_scalar($value) && $value !== null && !(is_object($value) && method_exists($value, '__toString'))) {
+                    throw new \InvalidArgumentException(sprintf(
+                        'Multipart part header value must be a string or stringable value but %s provided.',
+                        is_object($value) ? get_class($value) : gettype($value)
+                    ));
+                }
+
+                \trigger_deprecation(
+                    'guzzlehttp/psr7',
+                    '2.11',
+                    'Passing %s as a multipart part header value is deprecated; guzzlehttp/psr7 3.0 requires string multipart part header values.',
+                    \get_debug_type($value)
+                );
+            }
+
+            $value = (string) $value;
+
+            self::deprecateInvalidPartHeaderValue($value);
+
+            $normalized[$key] = $value;
+        }
+
+        return $normalized;
+    }
+
+    private static function deprecateInvalidPartHeaderName(string $name): void
+    {
+        if (!preg_match('/^[a-zA-Z0-9\'`#$%&*+.^_|~!-]+$/D', $name)) {
+            \trigger_deprecation(
+                'guzzlehttp/psr7',
+                '2.11',
+                'Passing an invalid multipart part header name to MultipartStream is deprecated; guzzlehttp/psr7 3.0 rejects invalid multipart part header names.'
+            );
+        }
+    }
+
+    private static function deprecateInvalidPartHeaderValue(string $value): void
+    {
+        if (!preg_match('/^[\x20\x09\x21-\x7E\x80-\xFF]*$/D', $value)) {
+            \trigger_deprecation(
+                'guzzlehttp/psr7',
+                '2.11',
+                'Passing an invalid multipart part header value to MultipartStream is deprecated; guzzlehttp/psr7 3.0 rejects invalid multipart part header values.'
+            );
+        }
+    }
+
+    private static function escapeContentDispositionParameter(string $value): string
+    {
+        return str_replace(["\r", "\n", '"'], ['%0D', '%0A', '%22'], $value);
     }
 }

--- a/tests/MultipartStreamTest.php
+++ b/tests/MultipartStreamTest.php
@@ -655,6 +655,50 @@ class MultipartStreamTest extends TestCase
         self::assertSame($expected, (string) $b);
     }
 
+    /**
+     * @dataProvider unstringableCustomHeaderValueProvider
+     */
+    public function testRejectsUnstringableCustomHeaderValues($value): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Multipart part header value must be a string or stringable value');
+
+        new MultipartStream([
+            [
+                'name' => 'field',
+                'contents' => 'body',
+                'headers' => ['X-Test' => $value],
+            ],
+        ], 'boundary');
+    }
+
+    public static function unstringableCustomHeaderValueProvider(): iterable
+    {
+        yield 'array' => [['value']];
+        yield 'object' => [new \stdClass()];
+    }
+
+    public function testRejectsResourceCustomHeaderValue(): void
+    {
+        $resource = fopen('php://temp', 'r');
+        self::assertIsResource($resource);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Multipart part header value must be a string or stringable value');
+
+        try {
+            new MultipartStream([
+                [
+                    'name' => 'field',
+                    'contents' => 'body',
+                    'headers' => ['X-Test' => $resource],
+                ],
+            ], 'boundary');
+        } finally {
+            fclose($resource);
+        }
+    }
+
     public function testSerializesFilesWithCustomHeadersAndMultipleValues(): void
     {
         $f1 = Psr7\FnStream::decorate(Psr7\Utils::streamFor('foo'), [


### PR DESCRIPTION
This deprecates multipart boundary and custom part header metadata that guzzlehttp/psr7 3.0 will reject. It also rejects custom multipart part header values that cannot be converted to strings safely.