### PR TITLE
Make static utility classes non-instantiable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Throw `TimeoutException` when stream read, copy, hash, and line operations detect timeout metadata
 - Stop adding default `Content-Length` headers to `multipart/form-data` parts to comply with RFC 7578 section 4.8
 - Escape generated multipart `Content-Disposition` parameters and reject unsafe multipart boundary and part header metadata
+- Made static utility classes non-instantiable
 
 ### Removed
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -362,6 +362,12 @@ use GuzzleHttp\Psr7\Utils;
 (string) Utils::redactUserInfo(new Uri('https://user:pass@example.com'));
 ```
 
+#### Non-instantiable Utility Classes
+
+Static utility and constant classes such as `Header`, `Message`, `MimeType`,
+`Query`, `Rfc7230`, and `Utils` now have private constructors. Replace any
+accidental instantiation with static method calls or constant access.
+
 1.x to 2.0
 ----------
 

--- a/src/Header.php
+++ b/src/Header.php
@@ -6,6 +6,10 @@ namespace GuzzleHttp\Psr7;
 
 final class Header
 {
+    private function __construct()
+    {
+    }
+
     /**
      * Parse an array of header values containing ";" separated data into an
      * array of associative arrays representing the header key value pair data

--- a/src/Message.php
+++ b/src/Message.php
@@ -10,6 +10,10 @@ use Psr\Http\Message\ResponseInterface;
 
 final class Message
 {
+    private function __construct()
+    {
+    }
+
     /**
      * Returns the string representation of an HTTP message.
      *

--- a/src/MimeType.php
+++ b/src/MimeType.php
@@ -6,6 +6,10 @@ namespace GuzzleHttp\Psr7;
 
 final class MimeType
 {
+    private function __construct()
+    {
+    }
+
     private const MIME_TYPES = [
         '123' => 'application/vnd.lotus-1-2-3',
         '1km' => 'application/vnd.1000minds.decision-model+xml',

--- a/src/Query.php
+++ b/src/Query.php
@@ -6,6 +6,10 @@ namespace GuzzleHttp\Psr7;
 
 final class Query
 {
+    private function __construct()
+    {
+    }
+
     /**
      * Parse a query string into an associative array.
      *

--- a/src/Rfc7230.php
+++ b/src/Rfc7230.php
@@ -9,6 +9,10 @@ namespace GuzzleHttp\Psr7;
  */
 final class Rfc7230
 {
+    private function __construct()
+    {
+    }
+
     /**
      * Header related regular expressions (based on amphp/http package)
      *

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -11,6 +11,10 @@ use Psr\Http\Message\UriInterface;
 
 final class Utils
 {
+    private function __construct()
+    {
+    }
+
     /**
      * Remove the items given by the keys, case insensitively from the data.
      *


### PR DESCRIPTION
This makes PSR-7 static utility and constant classes non-instantiable. The affected classes only expose static members, so callers should use static method calls or constant access.