### PR TITLE
Redact all URI userinfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reject malformed uploaded file specifications missing `tmp_name`, `size`, or `error`
 - Normalize multiple leading slashes to one slash in `Uri::getPath()` and URI-derived `Request::getRequestTarget()` values
 - Harden URI host and scheme validation, including rejecting schemes that do not begin with a letter
+- Redact all non-empty URI userinfo in `Utils::redactUserInfo()`
 - Tighten `ServerRequest::getUriFromGlobals()` validation for malformed `HTTP_HOST` and `SERVER_PORT` values
 - Stop preserving malformed `Host` headers when building server requests from globals
 - Normalize server request URI reconstruction from globals, including `REQUEST_METHOD` values used for request-target parsing

--- a/README.md
+++ b/README.md
@@ -531,7 +531,7 @@ metadata can be detected after a stream read cannot make progress.
 
 `public static function redactUserInfo(UriInterface $uri): UriInterface`
 
-Redact the password in the user info part of a URI.
+Redact the user info part of a URI.
 
 
 ## `GuzzleHttp\Psr7\Utils::streamFor`

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -194,6 +194,25 @@ Applications that need to reject malformed inbound `Host` headers should
 validate the request host before calling `getUriFromGlobals()` or inspect the
 original server parameters.
 
+#### URI Userinfo Redaction
+
+`Utils::redactUserInfo()` now redacts all non-empty URI userinfo, including
+username-only userinfo. In 2.x, it only redacted the password portion when
+userinfo contained a password delimiter.
+
+```php
+use GuzzleHttp\Psr7\Uri;
+use GuzzleHttp\Psr7\Utils;
+
+// 2.x: https://TOKEN@example.com
+// 3.0: https://***@example.com
+(string) Utils::redactUserInfo(new Uri('https://TOKEN@example.com'));
+
+// 2.x: https://user:***@example.com
+// 3.0: https://***@example.com
+(string) Utils::redactUserInfo(new Uri('https://user:pass@example.com'));
+```
+
 #### URI Paths and Request Targets
 
 `Uri::getPath()` now normalizes multiple leading slashes to one slash when

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -194,25 +194,6 @@ Applications that need to reject malformed inbound `Host` headers should
 validate the request host before calling `getUriFromGlobals()` or inspect the
 original server parameters.
 
-#### URI Userinfo Redaction
-
-`Utils::redactUserInfo()` now redacts all non-empty URI userinfo, including
-username-only userinfo. In 2.x, it only redacted the password portion when
-userinfo contained a password delimiter.
-
-```php
-use GuzzleHttp\Psr7\Uri;
-use GuzzleHttp\Psr7\Utils;
-
-// 2.x: https://TOKEN@example.com
-// 3.0: https://***@example.com
-(string) Utils::redactUserInfo(new Uri('https://TOKEN@example.com'));
-
-// 2.x: https://user:***@example.com
-// 3.0: https://***@example.com
-(string) Utils::redactUserInfo(new Uri('https://user:pass@example.com'));
-```
-
 #### URI Paths and Request Targets
 
 `Uri::getPath()` now normalizes multiple leading slashes to one slash when
@@ -361,6 +342,25 @@ boundary.
 Custom multipart part header names and values are also validated before
 serialization. Header names must be valid HTTP tokens, and header values must be
 strings without CR, LF, or other invalid control bytes.
+
+#### URI Userinfo Redaction
+
+`Utils::redactUserInfo()` now redacts all non-empty URI userinfo, including
+username-only userinfo. In 2.x, it only redacted the password portion when
+userinfo contained a password delimiter.
+
+```php
+use GuzzleHttp\Psr7\Uri;
+use GuzzleHttp\Psr7\Utils;
+
+// 2.x: https://TOKEN@example.com
+// 3.0: https://***@example.com
+(string) Utils::redactUserInfo(new Uri('https://TOKEN@example.com'));
+
+// 2.x: https://user:***@example.com
+// 3.0: https://***@example.com
+(string) Utils::redactUserInfo(new Uri('https://user:pass@example.com'));
+```
 
 1.x to 2.0
 ----------

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -327,9 +327,7 @@ final class Utils
      */
     public static function redactUserInfo(UriInterface $uri): UriInterface
     {
-        return $uri->getUserInfo() === ''
-            ? $uri
-            : $uri->withUserInfo('***');
+        return $uri->getUserInfo() === '' ? $uri : $uri->withUserInfo('***');
     }
 
     /**

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -323,17 +323,13 @@ final class Utils
     }
 
     /**
-     * Redact the password in the user info part of a URI.
+     * Redact the user info part of a URI.
      */
     public static function redactUserInfo(UriInterface $uri): UriInterface
     {
-        $userInfo = $uri->getUserInfo();
-
-        if (false !== ($pos = \strpos($userInfo, ':'))) {
-            return $uri->withUserInfo(\substr($userInfo, 0, $pos), '***');
-        }
-
-        return $uri;
+        return $uri->getUserInfo() === ''
+            ? $uri
+            : $uri->withUserInfo('***');
     }
 
     /**

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -457,11 +457,20 @@ class UtilsTest extends TestCase
 
     public function testRedactUserInfo(): void
     {
-        $uri = new Psr7\Uri('http://my_user:secretPass@localhost/');
+        self::assertSame(
+            'http://***@localhost/',
+            (string) Psr7\Utils::redactUserInfo(new Psr7\Uri('http://my_user:secretPass@localhost/'))
+        );
 
-        $redactedUri = Psr7\Utils::redactUserInfo($uri);
+        self::assertSame(
+            'http://***@localhost/',
+            (string) Psr7\Utils::redactUserInfo(new Psr7\Uri('http://ghp_TOKEN@localhost/'))
+        );
 
-        self::assertSame('http://my_user:***@localhost/', (string) $redactedUri);
+        self::assertSame(
+            'http://localhost/',
+            (string) Psr7\Utils::redactUserInfo(new Psr7\Uri('http://localhost/'))
+        );
     }
 
     public function testCalculatesHash(): void


### PR DESCRIPTION
Updates Utils::redactUserInfo() to redact every non-empty URI userinfo value and documents the 3.0 behavior change.