### PR TITLE
Clarify multipart parameter escaping

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -249,7 +249,9 @@ $body = new MultipartStream([
 
 `MultipartStream` now escapes generated `Content-Disposition` `name` and
 `filename` parameters before serializing multipart part headers. Double quotes,
-carriage returns, and line feeds are encoded as `%22`, `%0D`, and `%0A`.
+carriage returns, and line feeds are encoded as `%22`, `%0D`, and `%0A`. Literal
+backslashes and other characters are serialized unchanged, matching browser
+multipart form submission behavior.
 
 ```php
 // Before: these values were interpolated into the generated part header.

--- a/src/MultipartStream.php
+++ b/src/MultipartStream.php
@@ -265,6 +265,7 @@ final class MultipartStream implements StreamInterface
 
     private static function escapeContentDispositionParameter(string $value): string
     {
+        // Match WHATWG browser multipart/form-data behavior: escape CR, LF, and DQUOTE only.
         return str_replace(["\r", "\n", '"'], ['%0D', '%0A', '%22'], $value);
     }
 }

--- a/tests/MultipartStreamTest.php
+++ b/tests/MultipartStreamTest.php
@@ -162,6 +162,26 @@ class MultipartStreamTest extends TestCase
         self::assertSame($expected, (string) $b);
     }
 
+    public function testSerializesLiteralBackslashesUnchangedInGeneratedContentDispositionName(): void
+    {
+        $b = new MultipartStream([
+            [
+                'name' => 'field\\name',
+                'contents' => 'value',
+            ],
+        ], 'boundary');
+
+        $expected = \implode('', [
+            "--boundary\r\n",
+            "Content-Disposition: form-data; name=\"field\\name\"\r\n",
+            "\r\n",
+            "value\r\n",
+            "--boundary--\r\n",
+        ]);
+
+        self::assertSame($expected, (string) $b);
+    }
+
     public function testRejectsGeneratedContentDispositionNameWithNul(): void
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -669,6 +689,28 @@ class MultipartStreamTest extends TestCase
         self::assertSame($expected, (string) $b);
     }
 
+    public function testSerializesLiteralBackslashesUnchangedInGeneratedContentDispositionFilename(): void
+    {
+        $b = new MultipartStream([
+            [
+                'name' => 'upload',
+                'contents' => 'body',
+                'filename' => 'avatar\\name.txt',
+            ],
+        ], 'boundary');
+
+        $expected = \implode('', [
+            "--boundary\r\n",
+            "Content-Disposition: form-data; name=\"upload\"; filename=\"avatar\\name.txt\"\r\n",
+            "Content-Type: text/plain\r\n",
+            "\r\n",
+            "body\r\n",
+            "--boundary--\r\n",
+        ]);
+
+        self::assertSame($expected, (string) $b);
+    }
+
     public function testEscapesUriDerivedContentDispositionFilename(): void
     {
         $file = Psr7\FnStream::decorate(Psr7\Utils::streamFor('body'), [
@@ -687,6 +729,33 @@ class MultipartStreamTest extends TestCase
         $expected = \implode('', [
             "--boundary\r\n",
             "Content-Disposition: form-data; name=\"upload\"; filename=\"avatar%22%0D%0A.txt\"\r\n",
+            "Content-Type: text/plain\r\n",
+            "\r\n",
+            "body\r\n",
+            "--boundary--\r\n",
+        ]);
+
+        self::assertSame($expected, (string) $b);
+    }
+
+    public function testSerializesLiteralBackslashesUnchangedInUriDerivedContentDispositionFilename(): void
+    {
+        $file = Psr7\FnStream::decorate(Psr7\Utils::streamFor('body'), [
+            'getMetadata' => static function (): string {
+                return '/foo/avatar\\name.txt';
+            },
+        ]);
+
+        $b = new MultipartStream([
+            [
+                'name' => 'upload',
+                'contents' => $file,
+            ],
+        ], 'boundary');
+
+        $expected = \implode('', [
+            "--boundary\r\n",
+            "Content-Disposition: form-data; name=\"upload\"; filename=\"avatar\\name.txt\"\r\n",
             "Content-Type: text/plain\r\n",
             "\r\n",
             "body\r\n",


### PR DESCRIPTION
This documents and tests that generated multipart Content-Disposition parameters follow browser form submission behavior by escaping double quotes, carriage returns, and line feeds while serializing other characters unchanged.