### PR TITLE
Clarify 3.0 URI host validation notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reject invalid uploaded file trees and invalid parsed body values
 - Reject malformed uploaded file specifications missing `tmp_name`, `size`, or `error`
 - Normalize multiple leading slashes to one slash in `Uri::getPath()` and URI-derived `Request::getRequestTarget()` values
-- Harden URI host validation for URI delimiters, backslashes, unbracketed IPv6, and malformed IP literals, and reject schemes that do not begin with a letter
+- Harden URI host validation for delimiters, backslashes, and invalid IPv6/IP literals; reject schemes not beginning with a letter
 - Redact all non-empty URI userinfo in `Utils::redactUserInfo()`
 - Tighten `ServerRequest::getUriFromGlobals()` validation for malformed `HTTP_HOST` and `SERVER_PORT` values
 - Stop preserving malformed `Host` headers when building server requests from globals

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reject invalid uploaded file trees and invalid parsed body values
 - Reject malformed uploaded file specifications missing `tmp_name`, `size`, or `error`
 - Normalize multiple leading slashes to one slash in `Uri::getPath()` and URI-derived `Request::getRequestTarget()` values
-- Harden URI host and scheme validation, including rejecting schemes that do not begin with a letter
+- Harden URI host validation for URI delimiters, backslashes, unbracketed IPv6, and malformed IP literals, and reject schemes that do not begin with a letter
 - Redact all non-empty URI userinfo in `Utils::redactUserInfo()`
 - Tighten `ServerRequest::getUriFromGlobals()` validation for malformed `HTTP_HOST` and `SERVER_PORT` values
 - Stop preserving malformed `Host` headers when building server requests from globals

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -162,10 +162,10 @@ $request = $request->withParsedBody(['name' => 'value']);
 
 #### URI Host and Scheme Validation
 
-URI hosts containing control characters, whitespace, URI delimiters, backslashes,
-ambiguous port separators, or malformed IP-literal brackets are no longer
-accepted. URI schemes containing whitespace or control characters are also no
-longer accepted.
+URI hosts containing URI delimiters, backslashes, embedded ports passed to
+`withHost()`, malformed IP-literal brackets, unbracketed IPv6, or other
+malformed host forms are no longer accepted. URI schemes containing whitespace
+or control characters are also no longer accepted.
 
 If you previously passed a host and port together to `withHost()`, split them
 between `withHost()` and `withPort()`:


### PR DESCRIPTION
Follow-up to the URI host validation backport. Keeps the 3.0 notes focused on 3.0-only host grammar changes.