### PR TITLE
Document callable stream sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,9 +517,14 @@ This method is useful for reducing the number of clones needed to mutate
 a message.
 
 - method: (string) Changes the HTTP method.
-- set_headers: (array) Sets the given headers.
-- remove_headers: (array) Remove the given headers.
-- body: (mixed) Sets the given body.
+- set_headers: (array) Sets the given headers. Values must be strings or arrays
+  of strings.
+- remove_headers: (array) Remove the given headers. Values may be strings or
+  integers.
+- body: (mixed) Sets the given body. Present non-null values are converted with
+  `GuzzleHttp\Psr7\Utils::streamFor()`, including scalar values, resources,
+  streams, iterators, callable arrays, closures, invokable objects, and
+  stringable objects. String inputs remain literal bodies.
 - uri: (UriInterface) Set the URI.
 - query: (string) Set the query string value of the URI.
 - version: (string) Set the protocol version.
@@ -544,7 +549,7 @@ Redact the user info part of a URI.
 
 ## `GuzzleHttp\Psr7\Utils::streamFor`
 
-`public static function streamFor(resource|string|null|int|float|bool|StreamInterface|callable|\Iterator $resource = '', array $options = []): StreamInterface`
+`public static function streamFor(resource|string|null|int|float|bool|StreamInterface|callable|\Iterator|\Stringable $resource = '', array $options = []): StreamInterface`
 
 Create a new stream based on the input type.
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ echo $stream; // 0123456789
 
 `GuzzleHttp\Psr7\FnStream`
 
-Compose stream implementations based on a hash of functions.
+Compose stream implementations based on a hash of callables.
 
 Allows for easy testing and extension of a provided stream without needing
 to create a concrete class for a simple extension point.
@@ -211,6 +211,11 @@ echo $stream->tell();
 Stream that when read returns bytes for a streaming multipart or
 multipart/form-data stream.
 
+Each multipart element must contain a `name` and `contents` key. `contents` may
+be any non-array value accepted by `GuzzleHttp\Psr7\Utils::streamFor()`,
+including closures and invokable objects. Array contents are recursively
+expanded into nested form fields.
+
 
 ## NoSeekStream
 
@@ -240,12 +245,15 @@ var_export($noSeek->read(3));
 
 Provides a read only stream that pumps data from a PHP callable.
 
-When invoking the provided callable, the PumpStream will pass the amount of
-data requested to read to the callable. The callable can choose to ignore
+When invoking the provided callable, the PumpStream will pass the suggested
+number of bytes to read to the callable. The callable can choose to ignore
 this value and return fewer or more bytes than requested. Any extra data
 returned by the provided callable is buffered internally until drained using
 the read() function of the PumpStream. The provided callable MUST return
-false when there is no more data to read.
+false or null when there is no more data to read.
+
+Userland callables that declare no parameters are tolerated by PHP, but
+length-aware callables remain the recommended formal shape.
 
 
 ## Implementing stream decorators
@@ -560,13 +568,13 @@ This method accepts the following `$resource` types:
   the object will be cast to a string and then a stream will be returned that
   uses the string value.
 - `NULL`: When `null` is passed, an empty stream object is returned.
-- `callable` When a callable is passed, a read-only stream object will be
-  created that invokes the given callable. The callable is invoked with the
-  number of suggested bytes to read. The callable can return any number of
-  bytes, but MUST return `false` when there is no more data to return. The
-  stream object that wraps the callable will invoke the callable until the
-  number of requested bytes are available. Any additional bytes will be
-  buffered and used in subsequent reads.
+- `callable`: When a callable array, closure, or invokable object is passed, a
+  read-only stream object will be created that invokes the given callable. The
+  callable is invoked with the suggested number of bytes to read. The callable
+  can return fewer or more bytes than requested, but MUST return `false` or
+  `null` when there is no more data to return. Any additional bytes will be
+  buffered and used in subsequent reads. String inputs are always treated as
+  string bodies, even when they name callable functions.
 
 ```php
 $stream = GuzzleHttp\Psr7\Utils::streamFor('foo');

--- a/src/FnStream.php
+++ b/src/FnStream.php
@@ -7,7 +7,7 @@ namespace GuzzleHttp\Psr7;
 use Psr\Http\Message\StreamInterface;
 
 /**
- * Compose stream implementations based on a hash of functions.
+ * Compose stream implementations based on a hash of callables.
  *
  * Allows for easy testing and extension of a provided stream without needing
  * to create a concrete class for a simple extension point.
@@ -31,7 +31,7 @@ final class FnStream implements StreamInterface
     {
         $this->methods = $methods;
 
-        // Create the functions on the class
+        // Create the callables on the class
         foreach ($methods as $name => $fn) {
             $this->{'_fn_'.$name} = $fn;
         }
@@ -73,7 +73,7 @@ final class FnStream implements StreamInterface
      * specific method calls.
      *
      * @param StreamInterface         $stream  Stream to decorate
-     * @param array<string, callable> $methods Hash of method name to a closure
+     * @param array<string, callable> $methods Hash of method name to a callable
      */
     public static function decorate(StreamInterface $stream, array $methods): self
     {

--- a/src/MultipartStream.php
+++ b/src/MultipartStream.php
@@ -26,9 +26,8 @@ final class MultipartStream implements StreamInterface
      * @param array       $elements Array of associative arrays, each containing a
      *                              required "name" key mapping to the form field,
      *                              name, a required "contents" key mapping to any
-     *                              value accepted by Utils::streamFor() (scalar,
-     *                              null, resource, StreamInterface, Iterator, or
-     *                              callable), or an array for nested expansion.
+     *                              non-array value accepted by Utils::streamFor(),
+     *                              or an array for nested expansion.
      *                              Optional keys include "headers" (associative
      *                              array of custom headers) and "filename" (string
      *                              to send as the filename in the part).

--- a/src/PumpStream.php
+++ b/src/PumpStream.php
@@ -37,17 +37,17 @@ final class PumpStream implements StreamInterface
     private $buffer;
 
     /**
-     * @param callable                            $source  Source of the stream data. The callable receives
-     *                                                     the suggested number of bytes to read, may ignore
-     *                                                     that value, and may return fewer or more bytes.
-     *                                                     Extra bytes are buffered. The callable MUST return
-     *                                                     a string when called, or false|null on error or EOF.
-     *                                                     Userland callables that declare no parameters are
-     *                                                     tolerated by PHP, but length-aware callables remain
-     *                                                     the recommended formal shape.
-     * @param array{size?: int, metadata?: array} $options Stream options:
-     *                                                     - metadata: Hash of metadata to use with stream.
-     *                                                     - size: Size of the stream, if known.
+     * @param (callable(): (string|false|null))|(callable(int): (string|false|null)) $source  Source of the stream data. The callable receives
+     *                                                                                        the suggested number of bytes to read, may ignore
+     *                                                                                        that value, and may return fewer or more bytes.
+     *                                                                                        Extra bytes are buffered. The callable MUST return
+     *                                                                                        a string when called, or false|null on error or EOF.
+     *                                                                                        Userland callables that declare no parameters are
+     *                                                                                        tolerated by PHP, but length-aware callables remain
+     *                                                                                        the recommended formal shape.
+     * @param array{size?: int, metadata?: array}                                    $options Stream options:
+     *                                                                                        - metadata: Hash of metadata to use with stream.
+     *                                                                                        - size: Size of the stream, if known.
      */
     public function __construct(callable $source, array $options = [])
     {

--- a/src/PumpStream.php
+++ b/src/PumpStream.php
@@ -9,16 +9,19 @@ use Psr\Http\Message\StreamInterface;
 /**
  * Provides a read only stream that pumps data from a PHP callable.
  *
- * When invoking the provided callable, the PumpStream will pass the amount of
- * data requested to read to the callable. The callable can choose to ignore
+ * When invoking the provided callable, the PumpStream will pass the suggested
+ * number of bytes to read to the callable. The callable can choose to ignore
  * this value and return fewer or more bytes than requested. Any extra data
- * returned by the provided callable is buffered internally until drained using
- * the read() function of the PumpStream. The provided callable MUST return
- * false when there is no more data to read.
+ * returned by the callable is buffered internally until drained using the
+ * read() function of the PumpStream. The callable MUST return false or null
+ * when there is no more data to read.
+ *
+ * Userland callables that declare no parameters are tolerated by PHP, but
+ * length-aware callables remain the recommended formal shape.
  */
 final class PumpStream implements StreamInterface
 {
-    /** @var callable(int): (string|false|null)|null */
+    /** @var callable|null */
     private $source;
 
     /** @var int|null */
@@ -34,11 +37,14 @@ final class PumpStream implements StreamInterface
     private $buffer;
 
     /**
-     * @param callable(int): (string|false|null)  $source  Source of the stream data. The callable MAY
-     *                                                     accept an integer argument used to control the
-     *                                                     amount of data to return. The callable MUST
-     *                                                     return a string when called, or false|null on error
-     *                                                     or EOF.
+     * @param callable                            $source  Source of the stream data. The callable receives
+     *                                                     the suggested number of bytes to read, may ignore
+     *                                                     that value, and may return fewer or more bytes.
+     *                                                     Extra bytes are buffered. The callable MUST return
+     *                                                     a string when called, or false|null on error or EOF.
+     *                                                     Userland callables that declare no parameters are
+     *                                                     tolerated by PHP, but length-aware callables remain
+     *                                                     the recommended formal shape.
      * @param array{size?: int, metadata?: array} $options Stream options:
      *                                                     - metadata: Hash of metadata to use with stream.
      *                                                     - size: Size of the stream, if known.
@@ -151,6 +157,7 @@ final class PumpStream implements StreamInterface
     {
         if ($this->source !== null) {
             do {
+                /** @var string|false|null $data */
                 $data = ($this->source)($length);
                 if ($data === false || $data === null) {
                     $this->source = null;

--- a/src/Query.php
+++ b/src/Query.php
@@ -31,24 +31,21 @@ final class Query
 
         if ($urlEncoding === true) {
             $decoder = function (string $value): string {
-                return rawurldecode(str_replace('+', ' ', $value));
+                return \rawurldecode(str_replace('+', ' ', $value));
             };
         } elseif ($urlEncoding === PHP_QUERY_RFC3986) {
             $decoder = static function (string $value): string {
-                return rawurldecode($value);
+                return \rawurldecode($value);
             };
         } elseif ($urlEncoding === PHP_QUERY_RFC1738) {
             $decoder = static function (string $value): string {
-                return urldecode($value);
+                return \urldecode($value);
             };
         } else {
             $decoder = function (string $str): string {
                 return $str;
             };
         }
-
-        /** @var \Closure(string): string $decoder */
-        $decoder = $decoder;
 
         foreach (explode('&', $str) as $kvp) {
             $parts = explode('=', $kvp, 2);
@@ -94,18 +91,15 @@ final class Query
             };
         } elseif ($encoding === PHP_QUERY_RFC3986) {
             $encoder = static function (string $value): string {
-                return rawurlencode($value);
+                return \rawurlencode($value);
             };
         } elseif ($encoding === PHP_QUERY_RFC1738) {
             $encoder = static function (string $value): string {
-                return urlencode($value);
+                return \urlencode($value);
             };
         } else {
             throw new \InvalidArgumentException('Invalid type');
         }
-
-        /** @var \Closure(string): string $encoder */
-        $encoder = $encoder;
 
         $qs = '';
         foreach ($params as $k => $v) {

--- a/src/Query.php
+++ b/src/Query.php
@@ -30,18 +30,25 @@ final class Query
         }
 
         if ($urlEncoding === true) {
-            $decoder = function ($value): string {
-                return rawurldecode(str_replace('+', ' ', (string) $value));
+            $decoder = function (string $value): string {
+                return rawurldecode(str_replace('+', ' ', $value));
             };
         } elseif ($urlEncoding === PHP_QUERY_RFC3986) {
-            $decoder = 'rawurldecode';
+            $decoder = static function (string $value): string {
+                return rawurldecode($value);
+            };
         } elseif ($urlEncoding === PHP_QUERY_RFC1738) {
-            $decoder = 'urldecode';
+            $decoder = static function (string $value): string {
+                return urldecode($value);
+            };
         } else {
-            $decoder = function ($str): string {
+            $decoder = function (string $str): string {
                 return $str;
             };
         }
+
+        /** @var \Closure(string): string $decoder */
+        $decoder = $decoder;
 
         foreach (explode('&', $str) as $kvp) {
             $parts = explode('=', $kvp, 2);
@@ -86,12 +93,19 @@ final class Query
                 return $str;
             };
         } elseif ($encoding === PHP_QUERY_RFC3986) {
-            $encoder = 'rawurlencode';
+            $encoder = static function (string $value): string {
+                return rawurlencode($value);
+            };
         } elseif ($encoding === PHP_QUERY_RFC1738) {
-            $encoder = 'urlencode';
+            $encoder = static function (string $value): string {
+                return urlencode($value);
+            };
         } else {
             throw new \InvalidArgumentException('Invalid type');
         }
+
+        /** @var \Closure(string): string $encoder */
+        $encoder = $encoder;
 
         $qs = '';
         foreach ($params as $k => $v) {

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -18,7 +18,7 @@ final class Utils
     /**
      * Remove the items given by the keys, case insensitively from the data.
      *
-     * @param (string|int)[] $keys
+     * @param array<array-key, string|int> $keys
      */
     public static function caselessRemove(array $keys, array $data): array
     {
@@ -184,15 +184,28 @@ final class Utils
      *
      * The changes can be one of:
      * - method: (string) Changes the HTTP method.
-     * - set_headers: (array) Sets the given headers.
-     * - remove_headers: (array) Remove the given headers.
-     * - body: (mixed) Sets the given body.
+     * - set_headers: (array) Sets the given headers. Values must be strings
+     *   or arrays of strings.
+     * - remove_headers: (array) Remove the given headers. Values may be
+     *   strings or integers.
+     * - body: (mixed) Sets the given body. Present non-null values are converted
+     *   with self::streamFor(), including scalar values, resources, streams,
+     *   iterators, callable arrays, closures, invokable objects, and stringable
+     *   objects. String inputs remain literal bodies.
      * - uri: (UriInterface) Set the URI.
      * - query: (string) Set the query string value of the URI.
      * - version: (string) Set the protocol version.
      *
      * @param RequestInterface $request Request to clone and modify.
-     * @param array            $changes Changes to apply.
+     * @param array{
+     *     method?: string,
+     *     set_headers?: array<array-key, string|array<array-key, string>>,
+     *     remove_headers?: array<array-key, string|int>,
+     *     body?: resource|string|int|float|bool|StreamInterface|callable|\Iterator|\Stringable,
+     *     uri?: UriInterface,
+     *     query?: string,
+     *     version?: string
+     * } $changes Changes to apply.
      */
     public static function modifyRequest(RequestInterface $request, array $changes): RequestInterface
     {
@@ -363,8 +376,8 @@ final class Utils
      *   bytes will be buffered and used in subsequent reads. String inputs are
      *   always treated as string bodies, even when they name callable functions.
      *
-     * @param resource|string|int|float|bool|StreamInterface|callable|\Iterator|null $resource Entity body data
-     * @param array{size?: int, metadata?: array}                                    $options  Additional options
+     * @param resource|string|int|float|bool|StreamInterface|callable|\Iterator|\Stringable|null $resource Entity body data
+     * @param array{size?: int, metadata?: array}                                                $options  Additional options
      *
      * @throws \InvalidArgumentException if the $resource arg is not valid.
      */

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -355,13 +355,13 @@ final class Utils
      *   the object will be cast to a string and then a stream will be returned that
      *   uses the string value.
      * - `NULL`: When `null` is passed, an empty stream object is returned.
-     * - `callable` When a callable is passed, a read-only stream object will be
-     *   created that invokes the given callable. The callable is invoked with the
-     *   number of suggested bytes to read. The callable can return any number of
-     *   bytes, but MUST return `false` when there is no more data to return. The
-     *   stream object that wraps the callable will invoke the callable until the
-     *   number of requested bytes are available. Any additional bytes will be
-     *   buffered and used in subsequent reads.
+     * - `callable`: When a callable array, closure, or invokable object is passed,
+     *   a read-only stream object will be created that invokes the given callable.
+     *   The callable is invoked with the suggested number of bytes to read. The
+     *   callable can return fewer or more bytes than requested, but MUST return
+     *   `false` or `null` when there is no more data to return. Any additional
+     *   bytes will be buffered and used in subsequent reads. String inputs are
+     *   always treated as string bodies, even when they name callable functions.
      *
      * @param resource|string|int|float|bool|StreamInterface|callable|\Iterator|null $resource Entity body data
      * @param array{size?: int, metadata?: array}                                    $options  Additional options

--- a/tests/FnStreamTest.php
+++ b/tests/FnStreamTest.php
@@ -33,6 +33,31 @@ class FnStreamTest extends TestCase
         self::assertSame('foo', $s->read(3));
     }
 
+    public function testProxiesToNonClosureCallable(): void
+    {
+        $s = new FnStream([
+            'write' => 'strlen',
+        ]);
+
+        self::assertSame(3, $s->write('foo'));
+    }
+
+    public function testDecoratesWithNonClosureCallable(): void
+    {
+        $source = new class {
+            public function read(int $length): string
+            {
+                return str_repeat('x', $length);
+            }
+        };
+
+        $s = FnStream::decorate(Psr7\Utils::streamFor('foo'), [
+            'read' => [$source, 'read'],
+        ]);
+
+        self::assertSame('xxx', $s->read(3));
+    }
+
     public function testCanCloseOnDestruct(): void
     {
         $called = false;

--- a/tests/MultipartStreamTest.php
+++ b/tests/MultipartStreamTest.php
@@ -142,6 +142,33 @@ class MultipartStreamTest extends TestCase
         self::assertSame($expected, (string) $b);
     }
 
+    public function testSerializesRawCallableContents(): void
+    {
+        $chunks = ['callable body', false];
+        $b = new MultipartStream([
+            [
+                'name' => 'foo',
+                'contents' => static function (int $length) use (&$chunks) {
+                    if ($chunks === []) {
+                        return false;
+                    }
+
+                    return array_shift($chunks);
+                },
+            ],
+        ], 'boundary');
+
+        $expected = \implode('', [
+            "--boundary\r\n",
+            "Content-Disposition: form-data; name=\"foo\"\r\n",
+            "\r\n",
+            "callable body\r\n",
+            "--boundary--\r\n",
+        ]);
+
+        self::assertSame($expected, (string) $b);
+    }
+
     public function testEscapesGeneratedContentDispositionName(): void
     {
         $b = new MultipartStream([

--- a/tests/PumpStreamTest.php
+++ b/tests/PumpStreamTest.php
@@ -11,6 +11,21 @@ use PHPUnit\Framework\TestCase;
 
 class PumpStreamTest extends TestCase
 {
+    /** @var list<string|false|null> */
+    private static array $chunks = [];
+
+    /**
+     * @return string|false|null
+     */
+    public static function dequeueChunk(int $length)
+    {
+        if (self::$chunks === []) {
+            return false;
+        }
+
+        return array_shift(self::$chunks);
+    }
+
     public function testHasMetadataAndSize(): void
     {
         $p = new PumpStream(function (): void {
@@ -33,6 +48,63 @@ class PumpStreamTest extends TestCase
         self::assertSame(1, $p->tell());
         self::assertSame('aaaaa', $p->read(5));
         self::assertSame(6, $p->tell());
+    }
+
+    public function testCanReadFromCallableString(): void
+    {
+        self::$chunks = ['foo', false];
+
+        $p = new PumpStream(self::class.'::dequeueChunk');
+
+        self::assertSame('foo', $p->getContents());
+    }
+
+    public function testCanReadFromCallableArray(): void
+    {
+        $source = new class {
+            /** @var list<string|false> */
+            private array $chunks = ['foo', false];
+
+            /**
+             * @return string|false
+             */
+            public function read(int $length)
+            {
+                if ($this->chunks === []) {
+                    return false;
+                }
+
+                return array_shift($this->chunks);
+            }
+        };
+
+        $p = new PumpStream([$source, 'read']);
+
+        self::assertSame('foo', $p->getContents());
+    }
+
+    public function testCanReadFromInvokableObject(): void
+    {
+        $source = new class {
+            /** @var list<string|false> */
+            private array $chunks = ['foo', false];
+
+            /**
+             * @return string|false
+             */
+            public function __invoke(int $length)
+            {
+                if ($this->chunks === []) {
+                    return false;
+                }
+
+                return array_shift($this->chunks);
+            }
+        };
+
+        $p = new PumpStream($source);
+
+        self::assertSame('foo', $p->getContents());
     }
 
     public function testStoresExcessDataInBuffer(): void

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -1102,6 +1102,58 @@ class UtilsTest extends TestCase
         self::assertSame('payload', (string) $modified->getBody());
     }
 
+    public function testModifyRequestConvertsCallableArrayBodyWithStreamFor(): void
+    {
+        $source = new class {
+            /** @var list<string|false> */
+            private array $chunks = ['payload', false];
+
+            /**
+             * @return string|false
+             */
+            public function read(int $length)
+            {
+                if ($this->chunks === []) {
+                    return false;
+                }
+
+                return array_shift($this->chunks);
+            }
+        };
+
+        $request = new Psr7\Request('GET', 'http://example.com');
+
+        $modified = Psr7\Utils::modifyRequest($request, [
+            'body' => [$source, 'read'],
+        ]);
+
+        self::assertInstanceOf(Psr7\PumpStream::class, $modified->getBody());
+        self::assertSame('payload', $modified->getBody()->getContents());
+    }
+
+    public function testModifyRequestConvertsStringableBodyWithStreamFor(): void
+    {
+        $request = new Psr7\Request('GET', 'http://example.com');
+
+        $modified = Psr7\Utils::modifyRequest($request, [
+            'body' => new HasToString(),
+        ]);
+
+        self::assertSame('foo', $modified->getBody()->getContents());
+    }
+
+    public function testModifyRequestTreatsCallableStringBodyAsString(): void
+    {
+        $request = new Psr7\Request('GET', 'http://example.com');
+
+        $modified = Psr7\Utils::modifyRequest($request, [
+            'body' => 'strlen',
+        ]);
+
+        self::assertNotInstanceOf(Psr7\PumpStream::class, $modified->getBody());
+        self::assertSame('strlen', $modified->getBody()->getContents());
+    }
+
     public function testModifyRequestReaddsHostHeaderWhenFinalHeadersDoNotContainHost(): void
     {
         $request = (new Psr7\Request('GET', 'http://example.com'))->withoutHeader('Host');

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -633,6 +633,64 @@ class UtilsTest extends TestCase
         self::assertSame('foo', (string) $s);
     }
 
+    public function testFactoryTreatsCallableStringAsStringBody(): void
+    {
+        $s = Psr7\Utils::streamFor('strlen');
+
+        self::assertNotInstanceOf(Psr7\PumpStream::class, $s);
+        self::assertSame('strlen', $s->getContents());
+    }
+
+    public function testFactoryCreatesFromCallableArray(): void
+    {
+        $source = new class {
+            /** @var list<string|false> */
+            private array $chunks = ['foo', false];
+
+            /**
+             * @return string|false
+             */
+            public function read(int $length)
+            {
+                if ($this->chunks === []) {
+                    return false;
+                }
+
+                return array_shift($this->chunks);
+            }
+        };
+
+        $s = Psr7\Utils::streamFor([$source, 'read']);
+
+        self::assertInstanceOf(Psr7\PumpStream::class, $s);
+        self::assertSame('foo', $s->getContents());
+    }
+
+    public function testFactoryCreatesFromInvokableObject(): void
+    {
+        $source = new class {
+            /** @var list<string|false> */
+            private array $chunks = ['foo', false];
+
+            /**
+             * @return string|false
+             */
+            public function __invoke(int $length)
+            {
+                if ($this->chunks === []) {
+                    return false;
+                }
+
+                return array_shift($this->chunks);
+            }
+        };
+
+        $s = Psr7\Utils::streamFor($source);
+
+        self::assertInstanceOf(Psr7\PumpStream::class, $s);
+        self::assertSame('foo', $s->getContents());
+    }
+
     public function testCreatePassesThrough(): void
     {
         $s = Psr7\Utils::streamFor('foo');


### PR DESCRIPTION
This documents callable stream source behavior for PumpStream, Utils::streamFor, FnStream, and MultipartStream. It also documents the supported Utils::modifyRequest change shape and adds coverage for callable body sources while preserving callable-looking strings as string bodies.