### PR TITLE
Clarify callable source docblocks

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -613,7 +613,7 @@ parameters:
 			path: src/Utils.php
 
 		-
-			message: '#^Parameter \#1 \$source of class GuzzleHttp\\Psr7\\PumpStream constructor expects callable\(int\)\: \(string\|false\|null\), Closure\(\)\: mixed given\.$#'
+			message: '#^Parameter \#1 \$source of class GuzzleHttp\\Psr7\\PumpStream constructor expects \(callable\(\)\: \(string\|false\|null\)\)\|\(callable\(int\)\: \(string\|false\|null\)\), Closure\(\)\: mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Utils.php

--- a/src/FnStream.php
+++ b/src/FnStream.php
@@ -7,7 +7,7 @@ namespace GuzzleHttp\Psr7;
 use Psr\Http\Message\StreamInterface;
 
 /**
- * Compose stream implementations based on a hash of functions.
+ * Compose stream implementations based on a hash of callables.
  *
  * Allows for easy testing and extension of a provided stream without needing
  * to create a concrete class for a simple extension point.
@@ -31,7 +31,7 @@ final class FnStream implements StreamInterface
     {
         $this->methods = $methods;
 
-        // Create the functions on the class
+        // Create the callables on the class
         foreach ($methods as $name => $fn) {
             $this->{'_fn_'.$name} = $fn;
         }
@@ -73,7 +73,7 @@ final class FnStream implements StreamInterface
      * specific method calls.
      *
      * @param StreamInterface         $stream  Stream to decorate
-     * @param array<string, callable> $methods Hash of method name to a closure
+     * @param array<string, callable> $methods Hash of method name to a callable
      *
      * @return FnStream
      */

--- a/src/MultipartStream.php
+++ b/src/MultipartStream.php
@@ -26,9 +26,8 @@ final class MultipartStream implements StreamInterface
      * @param array       $elements Array of associative arrays, each containing a
      *                              required "name" key mapping to the form field,
      *                              name, a required "contents" key mapping to any
-     *                              value accepted by Utils::streamFor() (scalar,
-     *                              null, resource, StreamInterface, Iterator, or
-     *                              callable), or an array for nested expansion.
+     *                              non-array value accepted by Utils::streamFor(),
+     *                              or an array for nested expansion.
      *                              Optional keys include "headers" (associative
      *                              array of custom headers) and "filename" (string
      *                              to send as the filename in the part).

--- a/src/PumpStream.php
+++ b/src/PumpStream.php
@@ -9,16 +9,19 @@ use Psr\Http\Message\StreamInterface;
 /**
  * Provides a read only stream that pumps data from a PHP callable.
  *
- * When invoking the provided callable, the PumpStream will pass the amount of
- * data requested to read to the callable. The callable can choose to ignore
+ * When invoking the provided callable, the PumpStream will pass the suggested
+ * number of bytes to read to the callable. The callable can choose to ignore
  * this value and return fewer or more bytes than requested. Any extra data
- * returned by the provided callable is buffered internally until drained using
- * the read() function of the PumpStream. The provided callable MUST return
- * false when there is no more data to read.
+ * returned by the callable is buffered internally until drained using the
+ * read() function of the PumpStream. The callable MUST return false or null
+ * when there is no more data to read.
+ *
+ * Userland callables that declare no parameters are tolerated by PHP, but
+ * length-aware callables remain the recommended formal shape.
  */
 final class PumpStream implements StreamInterface
 {
-    /** @var callable(int): (string|false|null)|null */
+    /** @var callable|null */
     private $source;
 
     /** @var int|null */
@@ -34,14 +37,17 @@ final class PumpStream implements StreamInterface
     private $buffer;
 
     /**
-     * @param callable(int): (string|false|null)  $source  Source of the stream data. The callable MAY
-     *                                                     accept an integer argument used to control the
-     *                                                     amount of data to return. The callable MUST
-     *                                                     return a string when called, or false|null on error
-     *                                                     or EOF.
-     * @param array{size?: int, metadata?: array} $options Stream options:
-     *                                                     - metadata: Hash of metadata to use with stream.
-     *                                                     - size: Size of the stream, if known.
+     * @param (callable(): (string|false|null))|(callable(int): (string|false|null)) $source  Source of the stream data. The callable receives
+     *                                                                                        the suggested number of bytes to read, may ignore
+     *                                                                                        that value, and may return fewer or more bytes.
+     *                                                                                        Extra bytes are buffered. The callable MUST return
+     *                                                                                        a string when called, or false|null on error or EOF.
+     *                                                                                        Userland callables that declare no parameters are
+     *                                                                                        tolerated by PHP, but length-aware callables remain
+     *                                                                                        the recommended formal shape.
+     * @param array{size?: int, metadata?: array}                                    $options Stream options:
+     *                                                                                        - metadata: Hash of metadata to use with stream.
+     *                                                                                        - size: Size of the stream, if known.
      */
     public function __construct(callable $source, array $options = [])
     {

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -339,13 +339,14 @@ final class Utils
      *   the object will be cast to a string and then a stream will be returned that
      *   uses the string value.
      * - `NULL`: When `null` is passed, an empty stream object is returned.
-     * - `callable`: When a callable array, closure, or invokable object is passed,
-     *   a read-only stream object will be created that invokes the given callable.
-     *   The callable is invoked with the suggested number of bytes to read. The
-     *   callable can return fewer or more bytes than requested, but MUST return
-     *   `false` or `null` when there is no more data to return. Any additional
-     *   bytes will be buffered and used in subsequent reads. String inputs are
-     *   always treated as string bodies, even when they name callable functions.
+     * - `callable`: When a callable array, closure, or invokable object is passed
+     *   and no earlier resource or object rule applies, a read-only stream object
+     *   will be created that invokes the given callable. The callable is invoked
+     *   with the suggested number of bytes to read. The callable can return fewer
+     *   or more bytes than requested, but MUST return `false` or `null` when there
+     *   is no more data to return. Any additional bytes will be buffered and used
+     *   in subsequent reads. String inputs are always treated as string bodies,
+     *   even when they name callable functions.
      *
      * @param resource|string|int|float|bool|StreamInterface|callable|\Iterator|null $resource Entity body data
      * @param array{size?: int, metadata?: array}                                    $options  Additional options

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -165,7 +165,10 @@ final class Utils
      * - method: (string) Changes the HTTP method.
      * - set_headers: (array) Sets the given headers.
      * - remove_headers: (array) Remove the given headers.
-     * - body: (mixed) Sets the given body.
+     * - body: (mixed) Sets the given body. Present non-null values are converted
+     *   with self::streamFor(), including scalar values, resources, streams,
+     *   iterators, callable arrays, closures, invokable objects, and stringable
+     *   objects. String inputs remain literal bodies.
      * - uri: (UriInterface) Set the URI.
      * - query: (string) Set the query string value of the URI.
      * - version: (string) Set the protocol version.
@@ -336,16 +339,16 @@ final class Utils
      *   the object will be cast to a string and then a stream will be returned that
      *   uses the string value.
      * - `NULL`: When `null` is passed, an empty stream object is returned.
-     * - `callable` When a callable is passed, a read-only stream object will be
-     *   created that invokes the given callable. The callable is invoked with the
-     *   number of suggested bytes to read. The callable can return any number of
-     *   bytes, but MUST return `false` when there is no more data to return. The
-     *   stream object that wraps the callable will invoke the callable until the
-     *   number of requested bytes are available. Any additional bytes will be
-     *   buffered and used in subsequent reads.
+     * - `callable`: When a callable array, closure, or invokable object is passed,
+     *   a read-only stream object will be created that invokes the given callable.
+     *   The callable is invoked with the suggested number of bytes to read. The
+     *   callable can return fewer or more bytes than requested, but MUST return
+     *   `false` or `null` when there is no more data to return. Any additional
+     *   bytes will be buffered and used in subsequent reads. String inputs are
+     *   always treated as string bodies, even when they name callable functions.
      *
-     * @param resource|string|int|float|bool|StreamInterface|callable|\Iterator|null $resource Entity body data
-     * @param array{size?: int, metadata?: array}                                    $options  Additional options
+     * @param resource|string|int|float|bool|StreamInterface|callable|\Iterator|\Stringable|null $resource Entity body data
+     * @param array{size?: int, metadata?: array}                                                $options  Additional options
      *
      * @throws \InvalidArgumentException if the $resource arg is not valid.
      */

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -167,8 +167,8 @@ final class Utils
      * - remove_headers: (array) Remove the given headers.
      * - body: (mixed) Sets the given body. Present non-null values are converted
      *   with self::streamFor(), including scalar values, resources, streams,
-     *   iterators, callable arrays, closures, invokable objects, and stringable
-     *   objects. String inputs remain literal bodies.
+     *   iterators, callable arrays, closures, invokable objects, and objects
+     *   with __toString(). String inputs remain literal bodies.
      * - uri: (UriInterface) Set the URI.
      * - query: (string) Set the query string value of the URI.
      * - version: (string) Set the protocol version.
@@ -347,8 +347,8 @@ final class Utils
      *   bytes will be buffered and used in subsequent reads. String inputs are
      *   always treated as string bodies, even when they name callable functions.
      *
-     * @param resource|string|int|float|bool|StreamInterface|callable|\Iterator|\Stringable|null $resource Entity body data
-     * @param array{size?: int, metadata?: array}                                                $options  Additional options
+     * @param resource|string|int|float|bool|StreamInterface|callable|\Iterator|null $resource Entity body data
+     * @param array{size?: int, metadata?: array}                                    $options  Additional options
      *
      * @throws \InvalidArgumentException if the $resource arg is not valid.
      */


### PR DESCRIPTION
This updates the 2.11 source documentation to describe callable stream sources consistently with the existing implementation. The comments now use callable terminology for FnStream, avoid an incomplete MultipartStream contents type list, and make PumpStream and Utils::streamFor() clearer about callable inputs and false or null EOF values without changing runtime behavior.