### PR TITLE
Accept additional request target forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tighten `ServerRequest::getUriFromGlobals()` validation for malformed `HTTP_HOST` and `SERVER_PORT` values
 - Stop preserving malformed `Host` headers when building server requests from globals
 - Normalize server request URI reconstruction from globals
+- Accept `OPTIONS *` and `CONNECT` authority-form request targets in `Message::parseRequest()`
 - Reject malformed HTTP start-line fields
 - Reject hosts with embedded ports in `Uri::withHost()`
 - Validate iterator chunks passed to `Utils::streamFor()`

--- a/src/Message.php
+++ b/src/Message.php
@@ -234,6 +234,23 @@ final class Message
      */
     public static function parseRequestUri(string $path, array $headers): string
     {
+        $host = self::getHostFromHeaders($headers);
+
+        // If no host is found, then a full URI cannot be constructed.
+        if ($host === null) {
+            return $path;
+        }
+
+        $scheme = substr($host, -4) === ':443' ? 'https' : 'http';
+
+        return $scheme.'://'.$host.'/'.ltrim($path, '/');
+    }
+
+    /**
+     * @param array $headers Array of headers (each value an array).
+     */
+    private static function getHostFromHeaders(array $headers): ?string
+    {
         $hostKey = array_filter(array_keys($headers), function ($k) {
             // Numeric array keys are converted to int by PHP.
             $k = (string) $k;
@@ -241,15 +258,26 @@ final class Message
             return strtolower($k) === 'host';
         });
 
-        // If no host is found, then a full URI cannot be constructed.
         if (!$hostKey) {
-            return $path;
+            return null;
         }
 
-        $host = $headers[reset($hostKey)][0];
+        return $headers[reset($hostKey)][0];
+    }
+
+    /**
+     * @param array $headers Array of headers (each value an array).
+     */
+    private static function parseRequestAuthorityUri(array $headers): string
+    {
+        $host = self::getHostFromHeaders($headers);
+        if ($host === null) {
+            return '';
+        }
+
         $scheme = substr($host, -4) === ':443' ? 'https' : 'http';
 
-        return $scheme.'://'.$host.'/'.ltrim($path, '/');
+        return $scheme.'://'.$host;
     }
 
     /**
@@ -261,19 +289,119 @@ final class Message
     {
         $data = self::parseMessage($message);
         $matches = [];
-        if (!preg_match('/^(?P<method>[!#$%&\'*+.^_`|~0-9A-Za-z-]+) (?P<target>(?:[A-Za-z][A-Za-z0-9+.-]*:\/\/|\/)[^\x00-\x20\x7F]*) HTTP\/(?P<version>\d+(?:\.\d+)?)$/D', $data['start-line'], $matches)) {
+        if (!preg_match('/^(?P<method>[!#$%&\'*+.^_`|~0-9A-Za-z-]+) (?P<target>[^\x00-\x20\x7F]+) HTTP\/(?P<version>\d+(?:\.\d+)?)$/D', $data['start-line'], $matches)) {
             throw new \InvalidArgumentException('Invalid request string');
         }
 
-        $request = new Request(
-            $matches['method'],
-            $matches['target'][0] === '/' ? self::parseRequestUri($matches['target'], $data['headers']) : $matches['target'],
-            $data['headers'],
-            $data['body'],
-            $matches['version']
-        );
+        if ($matches['target'][0] === '/') {
+            return new Request(
+                $matches['method'],
+                self::parseRequestUri($matches['target'], $data['headers']),
+                $data['headers'],
+                $data['body'],
+                $matches['version']
+            );
+        }
 
-        return $matches['target'][0] === '/' ? $request : $request->withRequestTarget($matches['target']);
+        if (self::isAbsoluteFormRequestTarget($matches['target'])) {
+            return (new Request(
+                $matches['method'],
+                $matches['target'],
+                $data['headers'],
+                $data['body'],
+                $matches['version']
+            ))->withRequestTarget($matches['target']);
+        }
+
+        if (self::isAsteriskFormRequestTarget($matches['method'], $matches['target'])) {
+            return (new Request(
+                $matches['method'],
+                self::parseRequestAuthorityUri($data['headers']),
+                $data['headers'],
+                $data['body'],
+                $matches['version']
+            ))->withRequestTarget($matches['target']);
+        }
+
+        $connectUri = self::parseConnectAuthorityFormRequestTarget($matches['method'], $matches['target']);
+        if ($connectUri !== null) {
+            return (new Request(
+                $matches['method'],
+                $connectUri,
+                $data['headers'],
+                $data['body'],
+                $matches['version']
+            ))->withRequestTarget($matches['target']);
+        }
+
+        throw new \InvalidArgumentException('Invalid request string');
+    }
+
+    private static function isAbsoluteFormRequestTarget(string $target): bool
+    {
+        return preg_match('/^[A-Za-z][A-Za-z0-9+.-]*:\/\//D', $target) === 1;
+    }
+
+    private static function isAsteriskFormRequestTarget(string $method, string $target): bool
+    {
+        return $method === 'OPTIONS' && $target === '*';
+    }
+
+    private static function parseConnectAuthorityFormRequestTarget(string $method, string $target): ?Uri
+    {
+        if ($method !== 'CONNECT' || strpbrk($target, '/?#') !== false) {
+            return null;
+        }
+
+        $host = $target;
+        $port = null;
+
+        if ($target === '') {
+            return null;
+        }
+
+        if ($target[0] === '[') {
+            $closingBracket = strpos($target, ']');
+            if ($closingBracket === false || !isset($target[$closingBracket + 1]) || $target[$closingBracket + 1] !== ':') {
+                return null;
+            }
+
+            $host = substr($target, 0, $closingBracket + 1);
+            $port = self::parseAuthorityPort(substr($target, $closingBracket + 2));
+        } elseif (false !== ($colon = strrpos($target, ':'))) {
+            $host = substr($target, 0, $colon);
+            $port = self::parseAuthorityPort(substr($target, $colon + 1));
+        }
+
+        if ($host === '' || $port === null) {
+            return null;
+        }
+
+        try {
+            Uri::assertValidHost($host);
+
+            return new Uri('//'.$host.':'.$port);
+        } catch (\InvalidArgumentException $e) {
+            return null;
+        }
+    }
+
+    private static function parseAuthorityPort(string $port): ?int
+    {
+        if ($port === '' || !ctype_digit($port)) {
+            return null;
+        }
+
+        $port = ltrim($port, '0');
+        if ($port === '') {
+            return null;
+        }
+
+        if (strlen($port) > 5 || (int) $port > 0xFFFF) {
+            return null;
+        }
+
+        return (int) $port;
     }
 
     /**

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -119,6 +119,65 @@ class MessageTest extends TestCase
         self::assertSame('https://www.google.com/search?q=foobar', (string) $request->getUri());
     }
 
+    public function testParsesOptionsAsteriskFormRequestTarget(): void
+    {
+        $req = "OPTIONS * HTTP/1.1\r\nHost: foo.com\r\n\r\n";
+        $request = Psr7\Message::parseRequest($req);
+
+        self::assertSame('OPTIONS', $request->getMethod());
+        self::assertSame('*', $request->getRequestTarget());
+        self::assertSame('1.1', $request->getProtocolVersion());
+        self::assertSame('foo.com', $request->getHeaderLine('Host'));
+        self::assertSame('', (string) $request->getBody());
+        self::assertSame('http://foo.com', (string) $request->getUri());
+    }
+
+    public function testParsesOptionsAsteriskFormRequestTargetWithoutHost(): void
+    {
+        $req = "OPTIONS * HTTP/1.1\r\n\r\n";
+        $request = Psr7\Message::parseRequest($req);
+
+        self::assertSame('OPTIONS', $request->getMethod());
+        self::assertSame('*', $request->getRequestTarget());
+        self::assertSame('', $request->getHeaderLine('Host'));
+        self::assertSame('', (string) $request->getUri());
+    }
+
+    public function testParsesConnectAuthorityFormRequestTarget(): void
+    {
+        $req = "CONNECT up.example:443 HTTP/1.1\r\nHost: up.example:443\r\n\r\n";
+        $request = Psr7\Message::parseRequest($req);
+
+        self::assertSame('CONNECT', $request->getMethod());
+        self::assertSame('up.example:443', $request->getRequestTarget());
+        self::assertSame('1.1', $request->getProtocolVersion());
+        self::assertSame('up.example:443', $request->getHeaderLine('Host'));
+        self::assertSame('', (string) $request->getBody());
+        self::assertSame('//up.example:443', (string) $request->getUri());
+    }
+
+    public function testParsesConnectAuthorityFormRequestTargetWithIpv6(): void
+    {
+        $req = "CONNECT [::1]:443 HTTP/1.1\r\nHost: [::1]:443\r\n\r\n";
+        $request = Psr7\Message::parseRequest($req);
+
+        self::assertSame('CONNECT', $request->getMethod());
+        self::assertSame('[::1]:443', $request->getRequestTarget());
+        self::assertSame('[::1]:443', $request->getHeaderLine('Host'));
+        self::assertSame('//[::1]:443', (string) $request->getUri());
+    }
+
+    public function testParsesConnectAuthorityFormRequestTargetWithLeadingZeroPort(): void
+    {
+        $req = "CONNECT up.example:000443 HTTP/1.1\r\nHost: up.example:000443\r\n\r\n";
+        $request = Psr7\Message::parseRequest($req);
+
+        self::assertSame('CONNECT', $request->getMethod());
+        self::assertSame('up.example:000443', $request->getRequestTarget());
+        self::assertSame('up.example:000443', $request->getHeaderLine('Host'));
+        self::assertSame('//up.example:443', (string) $request->getUri());
+    }
+
     public function testParsesRequestMessagesWithCustomMethod(): void
     {
         $req = "GET_DATA / HTTP/1.1\r\nFoo: Bar\r\nHost: foo.com\r\n\r\n";
@@ -192,6 +251,15 @@ class MessageTest extends TestCase
         yield 'target tab' => ["GET /foo\tbar HTTP/1.1"];
         yield 'target nul' => ["GET /foo\0bar HTTP/1.1"];
         yield 'target delete' => ["GET /foo\x7Fbar HTTP/1.1"];
+        yield 'asterisk non-options' => ['GET * HTTP/1.1'];
+        yield 'lowercase options asterisk' => ['options * HTTP/1.1'];
+        yield 'authority-form non-connect' => ['GET up.example:443 HTTP/1.1'];
+        yield 'lowercase connect authority-form' => ['connect up.example:443 HTTP/1.1'];
+        yield 'connect missing port' => ['CONNECT up.example HTTP/1.1'];
+        yield 'connect zero port' => ['CONNECT up.example:0 HTTP/1.1'];
+        yield 'connect user info' => ['CONNECT user@up.example:443 HTTP/1.1'];
+        yield 'connect path' => ['CONNECT up.example:443/ HTTP/1.1'];
+        yield 'connect query' => ['CONNECT up.example:443?x=1 HTTP/1.1'];
         yield 'invalid protocol text' => ['GET / HTTP/foo'];
         yield 'invalid protocol segments' => ['GET / HTTP/1.1.1'];
         yield 'missing version' => ['GET /'];


### PR DESCRIPTION
This accepts OPTIONS asterisk-form and CONNECT authority-form request targets in Message::parseRequest().