### PR TITLE
Deprecate automatic request method uppercasing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deprecated empty header value arrays that guzzlehttp/psr7 3.0 will reject
 - Deprecated URI schemes that do not match guzzlehttp/psr7 3.0 syntax requirements
 - Deprecated multipart boundary and custom part header metadata that guzzlehttp/psr7 3.0 will reject
+- Deprecated relying on automatic uppercasing of explicitly provided HTTP request methods; guzzlehttp/psr7 3.0 preserves request method casing
 
 ## 2.10.1 - 2026-05-20
 

--- a/src/Request.php
+++ b/src/Request.php
@@ -44,6 +44,7 @@ class Request implements RequestInterface
             $uri = new Uri($uri);
         }
 
+        self::warnOnMethodCasingChange($method);
         $this->method = strtoupper($method);
         $this->uri = $uri;
         $this->setHeaders($headers);
@@ -97,6 +98,7 @@ class Request implements RequestInterface
     public function withMethod($method): RequestInterface
     {
         $this->assertMethod($method);
+        self::warnOnMethodCasingChange($method);
         $new = clone $this;
         $new->method = strtoupper($method);
 
@@ -163,6 +165,17 @@ class Request implements RequestInterface
     {
         if (!is_string($method) || $method === '') {
             throw new InvalidArgumentException('Method must be a non-empty string.');
+        }
+    }
+
+    private static function warnOnMethodCasingChange(string $method): void
+    {
+        if ($method !== strtoupper($method)) {
+            \trigger_deprecation(
+                'guzzlehttp/psr7',
+                '2.11',
+                'Passing a non-uppercase HTTP method is deprecated; guzzlehttp/psr7 3.0 preserves method casing and will no longer uppercase it. Normalize the method before constructing or modifying requests if uppercase is required.'
+            );
         }
     }
 }

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -165,7 +165,7 @@ class ServerRequest extends Request implements ServerRequestInterface
      */
     public static function fromGlobals(): ServerRequestInterface
     {
-        $method = self::getServerParam('REQUEST_METHOD') ?? 'GET';
+        $method = strtoupper(self::getServerParam('REQUEST_METHOD') ?? 'GET');
         $headers = getallheaders();
         $uri = self::getUriFromGlobals();
         $body = new CachingStream(new LazyOpenStream('php://input', 'r+'));


### PR DESCRIPTION
This warns callers that rely on PSR-7 2.x automatically uppercasing explicitly provided request methods. Guzzle PSR-7 3.0 preserves method casing, so callers that need uppercase standard methods should normalize before constructing or modifying requests. ServerRequest::fromGlobals() remains the compatibility path and continues normalizing REQUEST_METHOD values from server globals.