### PR TITLE
Document cross-origin comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Changed `Utils::copyToStream()` to retry short destination writes and throw when destination streams cannot make progress
 - Changed `Header::parse()` to split semicolon-separated parameters without repeated regular expression lookaheads
+- Clarified cross-origin URI comparison behavior in the documentation
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Changed `Utils::copyToStream()` to retry short destination writes and throw when destination streams cannot make progress
 - Changed `Header::parse()` to split semicolon-separated parameters without repeated regular expression lookaheads
-- Clarified cross-origin URI comparison behavior in the documentation
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -717,6 +717,10 @@ provided key are removed.
 
 Determines if a modified URL should be considered cross-origin with respect to an original URL.
 
+Two URLs are cross-origin when their scheme, host, or effective port differ. Host comparison is case-insensitive, and missing ports use the default port for `http` or `https`.
+
+This helper only compares URI origins. It does not implement redirect handling or credential policy.
+
 ## Reference Resolution
 
 `GuzzleHttp\Psr7\UriResolver` provides methods to resolve a URI reference in the context of a base URI according


### PR DESCRIPTION
Clarifies what UriComparator treats as cross-origin and notes that it does not implement redirect or credential policy. This is docs-only.