### PR TITLE
Add native property types

### DIFF
--- a/src/AppendStream.php
+++ b/src/AppendStream.php
@@ -17,13 +17,10 @@ final class AppendStream implements StreamInterface
     /** @var StreamInterface[] Streams being decorated */
     private array $streams = [];
 
-    /** @var bool */
     private bool $seekable = true;
 
-    /** @var int */
     private int $current = 0;
 
-    /** @var int */
     private int $pos = 0;
 
     /**

--- a/src/AppendStream.php
+++ b/src/AppendStream.php
@@ -15,16 +15,16 @@ use Psr\Http\Message\StreamInterface;
 final class AppendStream implements StreamInterface
 {
     /** @var StreamInterface[] Streams being decorated */
-    private $streams = [];
+    private array $streams = [];
 
     /** @var bool */
-    private $seekable = true;
+    private bool $seekable = true;
 
     /** @var int */
-    private $current = 0;
+    private int $current = 0;
 
     /** @var int */
-    private $pos = 0;
+    private int $pos = 0;
 
     /**
      * @param StreamInterface[] $streams Streams to decorate. Each stream must

--- a/src/BufferStream.php
+++ b/src/BufferStream.php
@@ -17,10 +17,10 @@ use Psr\Http\Message\StreamInterface;
 final class BufferStream implements StreamInterface
 {
     /** @var int */
-    private $hwm;
+    private int $hwm;
 
     /** @var string */
-    private $buffer = '';
+    private string $buffer = '';
 
     /**
      * @param int $hwm High water mark, representing the preferred maximum

--- a/src/BufferStream.php
+++ b/src/BufferStream.php
@@ -16,10 +16,8 @@ use Psr\Http\Message\StreamInterface;
  */
 final class BufferStream implements StreamInterface
 {
-    /** @var int */
     private int $hwm;
 
-    /** @var string */
     private string $buffer = '';
 
     /**

--- a/src/CachingStream.php
+++ b/src/CachingStream.php
@@ -21,12 +21,8 @@ final class CachingStream implements StreamInterface
     /** @var int Number of bytes to skip reading due to a write on the buffer */
     private int $skipReadBytes = 0;
 
-    /**
-     * @var StreamInterface
-     */
     private StreamInterface $stream;
 
-    /** @var bool */
     private bool $detached = false;
 
     /**

--- a/src/CachingStream.php
+++ b/src/CachingStream.php
@@ -16,18 +16,18 @@ final class CachingStream implements StreamInterface
     use StreamDecoratorTrait;
 
     /** @var StreamInterface Stream being wrapped */
-    private $remoteStream;
+    private StreamInterface $remoteStream;
 
     /** @var int Number of bytes to skip reading due to a write on the buffer */
-    private $skipReadBytes = 0;
+    private int $skipReadBytes = 0;
 
     /**
      * @var StreamInterface
      */
-    private $stream;
+    private StreamInterface $stream;
 
     /** @var bool */
-    private $detached = false;
+    private bool $detached = false;
 
     /**
      * We will treat the buffer object as the body of the stream

--- a/src/DroppingStream.php
+++ b/src/DroppingStream.php
@@ -15,10 +15,10 @@ final class DroppingStream implements StreamInterface
     use StreamDecoratorTrait;
 
     /** @var int */
-    private $maxLength;
+    private int $maxLength;
 
     /** @var StreamInterface */
-    private $stream;
+    private StreamInterface $stream;
 
     /**
      * @param StreamInterface $stream    Underlying stream to decorate.

--- a/src/DroppingStream.php
+++ b/src/DroppingStream.php
@@ -14,10 +14,8 @@ final class DroppingStream implements StreamInterface
 {
     use StreamDecoratorTrait;
 
-    /** @var int */
     private int $maxLength;
 
-    /** @var StreamInterface */
     private StreamInterface $stream;
 
     /**

--- a/src/FnStream.php
+++ b/src/FnStream.php
@@ -22,7 +22,7 @@ final class FnStream implements StreamInterface
     ];
 
     /** @var array<string, callable> */
-    private $methods;
+    private array $methods;
 
     /**
      * @param array<string, callable> $methods Hash of method name to a callable.

--- a/src/InflateStream.php
+++ b/src/InflateStream.php
@@ -22,7 +22,7 @@ final class InflateStream implements StreamInterface
     use StreamDecoratorTrait;
 
     /** @var StreamInterface */
-    private $stream;
+    private StreamInterface $stream;
 
     public function __construct(StreamInterface $stream)
     {

--- a/src/InflateStream.php
+++ b/src/InflateStream.php
@@ -21,7 +21,6 @@ final class InflateStream implements StreamInterface
 {
     use StreamDecoratorTrait;
 
-    /** @var StreamInterface */
     private StreamInterface $stream;
 
     public function __construct(StreamInterface $stream)

--- a/src/LazyOpenStream.php
+++ b/src/LazyOpenStream.php
@@ -15,15 +15,15 @@ final class LazyOpenStream implements StreamInterface
     use StreamDecoratorTrait;
 
     /** @var string */
-    private $filename;
+    private string $filename;
 
     /** @var string */
-    private $mode;
+    private string $mode;
 
     /**
      * @var StreamInterface
      */
-    private $stream;
+    private StreamInterface $stream;
 
     /**
      * @param string $filename File to lazily open

--- a/src/LazyOpenStream.php
+++ b/src/LazyOpenStream.php
@@ -14,15 +14,10 @@ final class LazyOpenStream implements StreamInterface
 {
     use StreamDecoratorTrait;
 
-    /** @var string */
     private string $filename;
 
-    /** @var string */
     private string $mode;
 
-    /**
-     * @var StreamInterface
-     */
     private StreamInterface $stream;
 
     /**

--- a/src/LimitStream.php
+++ b/src/LimitStream.php
@@ -19,7 +19,6 @@ final class LimitStream implements StreamInterface
     /** @var int Limit the number of bytes that can be read */
     private int $limit;
 
-    /** @var StreamInterface */
     private StreamInterface $stream;
 
     /**

--- a/src/LimitStream.php
+++ b/src/LimitStream.php
@@ -14,13 +14,13 @@ final class LimitStream implements StreamInterface
     use StreamDecoratorTrait;
 
     /** @var int Offset to start reading from */
-    private $offset;
+    private int $offset;
 
     /** @var int Limit the number of bytes that can be read */
-    private $limit;
+    private int $limit;
 
     /** @var StreamInterface */
-    private $stream;
+    private StreamInterface $stream;
 
     /**
      * @param StreamInterface $stream Stream to wrap

--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -13,16 +13,16 @@ use Psr\Http\Message\StreamInterface;
 trait MessageTrait
 {
     /** @var string[][] Map of all registered headers, as original name => array of values */
-    private $headers = [];
+    private array $headers = [];
 
     /** @var string[] Map of lowercase header name => original name at registration */
-    private $headerNames = [];
+    private array $headerNames = [];
 
     /** @var string */
-    private $protocol = '1.1';
+    private string $protocol = '1.1';
 
     /** @var StreamInterface|null */
-    private $stream;
+    private ?StreamInterface $stream = null;
 
     public function getProtocolVersion(): string
     {

--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -18,10 +18,8 @@ trait MessageTrait
     /** @var string[] Map of lowercase header name => original name at registration */
     private array $headerNames = [];
 
-    /** @var string */
     private string $protocol = '1.1';
 
-    /** @var StreamInterface|null */
     private ?StreamInterface $stream = null;
 
     public function getProtocolVersion(): string

--- a/src/MultipartStream.php
+++ b/src/MultipartStream.php
@@ -14,10 +14,8 @@ final class MultipartStream implements StreamInterface
 {
     use StreamDecoratorTrait;
 
-    /** @var string */
     private string $boundary;
 
-    /** @var StreamInterface */
     private StreamInterface $stream;
 
     private const BOUNDARY_CHARS = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'()+_,-./:=? ";

--- a/src/MultipartStream.php
+++ b/src/MultipartStream.php
@@ -15,10 +15,10 @@ final class MultipartStream implements StreamInterface
     use StreamDecoratorTrait;
 
     /** @var string */
-    private $boundary;
+    private string $boundary;
 
     /** @var StreamInterface */
-    private $stream;
+    private StreamInterface $stream;
 
     private const BOUNDARY_CHARS = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'()+_,-./:=? ";
 

--- a/src/NoSeekStream.php
+++ b/src/NoSeekStream.php
@@ -13,7 +13,6 @@ final class NoSeekStream implements StreamInterface
 {
     use StreamDecoratorTrait;
 
-    /** @var StreamInterface */
     private StreamInterface $stream;
 
     public function seek(int $offset, int $whence = SEEK_SET): void

--- a/src/NoSeekStream.php
+++ b/src/NoSeekStream.php
@@ -14,7 +14,7 @@ final class NoSeekStream implements StreamInterface
     use StreamDecoratorTrait;
 
     /** @var StreamInterface */
-    private $stream;
+    private StreamInterface $stream;
 
     public function seek(int $offset, int $whence = SEEK_SET): void
     {

--- a/src/PumpStream.php
+++ b/src/PumpStream.php
@@ -25,16 +25,16 @@ final class PumpStream implements StreamInterface
     private $source;
 
     /** @var int|null */
-    private $size;
+    private ?int $size;
 
     /** @var int */
-    private $tellPos = 0;
+    private int $tellPos = 0;
 
     /** @var array */
-    private $metadata;
+    private array $metadata;
 
     /** @var BufferStream */
-    private $buffer;
+    private BufferStream $buffer;
 
     /**
      * @param (callable(): (string|false|null))|(callable(int): (string|false|null)) $source  Source of the stream data. The callable receives

--- a/src/PumpStream.php
+++ b/src/PumpStream.php
@@ -24,16 +24,12 @@ final class PumpStream implements StreamInterface
     /** @var callable|null */
     private $source;
 
-    /** @var int|null */
     private ?int $size;
 
-    /** @var int */
     private int $tellPos = 0;
 
-    /** @var array */
     private array $metadata;
 
-    /** @var BufferStream */
     private BufferStream $buffer;
 
     /**

--- a/src/Request.php
+++ b/src/Request.php
@@ -17,13 +17,13 @@ class Request implements RequestInterface
     use MessageTrait;
 
     /** @var string */
-    private $method;
+    private string $method;
 
     /** @var string|null */
-    private $requestTarget;
+    private ?string $requestTarget = null;
 
     /** @var UriInterface */
-    private $uri;
+    private UriInterface $uri;
 
     /**
      * @param string                               $method  HTTP method

--- a/src/Request.php
+++ b/src/Request.php
@@ -16,13 +16,10 @@ class Request implements RequestInterface
 {
     use MessageTrait;
 
-    /** @var string */
     private string $method;
 
-    /** @var string|null */
     private ?string $requestTarget = null;
 
-    /** @var UriInterface */
     private UriInterface $uri;
 
     /**

--- a/src/Response.php
+++ b/src/Response.php
@@ -78,10 +78,8 @@ class Response implements ResponseInterface
         511 => 'Network Authentication Required',
     ];
 
-    /** @var string */
     private string $reasonPhrase;
 
-    /** @var int */
     private int $statusCode;
 
     /**

--- a/src/Response.php
+++ b/src/Response.php
@@ -79,10 +79,10 @@ class Response implements ResponseInterface
     ];
 
     /** @var string */
-    private $reasonPhrase;
+    private string $reasonPhrase;
 
     /** @var int */
-    private $statusCode;
+    private int $statusCode;
 
     /**
      * @param int                                  $status  Status code

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -26,14 +26,8 @@ use Psr\Http\Message\UriInterface;
  */
 class ServerRequest extends Request implements ServerRequestInterface
 {
-    /**
-     * @var array
-     */
     private array $attributes = [];
 
-    /**
-     * @var array
-     */
     private array $cookieParams = [];
 
     /**
@@ -41,19 +35,10 @@ class ServerRequest extends Request implements ServerRequestInterface
      */
     private $parsedBody;
 
-    /**
-     * @var array
-     */
     private array $queryParams = [];
 
-    /**
-     * @var array
-     */
     private array $serverParams;
 
-    /**
-     * @var array
-     */
     private array $uploadedFiles = [];
 
     /**

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -29,12 +29,12 @@ class ServerRequest extends Request implements ServerRequestInterface
     /**
      * @var array
      */
-    private $attributes = [];
+    private array $attributes = [];
 
     /**
      * @var array
      */
-    private $cookieParams = [];
+    private array $cookieParams = [];
 
     /**
      * @var array|object|null
@@ -44,17 +44,17 @@ class ServerRequest extends Request implements ServerRequestInterface
     /**
      * @var array
      */
-    private $queryParams = [];
+    private array $queryParams = [];
 
     /**
      * @var array
      */
-    private $serverParams;
+    private array $serverParams;
 
     /**
      * @var array
      */
-    private $uploadedFiles = [];
+    private array $uploadedFiles = [];
 
     /**
      * @param string                               $method       HTTP method

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -22,17 +22,17 @@ class Stream implements StreamInterface
     /** @var resource */
     private $stream;
     /** @var int|null */
-    private $size;
+    private ?int $size = null;
     /** @var bool */
-    private $seekable;
+    private bool $seekable;
     /** @var bool */
-    private $readable;
+    private bool $readable;
     /** @var bool */
-    private $writable;
+    private bool $writable;
     /** @var string|null */
-    private $uri;
+    private ?string $uri = null;
     /** @var mixed[] */
-    private $customMetadata;
+    private array $customMetadata;
 
     /**
      * This constructor accepts an associative array of options.

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -21,15 +21,10 @@ class Stream implements StreamInterface
 
     /** @var resource */
     private $stream;
-    /** @var int|null */
     private ?int $size = null;
-    /** @var bool */
     private bool $seekable;
-    /** @var bool */
     private bool $readable;
-    /** @var bool */
     private bool $writable;
-    /** @var string|null */
     private ?string $uri = null;
     /** @var mixed[] */
     private array $customMetadata;

--- a/src/StreamWrapper.php
+++ b/src/StreamWrapper.php
@@ -17,10 +17,10 @@ final class StreamWrapper
     public $context;
 
     /** @var StreamInterface */
-    private $stream;
+    private StreamInterface $stream;
 
     /** @var string r, r+, or w */
-    private $mode;
+    private string $mode;
 
     /**
      * Returns a resource representing the stream.

--- a/src/StreamWrapper.php
+++ b/src/StreamWrapper.php
@@ -16,7 +16,6 @@ final class StreamWrapper
     /** @var resource */
     public $context;
 
-    /** @var StreamInterface */
     private StreamInterface $stream;
 
     /** @var string r, r+, or w */

--- a/src/UploadedFile.php
+++ b/src/UploadedFile.php
@@ -22,39 +22,18 @@ class UploadedFile implements UploadedFileInterface
         UPLOAD_ERR_EXTENSION => 'UPLOAD_ERR_EXTENSION',
     ];
 
-    /**
-     * @var string|null
-     */
     private ?string $clientFilename;
 
-    /**
-     * @var string|null
-     */
     private ?string $clientMediaType;
 
-    /**
-     * @var int
-     */
     private int $error;
 
-    /**
-     * @var string|null
-     */
     private ?string $file = null;
 
-    /**
-     * @var bool
-     */
     private bool $moved = false;
 
-    /**
-     * @var int|null
-     */
     private ?int $size;
 
-    /**
-     * @var StreamInterface|null
-     */
     private ?StreamInterface $stream = null;
 
     /**

--- a/src/UploadedFile.php
+++ b/src/UploadedFile.php
@@ -25,37 +25,37 @@ class UploadedFile implements UploadedFileInterface
     /**
      * @var string|null
      */
-    private $clientFilename;
+    private ?string $clientFilename;
 
     /**
      * @var string|null
      */
-    private $clientMediaType;
+    private ?string $clientMediaType;
 
     /**
      * @var int
      */
-    private $error;
+    private int $error;
 
     /**
      * @var string|null
      */
-    private $file;
+    private ?string $file = null;
 
     /**
      * @var bool
      */
-    private $moved = false;
+    private bool $moved = false;
 
     /**
      * @var int|null
      */
-    private $size;
+    private ?int $size;
 
     /**
      * @var StreamInterface|null
      */
-    private $stream;
+    private ?StreamInterface $stream = null;
 
     /**
      * @param StreamInterface|string|resource $streamOrFile

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -54,25 +54,25 @@ class Uri implements UriInterface, \JsonSerializable
     private const QUERY_SEPARATORS_REPLACEMENT = ['=' => '%3D', '&' => '%26', '+' => '%2B'];
 
     /** @var string Uri scheme. */
-    private $scheme = '';
+    private string $scheme = '';
 
     /** @var string Uri user info. */
-    private $userInfo = '';
+    private string $userInfo = '';
 
     /** @var string Uri host. */
-    private $host = '';
+    private string $host = '';
 
     /** @var int|null Uri port. */
-    private $port;
+    private ?int $port = null;
 
     /** @var string Uri path. */
-    private $path = '';
+    private string $path = '';
 
     /** @var string Uri query string. */
-    private $query = '';
+    private string $query = '';
 
     /** @var string Uri fragment. */
-    private $fragment = '';
+    private string $fragment = '';
 
     public function __construct(string $uri = '')
     {


### PR DESCRIPTION
Adds PHP 7.4-compatible native property types to internal PSR-7 message, stream, request, response, and URI state while leaving resource, callable, dynamic, and union-shaped properties untyped to preserve existing runtime behavior.