### PR TITLE
Normalize server-global request methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Require `psr/http-message:^2.0` and add its native parameter types
 - Require `psr/http-factory:^1.1`
-- Preserve HTTP request method casing instead of uppercasing methods automatically
+- Preserve HTTP request method casing for explicitly constructed requests while continuing to uppercase `ServerRequest::fromGlobals()` methods for server-global compatibility
 - Reject empty arrays and non-string values as header values
 - Reject invalid uploaded file trees and invalid parsed body values
 - Reject malformed uploaded file specifications missing `tmp_name`, `size`, or `error`
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Harden URI host and scheme validation, including rejecting schemes that do not begin with a letter
 - Tighten `ServerRequest::getUriFromGlobals()` validation for malformed `HTTP_HOST` and `SERVER_PORT` values
 - Stop preserving malformed `Host` headers when building server requests from globals
-- Normalize server request URI reconstruction from globals
+- Normalize server request URI reconstruction from globals, including `REQUEST_METHOD` values used for request-target parsing
 - Accept `OPTIONS *` and `CONNECT` authority-form request targets in `Message::parseRequest()`
 - Reject malformed HTTP start-line fields
 - Reject hosts with embedded ports in `Uri::withHost()`

--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ composer require guzzlehttp/psr7
 
 See [UPGRADING.md](UPGRADING.md) for package upgrade notes.
 
+## HTTP Method Casing
+
+HTTP method names are case-sensitive in PSR-7. Requests created explicitly with
+`Request`, `ServerRequest`, `withMethod()`, `Message::parseRequest()`, or the
+PSR-17 factories preserve the method string as provided. `ServerRequest::fromGlobals()`
+normalizes `$_SERVER['REQUEST_METHOD']` to uppercase for compatibility when
+hydrating requests from PHP server globals.
+
 
 ## AppendStream
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -56,9 +56,17 @@ $response = $response->withStatus(201);
 $uri = $uri->withPort(8080);
 ```
 
-Request methods are no longer uppercased by `Request` or `withMethod()`. If your
-application requires uppercase methods, normalize methods before constructing or
-modifying requests.
+Request methods passed explicitly to `Request`, `ServerRequest`, `withMethod()`,
+`Message::parseRequest()`, and the PSR-17 factories are no longer uppercased.
+PSR-7 treats method names as case-sensitive, so these APIs now preserve the
+method exactly as provided. If your application requires uppercase methods,
+normalize methods before constructing or modifying requests.
+
+`ServerRequest::fromGlobals()` is the compatibility-oriented exception. It
+continues to uppercase string `REQUEST_METHOD` values read from PHP server
+globals, matching Guzzle PSR-7 2.x and common server request behavior. This
+normalization only applies when hydrating from globals; it does not apply to
+methods passed explicitly to constructors, factories, or `withMethod()`.
 
 ```php
 // 2.x
@@ -68,6 +76,11 @@ $request->getMethod(); // GET
 // 3.0
 $request = new Request('get', '/');
 $request->getMethod(); // get
+
+// 3.0, server globals
+$_SERVER['REQUEST_METHOD'] = 'post';
+$request = ServerRequest::fromGlobals();
+$request->getMethod(); // POST
 ```
 
 Header values must now be strings or non-empty arrays of strings. Scalars, `null`,

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -204,7 +204,7 @@ class ServerRequest extends Request implements ServerRequestInterface
      */
     public static function fromGlobals(): ServerRequestInterface
     {
-        $method = self::getServerParam('REQUEST_METHOD') ?? 'GET';
+        $method = self::getRequestMethodFromGlobals();
         $headers = self::removeInvalidHostHeader(self::getAllHeaders());
         [$uri, $requestTarget] = self::getUriAndRequestTargetFromGlobals($method);
         $body = new CachingStream(new LazyOpenStream('php://input', 'r+'));
@@ -347,6 +347,11 @@ class ServerRequest extends Request implements ServerRequestInterface
     private static function getServerParam(string $key): ?string
     {
         return isset($_SERVER[$key]) && is_string($_SERVER[$key]) ? $_SERVER[$key] : null;
+    }
+
+    private static function getRequestMethodFromGlobals(): string
+    {
+        return strtoupper(self::getServerParam('REQUEST_METHOD') ?? 'GET');
     }
 
     /**
@@ -568,7 +573,7 @@ class ServerRequest extends Request implements ServerRequestInterface
 
     private static function isAsteriskFormRequestTarget(string $method, string $target): bool
     {
-        return strcasecmp($method, 'OPTIONS') === 0 && $target === '*';
+        return $method === 'OPTIONS' && $target === '*';
     }
 
     /**
@@ -576,7 +581,7 @@ class ServerRequest extends Request implements ServerRequestInterface
      */
     private static function parseConnectAuthorityFormRequestTarget(string $method, string $target): ?array
     {
-        if (strcasecmp($method, 'CONNECT') !== 0 || strpbrk($target, '/?#') !== false) {
+        if ($method !== 'CONNECT' || strpbrk($target, '/?#') !== false) {
             return null;
         }
 
@@ -617,7 +622,7 @@ class ServerRequest extends Request implements ServerRequestInterface
      */
     public static function getUriFromGlobals(): UriInterface
     {
-        $method = self::getServerParam('REQUEST_METHOD') ?? 'GET';
+        $method = self::getRequestMethodFromGlobals();
 
         return self::getUriAndRequestTargetFromGlobals($method)[0];
     }

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -253,8 +253,10 @@ class MessageTest extends TestCase
         yield 'target delete' => ["GET /foo\x7Fbar HTTP/1.1"];
         yield 'asterisk non-options' => ['GET * HTTP/1.1'];
         yield 'lowercase options asterisk' => ['options * HTTP/1.1'];
+        yield 'mixed-case options asterisk' => ['OpTiOnS * HTTP/1.1'];
         yield 'authority-form non-connect' => ['GET up.example:443 HTTP/1.1'];
         yield 'lowercase connect authority-form' => ['connect up.example:443 HTTP/1.1'];
+        yield 'mixed-case connect authority-form' => ['CoNnEcT up.example:443 HTTP/1.1'];
         yield 'connect missing port' => ['CONNECT up.example HTTP/1.1'];
         yield 'connect zero port' => ['CONNECT up.example:0 HTTP/1.1'];
         yield 'connect user info' => ['CONNECT user@up.example:443 HTTP/1.1'];

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -594,8 +594,44 @@ class ServerRequestTest extends TestCase
             '',
         ];
 
+        yield 'asterisk-form lowercase method is normalized from globals' => [
+            ['REQUEST_METHOD' => 'options', 'REQUEST_URI' => '*', 'HTTP_HOST' => 'good.example'],
+            'http://good.example',
+            'good.example',
+            null,
+            '',
+            '',
+        ];
+
+        yield 'asterisk-form mixed-case method is normalized from globals' => [
+            ['REQUEST_METHOD' => 'OpTiOnS', 'REQUEST_URI' => '*', 'HTTP_HOST' => 'good.example'],
+            'http://good.example',
+            'good.example',
+            null,
+            '',
+            '',
+        ];
+
         yield 'connect authority-form supplies authority' => [
             ['REQUEST_METHOD' => 'CONNECT', 'REQUEST_URI' => 'up.example:443', 'HTTP_HOST' => 'good.example'],
+            'http://up.example:443',
+            'up.example',
+            443,
+            '',
+            '',
+        ];
+
+        yield 'connect authority-form lowercase method is normalized from globals' => [
+            ['REQUEST_METHOD' => 'connect', 'REQUEST_URI' => 'up.example:443', 'HTTP_HOST' => 'good.example'],
+            'http://up.example:443',
+            'up.example',
+            443,
+            '',
+            '',
+        ];
+
+        yield 'connect authority-form mixed-case method is normalized from globals' => [
+            ['REQUEST_METHOD' => 'CoNnEcT', 'REQUEST_URI' => 'up.example:443', 'HTTP_HOST' => 'good.example'],
             'http://up.example:443',
             'up.example',
             443,
@@ -682,8 +718,32 @@ class ServerRequestTest extends TestCase
             'http://good.example',
         ];
 
+        yield 'asterisk-form target with lowercase method is normalized from globals' => [
+            ['REQUEST_METHOD' => 'options', 'REQUEST_URI' => '*', 'HTTP_HOST' => 'good.example'],
+            '*',
+            'http://good.example',
+        ];
+
+        yield 'asterisk-form target with mixed-case method is normalized from globals' => [
+            ['REQUEST_METHOD' => 'OpTiOnS', 'REQUEST_URI' => '*', 'HTTP_HOST' => 'good.example'],
+            '*',
+            'http://good.example',
+        ];
+
         yield 'connect authority-form target is preserved' => [
             ['REQUEST_METHOD' => 'CONNECT', 'REQUEST_URI' => 'up.example:443', 'HTTP_HOST' => 'good.example'],
+            'up.example:443',
+            'http://up.example:443',
+        ];
+
+        yield 'connect authority-form target with lowercase method is normalized from globals' => [
+            ['REQUEST_METHOD' => 'connect', 'REQUEST_URI' => 'up.example:443', 'HTTP_HOST' => 'good.example'],
+            'up.example:443',
+            'http://up.example:443',
+        ];
+
+        yield 'connect authority-form target with mixed-case method is normalized from globals' => [
+            ['REQUEST_METHOD' => 'CoNnEcT', 'REQUEST_URI' => 'up.example:443', 'HTTP_HOST' => 'good.example'],
             'up.example:443',
             'http://up.example:443',
         ];
@@ -870,6 +930,30 @@ class ServerRequestTest extends TestCase
         ];
 
         self::assertEquals($expectedFiles, $server->getUploadedFiles());
+    }
+
+    /**
+     * @dataProvider requestMethodFromGlobalsProvider
+     */
+    public function testFromGlobalsNormalizesRequestMethod(string $requestMethod, string $expectedMethod): void
+    {
+        $_SERVER = [
+            'REQUEST_METHOD' => $requestMethod,
+            'REQUEST_URI' => '/',
+            'HTTP_HOST' => 'www.example.org',
+        ];
+        $_COOKIE = $_POST = $_GET = $_FILES = [];
+
+        $server = ServerRequest::fromGlobals();
+
+        self::assertSame($expectedMethod, $server->getMethod());
+    }
+
+    public static function requestMethodFromGlobalsProvider(): iterable
+    {
+        yield 'lowercase' => ['post', 'POST'];
+        yield 'mixed case' => ['OpTiOnS', 'OPTIONS'];
+        yield 'custom method' => ['custom.method', 'CUSTOM.METHOD'];
     }
 
     public static function dataInvalidHostHeaderFromGlobals(): iterable


### PR DESCRIPTION
This change keeps the new PSR-7 3.0 method-casing behavior for explicitly constructed requests while preserving the long-standing compatibility behavior of server-global hydration. Methods passed to request constructors, `withMethod()`, `Message::parseRequest()`, and PSR-17 factories continue to be preserved exactly as provided, but `ServerRequest::fromGlobals()` now normalizes string `REQUEST_METHOD` values to uppercase before constructing the server request.

That keeps applications compatible with Guzzle PSR-7 2.x and with common server request handling such as Symfony HttpFoundation, where inbound server methods are normalized when hydrating a request from PHP globals. URI and request-target reconstruction from globals uses the same normalized method, so malformed lowercase or mixed-case inbound `OPTIONS *` and `CONNECT` authority-form requests are still hydrated in the compatibility-oriented server-global path.

The documentation now calls out this boundary explicitly: explicit PSR-7 messages preserve method casing, while `ServerRequest::fromGlobals()` is the server-global compatibility exception.