### PR TITLE
Add missing native return types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Require `psr/http-message:^2.0` and add its native parameter types
+- Require `psr/http-message:^2.0` and add compatible native parameter and return types
 - Require `psr/http-factory:^1.1`
 - Preserve HTTP request method casing for explicitly constructed requests while continuing to uppercase `ServerRequest::fromGlobals()` methods for server-global compatibility
 - Reject empty arrays and non-string values as header values

--- a/src/AppendStream.php
+++ b/src/AppendStream.php
@@ -244,10 +244,7 @@ final class AppendStream implements StreamInterface
         throw new \RuntimeException('Cannot write to an AppendStream');
     }
 
-    /**
-     * @return mixed
-     */
-    public function getMetadata(?string $key = null)
+    public function getMetadata(?string $key = null): ?array
     {
         return $key === null ? [] : null;
     }

--- a/src/FnStream.php
+++ b/src/FnStream.php
@@ -74,10 +74,8 @@ final class FnStream implements StreamInterface
      *
      * @param StreamInterface         $stream  Stream to decorate
      * @param array<string, callable> $methods Hash of method name to a closure
-     *
-     * @return FnStream
      */
-    public static function decorate(StreamInterface $stream, array $methods)
+    public static function decorate(StreamInterface $stream, array $methods): self
     {
         // If any of the required methods were not provided, then simply
         // proxy to the decorated stream.

--- a/src/Message.php
+++ b/src/Message.php
@@ -251,7 +251,7 @@ final class Message
      */
     private static function getHostFromHeaders(array $headers): ?string
     {
-        $hostKey = array_filter(array_keys($headers), function ($k) {
+        $hostKey = array_filter(array_keys($headers), function ($k): bool {
             // Numeric array keys are converted to int by PHP.
             $k = (string) $k;
 

--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -214,7 +214,7 @@ trait MessageTrait
      */
     private function trimAndValidateHeaderValues(array $values): array
     {
-        return array_map(function ($value) {
+        return array_map(function ($value): string {
             if (!is_string($value)) {
                 throw new \InvalidArgumentException(sprintf(
                     'Header value must be a string or array of strings but %s provided.',

--- a/src/Query.php
+++ b/src/Query.php
@@ -26,7 +26,7 @@ final class Query
         }
 
         if ($urlEncoding === true) {
-            $decoder = function ($value) {
+            $decoder = function ($value): string {
                 return rawurldecode(str_replace('+', ' ', (string) $value));
             };
         } elseif ($urlEncoding === PHP_QUERY_RFC3986) {
@@ -34,7 +34,7 @@ final class Query
         } elseif ($urlEncoding === PHP_QUERY_RFC1738) {
             $decoder = 'urldecode';
         } else {
-            $decoder = function ($str) {
+            $decoder = function ($str): string {
                 return $str;
             };
         }

--- a/src/StreamDecoratorTrait.php
+++ b/src/StreamDecoratorTrait.php
@@ -24,10 +24,8 @@ trait StreamDecoratorTrait
     /**
      * Magic method used to create a new stream if streams are not added in
      * the constructor of a decorator (e.g., LazyOpenStream).
-     *
-     * @return StreamInterface
      */
-    public function __get(string $name)
+    public function __get(string $name): StreamInterface
     {
         if ($name === 'stream') {
             $this->stream = $this->createStream();

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -123,7 +123,7 @@ class Uri implements UriInterface, \JsonSerializable
         /** @var string */
         $encodedUrl = preg_replace_callback(
             '%[^:/@?&=#]+%usD',
-            static function ($matches) {
+            static function ($matches): string {
                 return urlencode($matches[0]);
             },
             $url
@@ -725,7 +725,7 @@ class Uri implements UriInterface, \JsonSerializable
             return rawurldecode((string) $k);
         }, $keys);
 
-        return array_filter(explode('&', $current), function ($part) use ($decodedKeys) {
+        return array_filter(explode('&', $current), function ($part) use ($decodedKeys): bool {
             return !in_array(rawurldecode(explode('=', $part)[0]), $decodedKeys, true);
         });
     }


### PR DESCRIPTION
This adds the remaining safe PHP 7.4-compatible return types in source code and folds the changelog mention into the existing native type entry.