### PR TITLE
Add stream timeout exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reject hosts with embedded ports in `Uri::withHost()`
 - Validate iterator chunks passed to `Utils::streamFor()`
 - Validate unsupported values passed to `Query::build()`
-- Throw `TimeoutException` when stream read, copy, hash, and line operations time out
+- Throw `TimeoutException` when stream read, copy, hash, and line operations detect timeout metadata
 - Stop adding default `Content-Length` headers to `multipart/form-data` parts to comply with RFC 7578 section 4.8
 - Escape generated multipart `Content-Disposition` parameters and reject unsafe multipart boundary and part header metadata
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 3.0.0 - Unreleased
 
+### Added
+
+- Add `GuzzleHttp\Psr7\Exception\TimeoutException` for timed-out stream operations
+
 ### Changed
 
 - Require `psr/http-message:^2.0` and add its native parameter types
@@ -25,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reject hosts with embedded ports in `Uri::withHost()`
 - Validate iterator chunks passed to `Utils::streamFor()`
 - Validate unsupported values passed to `Query::build()`
+- Throw `TimeoutException` when stream read, copy, hash, and line operations time out
 - Stop adding default `Content-Length` headers to `multipart/form-data` parts to comply with RFC 7578 section 4.8
 - Escape generated multipart `Content-Disposition` parameters and reject unsafe multipart boundary and part header metadata
 

--- a/README.md
+++ b/README.md
@@ -462,8 +462,9 @@ Remove the items given by the keys, case insensitively from the data.
 Copy the contents of a stream into another stream until the given number
 of bytes have been read.
 
-Throws `GuzzleHttp\Psr7\Exception\TimeoutException` if a source read or
-destination write times out.
+Throws `GuzzleHttp\Psr7\Exception\TimeoutException` when PHP-style timeout
+metadata can be detected after a source read or destination write cannot make
+progress.
 
 
 ## `GuzzleHttp\Psr7\Utils::copyToString`
@@ -473,7 +474,8 @@ destination write times out.
 Copy the contents of a stream into a string until the given number of
 bytes have been read.
 
-Throws `GuzzleHttp\Psr7\Exception\TimeoutException` if a stream read times out.
+Throws `GuzzleHttp\Psr7\Exception\TimeoutException` when PHP-style timeout
+metadata can be detected after a stream read cannot make progress.
 
 
 ## `GuzzleHttp\Psr7\Utils::hash`
@@ -485,7 +487,8 @@ Calculate a hash of a stream.
 This method reads the entire stream to calculate a rolling hash, based on
 PHP's `hash_init` functions.
 
-Throws `GuzzleHttp\Psr7\Exception\TimeoutException` if a stream read times out.
+Throws `GuzzleHttp\Psr7\Exception\TimeoutException` when PHP-style timeout
+metadata can be detected after a stream read cannot make progress.
 
 
 ## `GuzzleHttp\Psr7\Utils::modifyRequest`
@@ -512,7 +515,8 @@ a message.
 
 Read a line from the stream up to the maximum allowed buffer length.
 
-Throws `GuzzleHttp\Psr7\Exception\TimeoutException` if a stream read times out.
+Throws `GuzzleHttp\Psr7\Exception\TimeoutException` when PHP-style timeout
+metadata can be detected after a stream read cannot make progress.
 
 
 ## `GuzzleHttp\Psr7\Utils::redactUserInfo`
@@ -590,7 +594,8 @@ When stream_get_contents fails, PHP normally raises a warning. This
 function adds an error handler that checks for errors and throws an
 exception instead.
 
-Throws `GuzzleHttp\Psr7\Exception\TimeoutException` if the stream read times out.
+Throws `GuzzleHttp\Psr7\Exception\TimeoutException` when PHP-style timeout
+metadata can be detected after the stream read cannot make progress.
 
 
 ## `GuzzleHttp\Psr7\Utils::uriFor`

--- a/README.md
+++ b/README.md
@@ -462,6 +462,9 @@ Remove the items given by the keys, case insensitively from the data.
 Copy the contents of a stream into another stream until the given number
 of bytes have been read.
 
+Throws `GuzzleHttp\Psr7\Exception\TimeoutException` if a source read or
+destination write times out.
+
 
 ## `GuzzleHttp\Psr7\Utils::copyToString`
 
@@ -469,6 +472,8 @@ of bytes have been read.
 
 Copy the contents of a stream into a string until the given number of
 bytes have been read.
+
+Throws `GuzzleHttp\Psr7\Exception\TimeoutException` if a stream read times out.
 
 
 ## `GuzzleHttp\Psr7\Utils::hash`
@@ -479,6 +484,8 @@ Calculate a hash of a stream.
 
 This method reads the entire stream to calculate a rolling hash, based on
 PHP's `hash_init` functions.
+
+Throws `GuzzleHttp\Psr7\Exception\TimeoutException` if a stream read times out.
 
 
 ## `GuzzleHttp\Psr7\Utils::modifyRequest`
@@ -504,6 +511,8 @@ a message.
 `public static function readLine(StreamInterface $stream, ?int $maxLength = null): string`
 
 Read a line from the stream up to the maximum allowed buffer length.
+
+Throws `GuzzleHttp\Psr7\Exception\TimeoutException` if a stream read times out.
 
 
 ## `GuzzleHttp\Psr7\Utils::redactUserInfo`
@@ -580,6 +589,8 @@ Safely gets the contents of a given stream.
 When stream_get_contents fails, PHP normally raises a warning. This
 function adds an error handler that checks for errors and throws an
 exception instead.
+
+Throws `GuzzleHttp\Psr7\Exception\TimeoutException` if the stream read times out.
 
 
 ## `GuzzleHttp\Psr7\Utils::uriFor`

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -501,9 +501,11 @@ Timed-out stream operations now throw
 `GuzzleHttp\Psr7\Exception\TimeoutException`, which extends
 `RuntimeException`. `Stream::read()`, `Utils::copyToStream()`,
 `Utils::copyToString()`, `Utils::hash()`, `Utils::readLine()`, and
-`Utils::tryGetContents()` detect PHP stream timeout metadata when a read or
-write operation cannot make progress. Previously, timed-out reads could be
-treated as EOF or return partial results.
+`Utils::tryGetContents()` detect PHP-style stream timeout metadata when a read
+or write operation cannot make progress. Timeout detection is best-effort;
+custom stream implementations that do not expose `timed_out` metadata continue
+to behave as before. Previously, timed-out reads could be treated as EOF or
+return partial results.
 
 Several stream `__toString()` implementations now allow exceptions thrown during
 stringification to be rethrown. Avoid relying on `(string) $stream` to hide read

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -497,6 +497,14 @@ of depending on package internals.
 its high-water mark. This keeps the method compatible with the `int` return type
 from `StreamInterface::write()`.
 
+Timed-out stream operations now throw
+`GuzzleHttp\Psr7\Exception\TimeoutException`, which extends
+`RuntimeException`. `Stream::read()`, `Utils::copyToStream()`,
+`Utils::copyToString()`, `Utils::hash()`, `Utils::readLine()`, and
+`Utils::tryGetContents()` detect PHP stream timeout metadata when a read or
+write operation cannot make progress. Previously, timed-out reads could be
+treated as EOF or return partial results.
+
 Several stream `__toString()` implementations now allow exceptions thrown during
 stringification to be rethrown. Avoid relying on `(string) $stream` to hide read
 failures; call `getContents()` or `read()` and handle exceptions when failures

--- a/src/AppendStream.php
+++ b/src/AppendStream.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GuzzleHttp\Psr7;
 
+use GuzzleHttp\Psr7\Exception\TimeoutException;
 use Psr\Http\Message\StreamInterface;
 
 /**
@@ -196,6 +197,12 @@ final class AppendStream implements StreamInterface
             $result = $this->streams[$this->current]->read($remaining);
 
             if ($result === '') {
+                if ($this->streams[$this->current]->getMetadata('timed_out') === true
+                    && !$this->streams[$this->current]->eof()
+                ) {
+                    throw new TimeoutException('Unable to read from stream: timed out');
+                }
+
                 $progressToNext = true;
                 continue;
             }

--- a/src/AppendStream.php
+++ b/src/AppendStream.php
@@ -194,12 +194,20 @@ final class AppendStream implements StreamInterface
                 ++$this->current;
             }
 
-            $result = $this->streams[$this->current]->read($remaining);
+            try {
+                $result = $this->streams[$this->current]->read($remaining);
+            } catch (TimeoutException $e) {
+                throw $e;
+            } catch (\RuntimeException $e) {
+                if (StreamTimeout::isReadTimedOut($this->streams[$this->current])) {
+                    throw new TimeoutException('Unable to read from stream: timed out', 0, $e);
+                }
+
+                throw $e;
+            }
 
             if ($result === '') {
-                if ($this->streams[$this->current]->getMetadata('timed_out') === true
-                    && !$this->streams[$this->current]->eof()
-                ) {
+                if (StreamTimeout::isReadTimedOut($this->streams[$this->current])) {
                     throw new TimeoutException('Unable to read from stream: timed out');
                 }
 

--- a/src/CachingStream.php
+++ b/src/CachingStream.php
@@ -106,14 +106,21 @@ final class CachingStream implements StreamInterface
             // been filled from the remote stream, then we must skip bytes on
             // the remote stream to emulate overwriting bytes from that
             // position. This mimics the behavior of other PHP stream wrappers.
-            $remoteData = $this->remoteStream->read(
-                $remaining + $this->skipReadBytes
-            );
+            try {
+                $remoteData = $this->remoteStream->read(
+                    $remaining + $this->skipReadBytes
+                );
+            } catch (TimeoutException $e) {
+                throw $e;
+            } catch (\RuntimeException $e) {
+                if (StreamTimeout::isReadTimedOut($this->remoteStream)) {
+                    throw new TimeoutException('Unable to read from stream: timed out', 0, $e);
+                }
 
-            if ($remoteData === ''
-                && $this->remoteStream->getMetadata('timed_out') === true
-                && !$this->remoteStream->eof()
-            ) {
+                throw $e;
+            }
+
+            if ($remoteData === '' && StreamTimeout::isReadTimedOut($this->remoteStream)) {
                 throw new TimeoutException('Unable to read from stream: timed out');
             }
 

--- a/src/CachingStream.php
+++ b/src/CachingStream.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GuzzleHttp\Psr7;
 
+use GuzzleHttp\Psr7\Exception\TimeoutException;
 use Psr\Http\Message\StreamInterface;
 
 /**
@@ -108,6 +109,13 @@ final class CachingStream implements StreamInterface
             $remoteData = $this->remoteStream->read(
                 $remaining + $this->skipReadBytes
             );
+
+            if ($remoteData === ''
+                && $this->remoteStream->getMetadata('timed_out') === true
+                && !$this->remoteStream->eof()
+            ) {
+                throw new TimeoutException('Unable to read from stream: timed out');
+            }
 
             if ($this->skipReadBytes) {
                 $len = strlen($remoteData);

--- a/src/Exception/TimeoutException.php
+++ b/src/Exception/TimeoutException.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GuzzleHttp\Psr7\Exception;
+
+use RuntimeException;
+
+/**
+ * Exception thrown when a stream operation times out.
+ */
+class TimeoutException extends RuntimeException
+{
+}

--- a/src/PumpStream.php
+++ b/src/PumpStream.php
@@ -132,12 +132,7 @@ final class PumpStream implements StreamInterface
 
     public function getContents(): string
     {
-        $result = '';
-        while (!$this->eof()) {
-            $result .= $this->read(1000000);
-        }
-
-        return $result;
+        return Utils::copyToString($this);
     }
 
     /**

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GuzzleHttp\Psr7;
 
+use GuzzleHttp\Psr7\Exception\TimeoutException;
 use Psr\Http\Message\StreamInterface;
 
 /**
@@ -221,12 +222,26 @@ class Stream implements StreamInterface
 
         try {
             $string = fread($this->stream, $length);
+        } catch (TimeoutException $e) {
+            throw $e;
         } catch (\Exception $e) {
+            if ($this->timedOut()) {
+                throw new TimeoutException('Unable to read from stream: timed out', 0, $e);
+            }
+
             throw new \RuntimeException('Unable to read from stream', 0, $e);
         }
 
         if (false === $string) {
+            if ($this->timedOut()) {
+                throw new TimeoutException('Unable to read from stream: timed out');
+            }
+
             throw new \RuntimeException('Unable to read from stream');
+        }
+
+        if ($string === '' && $this->timedOut()) {
+            throw new TimeoutException('Unable to read from stream: timed out');
         }
 
         return $string;
@@ -268,5 +283,13 @@ class Stream implements StreamInterface
         $meta = stream_get_meta_data($this->stream);
 
         return $meta[$key] ?? null;
+    }
+
+    private function timedOut(): bool
+    {
+        /** @var array<string, mixed> $meta */
+        $meta = stream_get_meta_data($this->stream);
+
+        return ($meta['timed_out'] ?? false) === true && !feof($this->stream);
     }
 }

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -287,9 +287,6 @@ class Stream implements StreamInterface
 
     private function timedOut(): bool
     {
-        /** @var array<string, mixed> $meta */
-        $meta = stream_get_meta_data($this->stream);
-
-        return ($meta['timed_out'] ?? false) === true && !feof($this->stream);
+        return StreamTimeout::isResourceReadTimedOut($this->stream);
     }
 }

--- a/src/StreamTimeout.php
+++ b/src/StreamTimeout.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GuzzleHttp\Psr7;
+
+use Psr\Http\Message\StreamInterface;
+
+/**
+ * @internal
+ */
+final class StreamTimeout
+{
+    private function __construct()
+    {
+    }
+
+    public static function isReadTimedOut(StreamInterface $stream): bool
+    {
+        try {
+            if ($stream->getMetadata('timed_out') !== true) {
+                return false;
+            }
+
+            return !$stream->eof();
+        } catch (\Throwable $e) {
+            return false;
+        }
+    }
+
+    public static function isWriteTimedOut(StreamInterface $stream): bool
+    {
+        try {
+            return $stream->getMetadata('timed_out') === true;
+        } catch (\Throwable $e) {
+            return false;
+        }
+    }
+
+    /**
+     * @param resource $resource
+     */
+    public static function isResourceReadTimedOut($resource): bool
+    {
+        try {
+            /** @var array<string, mixed> $metadata */
+            $metadata = stream_get_meta_data($resource);
+
+            return ($metadata['timed_out'] ?? false) === true && !feof($resource);
+        } catch (\Throwable $e) {
+            return false;
+        }
+    }
+}

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GuzzleHttp\Psr7;
 
+use GuzzleHttp\Psr7\Exception\TimeoutException;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
@@ -49,7 +50,7 @@ final class Utils
 
         if ($maxLen === -1) {
             while (!$source->eof()) {
-                $buf = $source->read($bufferSize);
+                $buf = self::read($source, $bufferSize, 'Unable to read from stream: timed out');
                 if ($buf === '') {
                     break;
                 }
@@ -59,7 +60,7 @@ final class Utils
         } else {
             $remaining = $maxLen;
             while ($remaining > 0 && !$source->eof()) {
-                $buf = $source->read(min($bufferSize, $remaining));
+                $buf = self::read($source, min($bufferSize, $remaining), 'Unable to read from stream: timed out');
                 $len = strlen($buf);
                 if (!$len) {
                     break;
@@ -76,8 +77,19 @@ final class Utils
         $len = strlen($buf);
 
         while ($written < $len) {
-            $result = $dest->write(substr($buf, $written));
+            try {
+                $result = $dest->write(substr($buf, $written));
+            } catch (TimeoutException $e) {
+                throw $e;
+            } catch (\RuntimeException $e) {
+                self::throwIfWriteTimedOut($dest, $e);
+
+                throw $e;
+            }
+
             if ($result <= 0) {
+                self::throwIfWriteTimedOut($dest);
+
                 throw new \RuntimeException('Unable to write to stream');
             }
 
@@ -101,7 +113,7 @@ final class Utils
 
         if ($maxLen === -1) {
             while (!$stream->eof()) {
-                $buf = $stream->read(1048576);
+                $buf = self::read($stream, 1048576, 'Unable to read from stream: timed out');
                 if ($buf === '') {
                     break;
                 }
@@ -113,7 +125,7 @@ final class Utils
 
         $len = 0;
         while (!$stream->eof() && $len < $maxLen) {
-            $buf = $stream->read($maxLen - $len);
+            $buf = self::read($stream, $maxLen - $len, 'Unable to read from stream: timed out');
             if ($buf === '') {
                 break;
             }
@@ -146,7 +158,12 @@ final class Utils
 
         $ctx = hash_init($algo);
         while (!$stream->eof()) {
-            hash_update($ctx, $stream->read(1048576));
+            $buf = self::read($stream, 1048576, 'Unable to calculate stream hash: timed out');
+            if ($buf === '') {
+                break;
+            }
+
+            hash_update($ctx, $buf);
         }
 
         $out = hash_final($ctx, $rawOutput);
@@ -292,7 +309,7 @@ final class Utils
         $size = 0;
 
         while (!$stream->eof()) {
-            if ('' === ($byte = $stream->read(1))) {
+            if ('' === ($byte = self::read($stream, 1, 'Unable to read line from stream: timed out'))) {
                 return $buffer;
             }
             $buffer .= $byte;
@@ -495,13 +512,21 @@ final class Utils
             $contents = stream_get_contents($stream);
 
             if ($contents === false) {
-                $ex = new \RuntimeException('Unable to read stream contents');
+                $ex = self::resourceTimedOut($stream)
+                    ? new TimeoutException('Unable to read stream contents: timed out')
+                    : new \RuntimeException('Unable to read stream contents');
+            } elseif (self::resourceTimedOut($stream)) {
+                $ex = new TimeoutException('Unable to read stream contents: timed out');
             }
+        } catch (TimeoutException $e) {
+            $ex = $e;
         } catch (\Throwable $e) {
-            $ex = new \RuntimeException(sprintf(
-                'Unable to read stream contents: %s',
-                $e->getMessage()
-            ), 0, $e);
+            $ex = self::resourceTimedOut($stream)
+                ? new TimeoutException('Unable to read stream contents: timed out', 0, $e)
+                : new \RuntimeException(sprintf(
+                    'Unable to read stream contents: %s',
+                    $e->getMessage()
+                ), 0, $e);
         }
 
         restore_error_handler();
@@ -512,6 +537,67 @@ final class Utils
         }
 
         return $contents;
+    }
+
+    private static function read(StreamInterface $stream, int $length, string $timeoutMessage): string
+    {
+        try {
+            $buffer = $stream->read($length);
+        } catch (TimeoutException $e) {
+            throw $e;
+        } catch (\RuntimeException $e) {
+            self::throwIfReadTimedOut($stream, $timeoutMessage, $e);
+
+            throw $e;
+        }
+
+        if ($buffer === '') {
+            self::throwIfReadTimedOut($stream, $timeoutMessage);
+        }
+
+        return $buffer;
+    }
+
+    private static function throwIfReadTimedOut(
+        StreamInterface $stream,
+        string $message,
+        ?\Throwable $previous = null
+    ): void {
+        if ($stream->getMetadata('timed_out') !== true) {
+            return;
+        }
+
+        try {
+            if ($stream->eof()) {
+                return;
+            }
+        } catch (\RuntimeException $e) {
+            // Fall through to the timeout exception if EOF cannot be checked.
+        }
+
+        throw new TimeoutException($message, 0, $previous);
+    }
+
+    private static function throwIfWriteTimedOut(StreamInterface $stream, ?\Throwable $previous = null): void
+    {
+        if ($stream->getMetadata('timed_out') === true) {
+            throw new TimeoutException('Unable to write to stream: timed out', 0, $previous);
+        }
+    }
+
+    /**
+     * @param resource $stream
+     */
+    private static function resourceTimedOut($stream): bool
+    {
+        try {
+            /** @var array<string, mixed> $metadata */
+            $metadata = stream_get_meta_data($stream);
+
+            return ($metadata['timed_out'] ?? false) === true && !feof($stream);
+        } catch (\Throwable $e) {
+            return false;
+        }
     }
 
     /**

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -512,16 +512,16 @@ final class Utils
             $contents = stream_get_contents($stream);
 
             if ($contents === false) {
-                $ex = self::resourceTimedOut($stream)
+                $ex = StreamTimeout::isResourceReadTimedOut($stream)
                     ? new TimeoutException('Unable to read stream contents: timed out')
                     : new \RuntimeException('Unable to read stream contents');
-            } elseif (self::resourceTimedOut($stream)) {
+            } elseif (StreamTimeout::isResourceReadTimedOut($stream)) {
                 $ex = new TimeoutException('Unable to read stream contents: timed out');
             }
         } catch (TimeoutException $e) {
             $ex = $e;
         } catch (\Throwable $e) {
-            $ex = self::resourceTimedOut($stream)
+            $ex = StreamTimeout::isResourceReadTimedOut($stream)
                 ? new TimeoutException('Unable to read stream contents: timed out', 0, $e)
                 : new \RuntimeException(sprintf(
                     'Unable to read stream contents: %s',
@@ -563,40 +563,15 @@ final class Utils
         string $message,
         ?\Throwable $previous = null
     ): void {
-        if ($stream->getMetadata('timed_out') !== true) {
-            return;
+        if (StreamTimeout::isReadTimedOut($stream)) {
+            throw new TimeoutException($message, 0, $previous);
         }
-
-        try {
-            if ($stream->eof()) {
-                return;
-            }
-        } catch (\RuntimeException $e) {
-            // Fall through to the timeout exception if EOF cannot be checked.
-        }
-
-        throw new TimeoutException($message, 0, $previous);
     }
 
     private static function throwIfWriteTimedOut(StreamInterface $stream, ?\Throwable $previous = null): void
     {
-        if ($stream->getMetadata('timed_out') === true) {
+        if (StreamTimeout::isWriteTimedOut($stream)) {
             throw new TimeoutException('Unable to write to stream: timed out', 0, $previous);
-        }
-    }
-
-    /**
-     * @param resource $stream
-     */
-    private static function resourceTimedOut($stream): bool
-    {
-        try {
-            /** @var array<string, mixed> $metadata */
-            $metadata = stream_get_meta_data($stream);
-
-            return ($metadata['timed_out'] ?? false) === true && !feof($stream);
-        } catch (\Throwable $e) {
-            return false;
         }
     }
 

--- a/tests/AppendStreamTest.php
+++ b/tests/AppendStreamTest.php
@@ -184,6 +184,88 @@ class AppendStreamTest extends TestCase
         $a->read(1);
     }
 
+    public function testReadAdvancesPastCurrentStreamWhenMetadataProbeFails(): void
+    {
+        $stream = new Psr7\FnStream([
+            'isReadable' => function (): bool {
+                return true;
+            },
+            'isSeekable' => function (): bool {
+                return false;
+            },
+            'eof' => function (): bool {
+                return false;
+            },
+            'read' => function (): string {
+                return '';
+            },
+            'getMetadata' => function (): void {
+                throw new \RuntimeException('metadata failed');
+            },
+        ]);
+        $a = new AppendStream([$stream, Psr7\Utils::streamFor('foo')]);
+
+        self::assertSame('foo', $a->read(3));
+    }
+
+    public function testReadPreservesCurrentStreamExceptionWhenMetadataProbeFails(): void
+    {
+        $stream = new Psr7\FnStream([
+            'isReadable' => function (): bool {
+                return true;
+            },
+            'isSeekable' => function (): bool {
+                return false;
+            },
+            'eof' => function (): bool {
+                return false;
+            },
+            'read' => function (): string {
+                throw new \RuntimeException('read failed');
+            },
+            'getMetadata' => function (): void {
+                throw new \RuntimeException('metadata failed');
+            },
+        ]);
+        $a = new AppendStream([$stream]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('read failed');
+
+        $a->read(1);
+    }
+
+    public function testReadThrowsTimeoutWhenCurrentStreamExceptionTimesOut(): void
+    {
+        $stream = new Psr7\FnStream([
+            'isReadable' => function (): bool {
+                return true;
+            },
+            'isSeekable' => function (): bool {
+                return false;
+            },
+            'eof' => function (): bool {
+                return false;
+            },
+            'read' => function (): string {
+                throw new \RuntimeException('read failed');
+            },
+            'getMetadata' => function (?string $key = null) {
+                return $key === 'timed_out' ? true : null;
+            },
+        ]);
+        $a = new AppendStream([$stream]);
+
+        try {
+            $a->read(1);
+            self::fail('Expected timeout exception');
+        } catch (Psr7\Exception\TimeoutException $e) {
+            self::assertSame('Unable to read from stream: timed out', $e->getMessage());
+            self::assertInstanceOf(\RuntimeException::class, $e->getPrevious());
+            self::assertSame('read failed', $e->getPrevious()->getMessage());
+        }
+    }
+
     public function testCanDetermineSizeFromMultipleStreams(): void
     {
         $a = new AppendStream([

--- a/tests/AppendStreamTest.php
+++ b/tests/AppendStreamTest.php
@@ -157,6 +157,33 @@ class AppendStreamTest extends TestCase
         self::assertSame('foobarbaz', (string) $a);
     }
 
+    public function testReadThrowsWhenCurrentStreamTimesOut(): void
+    {
+        $stream = new Psr7\FnStream([
+            'isReadable' => function (): bool {
+                return true;
+            },
+            'isSeekable' => function (): bool {
+                return false;
+            },
+            'eof' => function (): bool {
+                return false;
+            },
+            'read' => function (): string {
+                return '';
+            },
+            'getMetadata' => function (?string $key = null) {
+                return $key === 'timed_out' ? true : null;
+            },
+        ]);
+        $a = new AppendStream([$stream]);
+
+        $this->expectException(Psr7\Exception\TimeoutException::class);
+        $this->expectExceptionMessage('Unable to read from stream: timed out');
+
+        $a->read(1);
+    }
+
     public function testCanDetermineSizeFromMultipleStreams(): void
     {
         $a = new AppendStream([

--- a/tests/CachingStreamTest.php
+++ b/tests/CachingStreamTest.php
@@ -135,6 +135,27 @@ class CachingStreamTest extends TestCase
         self::assertSame('test', $this->body->read(4));
     }
 
+    public function testReadThrowsWhenRemoteStreamTimesOut(): void
+    {
+        $remote = new Psr7\FnStream([
+            'read' => function (): string {
+                return '';
+            },
+            'getMetadata' => function (?string $key = null) {
+                return $key === 'timed_out' ? true : null;
+            },
+            'eof' => function (): bool {
+                return false;
+            },
+        ]);
+        $stream = new CachingStream($remote);
+
+        $this->expectException(Psr7\Exception\TimeoutException::class);
+        $this->expectExceptionMessage('Unable to read from stream: timed out');
+
+        $stream->read(1);
+    }
+
     public function testWritesToBufferStream(): void
     {
         $this->body->read(2);

--- a/tests/CachingStreamTest.php
+++ b/tests/CachingStreamTest.php
@@ -156,6 +156,70 @@ class CachingStreamTest extends TestCase
         $stream->read(1);
     }
 
+    public function testReadIgnoresRemoteMetadataProbeFailure(): void
+    {
+        $remote = new Psr7\FnStream([
+            'read' => function (): string {
+                return '';
+            },
+            'getMetadata' => function (): void {
+                throw new \RuntimeException('metadata failed');
+            },
+            'eof' => function (): bool {
+                return false;
+            },
+        ]);
+        $stream = new CachingStream($remote);
+
+        self::assertSame('', $stream->read(1));
+    }
+
+    public function testReadPreservesRemoteExceptionWhenMetadataProbeFails(): void
+    {
+        $remote = new Psr7\FnStream([
+            'read' => function (): string {
+                throw new \RuntimeException('read failed');
+            },
+            'getMetadata' => function (): void {
+                throw new \RuntimeException('metadata failed');
+            },
+            'eof' => function (): bool {
+                return false;
+            },
+        ]);
+        $stream = new CachingStream($remote);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('read failed');
+
+        $stream->read(1);
+    }
+
+    public function testReadThrowsTimeoutWhenRemoteExceptionTimesOut(): void
+    {
+        $remote = new Psr7\FnStream([
+            'read' => function (): string {
+                throw new \RuntimeException('read failed');
+            },
+            'getMetadata' => function (?string $key = null) {
+                return $key === 'timed_out' ? true : null;
+            },
+            'eof' => function (): bool {
+                return false;
+            },
+        ]);
+        $stream = new CachingStream($remote);
+
+        try {
+            $stream->read(1);
+            self::fail('Expected timeout exception');
+        } catch (Psr7\Exception\TimeoutException $e) {
+            self::assertSame('Unable to read from stream: timed out', $e->getMessage());
+            self::assertInstanceOf(\RuntimeException::class, $e->getPrevious());
+            self::assertSame('read failed', $e->getPrevious()->getMessage());
+        }
+    }
+
     public function testWritesToBufferStream(): void
     {
         $this->body->read(2);

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -35,6 +35,46 @@ class UtilsTest extends TestCase
         self::assertSame('', $result);
     }
 
+    public function testCopyToStringThrowsWhenReadTimesOut(): void
+    {
+        $s = new FnStream([
+            'eof' => function (): bool {
+                return false;
+            },
+            'read' => function (): string {
+                return '';
+            },
+            'getMetadata' => function (?string $key = null) {
+                return $key === 'timed_out' ? true : null;
+            },
+        ]);
+
+        $this->expectException(Psr7\Exception\TimeoutException::class);
+        $this->expectExceptionMessage('Unable to read from stream: timed out');
+
+        Psr7\Utils::copyToString($s);
+    }
+
+    public function testCopyToStringIgnoresStaleTimeoutMetadataAfterSuccessfulRead(): void
+    {
+        $read = false;
+        $s = new FnStream([
+            'eof' => function () use (&$read): bool {
+                return $read;
+            },
+            'read' => function () use (&$read): string {
+                $read = true;
+
+                return 'foo';
+            },
+            'getMetadata' => function (?string $key = null) {
+                return $key === 'timed_out' ? true : null;
+            },
+        ]);
+
+        self::assertSame('foo', Psr7\Utils::copyToString($s));
+    }
+
     public function testCopiesToStream(): void
     {
         $s1 = Psr7\Utils::streamFor('foobaz');
@@ -87,6 +127,82 @@ class UtilsTest extends TestCase
 
         self::assertSame('foo', (string) $sink);
         self::assertSame(3, $writes);
+    }
+
+    public function testCopyToStreamThrowsWhenReadTimesOut(): void
+    {
+        $s1 = new FnStream([
+            'eof' => function (): bool {
+                return false;
+            },
+            'read' => function (): string {
+                return '';
+            },
+            'getMetadata' => function (?string $key = null) {
+                return $key === 'timed_out' ? true : null;
+            },
+        ]);
+        $s2 = Psr7\Utils::streamFor('');
+
+        $this->expectException(Psr7\Exception\TimeoutException::class);
+        $this->expectExceptionMessage('Unable to read from stream: timed out');
+
+        Psr7\Utils::copyToStream($s1, $s2);
+    }
+
+    public function testCopyToStreamThrowsWhenReadTimesOutWithMaxLen(): void
+    {
+        $s1 = new FnStream([
+            'eof' => function (): bool {
+                return false;
+            },
+            'read' => function (): string {
+                return '';
+            },
+            'getMetadata' => function (?string $key = null) {
+                return $key === 'timed_out' ? true : null;
+            },
+        ]);
+        $s2 = Psr7\Utils::streamFor('');
+
+        $this->expectException(Psr7\Exception\TimeoutException::class);
+        $this->expectExceptionMessage('Unable to read from stream: timed out');
+
+        Psr7\Utils::copyToStream($s1, $s2, 10);
+    }
+
+    public function testCopyToStreamThrowsWhenWriteTimesOut(): void
+    {
+        $s1 = Psr7\Utils::streamFor('foobaz');
+        $s2 = Psr7\Utils::streamFor('');
+        $s2 = FnStream::decorate($s2, [
+            'write' => function (): int {
+                return 0;
+            },
+            'getMetadata' => function (?string $key = null) {
+                return $key === 'timed_out' ? true : null;
+            },
+        ]);
+
+        $this->expectException(Psr7\Exception\TimeoutException::class);
+        $this->expectExceptionMessage('Unable to write to stream: timed out');
+
+        Psr7\Utils::copyToStream($s1, $s2);
+    }
+
+    public function testCopyToStreamIgnoresStaleTimeoutMetadataAfterMaxLenIsSatisfied(): void
+    {
+        $s1 = Psr7\Utils::streamFor('foobaz');
+        $s1 = FnStream::decorate($s1, [
+            'getMetadata' => function (?string $key = null) {
+                return $key === 'timed_out' ? true : null;
+            },
+        ]);
+        $s2 = Psr7\Utils::streamFor('');
+
+        Psr7\Utils::copyToStream($s1, $s2, 3);
+
+        self::assertSame('foo', (string) $s2);
     }
 
     public function testCopyToStreamThrowsWhenWriteFails(): void
@@ -201,6 +317,19 @@ class UtilsTest extends TestCase
         self::assertSame('h', Psr7\Utils::readLine($s));
     }
 
+    public function testReadLineThrowsWhenReadTimesOut(): void
+    {
+        $s = $this->createMock(StreamInterface::class);
+        $s->method('read')->willReturn('');
+        $s->method('eof')->willReturn(false);
+        $s->method('getMetadata')->with('timed_out')->willReturn(true);
+
+        $this->expectException(Psr7\Exception\TimeoutException::class);
+        $this->expectExceptionMessage('Unable to read line from stream: timed out');
+
+        Psr7\Utils::readLine($s);
+    }
+
     public function testRedactUserInfo(): void
     {
         $uri = new Psr7\Uri('http://my_user:secretPass@localhost/');
@@ -232,6 +361,32 @@ class UtilsTest extends TestCase
         $s->seek(4);
         self::assertSame(md5('foobazbar'), Psr7\Utils::hash($s, 'md5'));
         self::assertSame(4, $s->tell());
+    }
+
+    public function testCalculatesHashThrowsWhenReadTimesOut(): void
+    {
+        $s = $this->createMock(StreamInterface::class);
+        $s->method('tell')->willReturn(0);
+        $s->method('eof')->willReturn(false);
+        $s->method('read')->willReturn('');
+        $s->method('getMetadata')->with('timed_out')->willReturn(true);
+
+        $this->expectException(Psr7\Exception\TimeoutException::class);
+        $this->expectExceptionMessage('Unable to calculate stream hash: timed out');
+
+        Psr7\Utils::hash($s, 'md5');
+    }
+
+    public function testCalculatesHashStopsWhenReadReturnsEmptyString(): void
+    {
+        $s = $this->createMock(StreamInterface::class);
+        $s->method('tell')->willReturn(0);
+        $s->method('eof')->willReturn(false);
+        $s->method('read')->willReturn('');
+        $s->method('getMetadata')->with('timed_out')->willReturn(false);
+        $s->expects(self::once())->method('seek')->with(0);
+
+        self::assertSame(md5(''), Psr7\Utils::hash($s, 'md5'));
     }
 
     public function testOpensFilesSuccessfully(): void

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -75,6 +75,83 @@ class UtilsTest extends TestCase
         self::assertSame('foo', Psr7\Utils::copyToString($s));
     }
 
+    public function testCopyToStringIgnoresMetadataProbeFailure(): void
+    {
+        $s = new FnStream([
+            'eof' => function (): bool {
+                return false;
+            },
+            'read' => function (): string {
+                return '';
+            },
+            'getMetadata' => function (): void {
+                throw new \RuntimeException('metadata failed');
+            },
+        ]);
+
+        self::assertSame('', Psr7\Utils::copyToString($s));
+    }
+
+    public function testCopyToStringPreservesReadExceptionWhenMetadataProbeFails(): void
+    {
+        $s = new FnStream([
+            'eof' => function (): bool {
+                return false;
+            },
+            'read' => function (): string {
+                throw new \RuntimeException('read failed');
+            },
+            'getMetadata' => function (): void {
+                throw new \RuntimeException('metadata failed');
+            },
+        ]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('read failed');
+
+        Psr7\Utils::copyToString($s);
+    }
+
+    public function testCopyToStringIgnoresEofProbeFailureDuringTimeoutDetection(): void
+    {
+        $eofCalls = 0;
+        $s = new FnStream([
+            'eof' => function () use (&$eofCalls): bool {
+                ++$eofCalls;
+                if ($eofCalls > 1) {
+                    throw new \RuntimeException('eof failed');
+                }
+
+                return false;
+            },
+            'read' => function (): string {
+                return '';
+            },
+            'getMetadata' => function (?string $key = null) {
+                return $key === 'timed_out' ? true : null;
+            },
+        ]);
+
+        self::assertSame('', Psr7\Utils::copyToString($s));
+    }
+
+    public function testCopyToStringIgnoresNonBooleanTimedOutMetadata(): void
+    {
+        $s = new FnStream([
+            'eof' => function (): bool {
+                return false;
+            },
+            'read' => function (): string {
+                return '';
+            },
+            'getMetadata' => function (?string $key = null) {
+                return $key === 'timed_out' ? 1 : null;
+            },
+        ]);
+
+        self::assertSame('', Psr7\Utils::copyToString($s));
+    }
+
     public function testCopiesToStream(): void
     {
         $s1 = Psr7\Utils::streamFor('foobaz');
@@ -186,6 +263,44 @@ class UtilsTest extends TestCase
 
         $this->expectException(Psr7\Exception\TimeoutException::class);
         $this->expectExceptionMessage('Unable to write to stream: timed out');
+
+        Psr7\Utils::copyToStream($s1, $s2);
+    }
+
+    public function testCopyToStreamPreservesWriteFailureWhenMetadataProbeFails(): void
+    {
+        $s1 = Psr7\Utils::streamFor('foobaz');
+        $s2 = Psr7\Utils::streamFor('');
+        $s2 = FnStream::decorate($s2, [
+            'write' => function (): int {
+                return 0;
+            },
+            'getMetadata' => function (): void {
+                throw new \RuntimeException('metadata failed');
+            },
+        ]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Unable to write to stream');
+
+        Psr7\Utils::copyToStream($s1, $s2);
+    }
+
+    public function testCopyToStreamPreservesThrownWriteExceptionWhenMetadataProbeFails(): void
+    {
+        $s1 = Psr7\Utils::streamFor('foobaz');
+        $s2 = Psr7\Utils::streamFor('');
+        $s2 = FnStream::decorate($s2, [
+            'write' => function (): int {
+                throw new \RuntimeException('write failed');
+            },
+            'getMetadata' => function (): void {
+                throw new \RuntimeException('metadata failed');
+            },
+        ]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('write failed');
 
         Psr7\Utils::copyToStream($s1, $s2);
     }
@@ -328,6 +443,16 @@ class UtilsTest extends TestCase
         $this->expectExceptionMessage('Unable to read line from stream: timed out');
 
         Psr7\Utils::readLine($s);
+    }
+
+    public function testReadLineIgnoresMetadataProbeFailure(): void
+    {
+        $s = $this->createMock(StreamInterface::class);
+        $s->method('read')->willReturn('');
+        $s->method('eof')->willReturn(false);
+        $s->method('getMetadata')->with('timed_out')->willThrowException(new \RuntimeException('metadata failed'));
+
+        self::assertSame('', Psr7\Utils::readLine($s));
     }
 
     public function testRedactUserInfo(): void


### PR DESCRIPTION
Adds a PSR-7 TimeoutException and uses it when stream read, copy, hash, line, and contents operations can reliably identify a stream timeout.