### PR TITLE
Expand host validation coverage

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -202,9 +202,10 @@ The stricter validation also applies when a request is created or modified from
 a custom `UriInterface` implementation and its host is used to generate or
 update a `Host` header.
 
-`ServerRequest::getUriFromGlobals()` now ignores malformed `HTTP_HOST` values
-and falls back to `SERVER_NAME`, then `SERVER_ADDR`, then the existing default
-host behavior.
+`ServerRequest::getUriFromGlobals()` now falls back to `SERVER_NAME`, then
+`SERVER_ADDR`, then the existing default host behavior for malformed
+`HTTP_HOST` values. It also rejects zero-port `HTTP_HOST` authorities and
+malformed `SERVER_PORT` values when reconstructing the URI from server globals.
 
 Applications that need to reject malformed inbound `Host` headers should
 validate the request host before calling `getUriFromGlobals()` or inspect the

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -119,6 +119,7 @@ class MessageTest extends TestCase
 
     public static function invalidHostHeaderProvider(): iterable
     {
+        yield 'empty' => [''];
         yield 'userinfo delimiter' => ['trusted.example@evil.example'];
         yield 'path delimiter' => ['example.com/path'];
         yield 'query delimiter' => ['example.com?query'];
@@ -128,12 +129,31 @@ class MessageTest extends TestCase
         yield 'tab' => ["bad\thost"];
         yield 'control character' => ['example'.chr(1).'com'];
         yield 'delete' => ['example'.chr(0x7F).'com'];
+        yield 'empty port' => ['example.com:'];
+        yield 'non numeric port' => ['example.com:abc'];
+        yield 'leading plus port' => ['example.com:+443'];
+        yield 'negative port' => ['example.com:-1'];
+        yield 'out of range port' => ['example.com:65536'];
         yield 'multiple ports' => ['example.com:443:8443'];
         yield 'missing closing bracket' => ['[::1'];
         yield 'unexpected bracket suffix' => ['[::1]x'];
         yield 'invalid ip literal' => ['[bad]'];
+        yield 'ipv6 empty port' => ['[::1]:'];
+        yield 'ipv6 non numeric port' => ['[::1]:abc'];
+        yield 'ipv6 out of range port' => ['[::1]:65536'];
+        yield 'empty ipvfuture address' => ['[v7.]'];
         yield 'unexpected opening bracket' => ['foo[bar'];
         yield 'unexpected closing bracket' => ['foo]bar'];
+    }
+
+    /**
+     * @dataProvider invalidHostHeaderProvider
+     */
+    public function testParseOptionsAsteriskRejectsInvalidHostHeader(string $host): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        Psr7\Message::parseRequest("OPTIONS * HTTP/1.1\r\nHost: {$host}\r\n\r\n");
     }
 
     /**

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -1006,9 +1006,19 @@ class ServerRequestTest extends TestCase
         yield 'backslash delimiter' => ['example.com\\evil'];
         yield 'space' => ['bad host'];
         yield 'newline' => ["bad.example\r\nX-Evil: yes"];
+        yield 'empty port' => ['bad.example:'];
+        yield 'non numeric port' => ['bad.example:abc'];
+        yield 'leading plus port' => ['bad.example:+443'];
+        yield 'negative port' => ['bad.example:-1'];
+        yield 'out of range port' => ['bad.example:65536'];
         yield 'multiple ports' => ['bad.example:443:8443'];
         yield 'zero port' => ['bad.example:0'];
         yield 'zero padded zero port' => ['bad.example:0000'];
+        yield 'ipv6 zero port' => ['[::1]:0'];
+        yield 'ipv6 zero padded zero port' => ['[::1]:0000'];
+        yield 'ipv6 non numeric port' => ['[::1]:abc'];
+        yield 'ipv6 out of range port' => ['[::1]:65536'];
+        yield 'unexpected bracket suffix' => ['[::1]x'];
         yield 'invalid ip literal' => ['[bad]'];
         yield 'unexpected opening bracket' => ['foo[bar'];
         yield 'unexpected closing bracket' => ['foo]bar'];
@@ -1276,6 +1286,36 @@ PHP
         $_SERVER = [
             'REQUEST_URI' => '/',
             'HTTP_HOST' => 'bad.example:443:8443',
+            'SERVER_NAME' => 'good.example',
+            'SERVER_PORT' => '443',
+            'HTTPS' => 'on',
+        ];
+
+        $_COOKIE = $_POST = $_GET = $_FILES = [];
+
+        $server = ServerRequest::fromGlobals();
+
+        self::assertSame('good.example', $server->getUri()->getHost());
+        self::assertSame('good.example', $server->getHeaderLine('Host'));
+        self::assertSame(['native'], $server->getHeader('X-Native'));
+    }
+
+    /**
+     * @runInSeparateProcess
+     *
+     * @preserveGlobalState disabled
+     */
+    public function testFromGlobalsDropsZeroPortApacheHostHeaderWhenUriFallsBack(): void
+    {
+        if (\function_exists('apache_request_headers')) {
+            self::markTestSkipped('apache_request_headers() is already available.');
+        }
+
+        eval('function apache_request_headers(): array { return ["Host" => "bad.example:0", "X-Native" => "native"]; }');
+
+        $_SERVER = [
+            'REQUEST_URI' => '/',
+            'HTTP_HOST' => 'bad.example:0',
             'SERVER_NAME' => 'good.example',
             'SERVER_PORT' => '443',
             'HTTPS' => 'on',

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -267,6 +267,26 @@ class UriTest extends TestCase
     }
 
     /**
+     * @dataProvider getValidHosts
+     */
+    public function testHostMayBeValid(string $host, string $expectedHost): void
+    {
+        $uri = (new Uri())->withHost($host);
+
+        self::assertSame($expectedHost, $uri->getHost());
+    }
+
+    public static function getValidHosts(): iterable
+    {
+        yield 'empty' => ['', ''];
+        yield 'mixed case' => ['Example.COM', 'example.com'];
+        yield 'underscore' => ['foo_bar.example', 'foo_bar.example'];
+        yield 'sub-delims' => ['foo!$&\'()*+,;=.example', 'foo!$&\'()*+,;=.example'];
+        yield 'ipv6 literal' => ['[::1]', '[::1]'];
+        yield 'ipvfuture literal' => ['[v7.a:b]', '[v7.a:b]'];
+    }
+
+    /**
      * @dataProvider getInvalidHosts
      */
     public function testHostMustBeValid(string $host): void
@@ -292,8 +312,33 @@ class UriTest extends TestCase
         yield 'unbracketed IPv6' => ['::1'];
         yield 'bracketed IPv6 with port' => ['[::1]:80'];
         yield 'unterminated bracketed IPv6' => ['[::1'];
+        yield 'unexpected bracket suffix' => ['[::1]x'];
+        yield 'empty ip literal' => ['[]'];
+        yield 'invalid ip literal' => ['[bad]'];
+        yield 'empty ipvfuture address' => ['[v7.]'];
+        yield 'invalid ipvfuture version' => ['[vg.foo]'];
         yield 'unbalanced opening bracket' => ['example[com'];
         yield 'unbalanced closing bracket' => ['example]com'];
+    }
+
+    /**
+     * @dataProvider getInvalidHostParts
+     */
+    public function testFromPartsRejectsInvalidHost(string $host): void
+    {
+        $this->expectException(MalformedUriException::class);
+
+        Uri::fromParts(['scheme' => 'http', 'host' => $host]);
+    }
+
+    public static function getInvalidHostParts(): iterable
+    {
+        yield 'path delimiter' => ['example.com/path'];
+        yield 'query delimiter' => ['example.com?query'];
+        yield 'fragment delimiter' => ['example.com#fragment'];
+        yield 'userinfo delimiter' => ['user@example.com'];
+        yield 'backslash' => ['example\\com'];
+        yield 'invalid ip literal' => ['[bad]'];
     }
 
     public function testCanParseFalseyUriPartsExceptScheme(): void


### PR DESCRIPTION
This expands the public-surface coverage for 3.0 Host validation before the follow-up refactors. It also updates the upgrade guide wording for ServerRequest::getUriFromGlobals() so it describes malformed HTTP_HOST fallback, zero-port rejection, and malformed SERVER_PORT behavior directly.