### PR TITLE
Apply message host authority semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Harden URI host validation for delimiters, backslashes, and invalid IPv6/IP literals; reject schemes not beginning with a letter
 - Redact all non-empty URI userinfo in `Utils::redactUserInfo()`
 - Reject zero-port `HTTP_HOST` authorities and malformed `SERVER_PORT` values in `ServerRequest::getUriFromGlobals()`
+- Reject zero-port `Host` authorities and normalize leading-zero `Host` ports when deriving request URIs in `Message::parseRequest()`
 - Normalize server request URI reconstruction from globals, including `REQUEST_METHOD` values used for request-target parsing
 - Accept `OPTIONS *` and `CONNECT` authority-form request targets in `Message::parseRequest()`
 - Reject malformed HTTP start-line fields

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Harden URI host validation for delimiters, backslashes, and invalid IPv6/IP literals; reject schemes not beginning with a letter
 - Redact all non-empty URI userinfo in `Utils::redactUserInfo()`
 - Reject zero-port `HTTP_HOST` authorities and malformed `SERVER_PORT` values in `ServerRequest::getUriFromGlobals()`
-- Reject zero-port `Host` authorities and normalize leading-zero `Host` ports when deriving request URIs in `Message::parseRequest()`
+- Reject zero-port `Host` authorities and normalize leading-zero ports in `Message::parseRequest()` URI derivation
 - Normalize server request URI reconstruction from globals, including `REQUEST_METHOD` values used for request-target parsing
 - Accept `OPTIONS *` and `CONNECT` authority-form request targets in `Message::parseRequest()`
 - Reject malformed HTTP start-line fields

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -207,6 +207,10 @@ update a `Host` header.
 `HTTP_HOST` values. It also rejects zero-port `HTTP_HOST` authorities and
 malformed `SERVER_PORT` values when reconstructing the URI from server globals.
 
+`Message::parseRequest()` now applies 3.0 authority rules when deriving a URI
+from an origin-form or asterisk-form request target. Host ports with leading
+zeroes are normalized for URI reconstruction, and port zero is rejected.
+
 Applications that need to reject malformed inbound `Host` headers should
 validate the request host before calling `getUriFromGlobals()` or inspect the
 original server parameters.

--- a/src/Message.php
+++ b/src/Message.php
@@ -245,9 +245,28 @@ final class Message
             return $path;
         }
 
-        $scheme = substr($host, -4) === ':443' ? 'https' : 'http';
+        [$authorityHost, $port] = self::parseHostHeaderAuthority($host);
+        $scheme = $port === 443 ? 'https' : 'http';
 
-        return $scheme.'://'.$host.'/'.ltrim($path, '/');
+        return $scheme.'://'.self::composeAuthority($authorityHost, $port).'/'.ltrim($path, '/');
+    }
+
+    /**
+     * @return array{0: string, 1: int|null}
+     */
+    private static function parseHostHeaderAuthority(string $authority): array
+    {
+        $parsed = Rfc7230::parseHostHeader($authority);
+        if ($parsed === null) {
+            throw new \InvalidArgumentException('Invalid request string');
+        }
+
+        return $parsed;
+    }
+
+    private static function composeAuthority(string $host, ?int $port): string
+    {
+        return $host.($port !== null ? ':'.$port : '');
     }
 
     /**
@@ -267,9 +286,11 @@ final class Message
         }
 
         $host = $headers[reset($hostKey)][0];
-        if (!is_string($host) || Rfc7230::parseHostHeader($host, true) === null) {
+        if (!is_string($host)) {
             throw new \InvalidArgumentException('Invalid request string');
         }
+
+        self::parseHostHeaderAuthority($host);
 
         return $host;
     }
@@ -284,9 +305,10 @@ final class Message
             return '';
         }
 
-        $scheme = substr($host, -4) === ':443' ? 'https' : 'http';
+        [$authorityHost, $port] = self::parseHostHeaderAuthority($host);
+        $scheme = $port === 443 ? 'https' : 'http';
 
-        return $scheme.'://'.$host;
+        return $scheme.'://'.self::composeAuthority($authorityHost, $port);
     }
 
     /**
@@ -362,55 +384,21 @@ final class Message
             return null;
         }
 
-        $host = $target;
-        $port = null;
-
-        if ($target === '') {
+        $parsed = Rfc7230::parseHostHeader($target);
+        if ($parsed === null) {
             return null;
         }
 
-        if ($target[0] === '[') {
-            $closingBracket = strpos($target, ']');
-            if ($closingBracket === false || !isset($target[$closingBracket + 1]) || $target[$closingBracket + 1] !== ':') {
-                return null;
-            }
-
-            $host = substr($target, 0, $closingBracket + 1);
-            $port = self::parseAuthorityPort(substr($target, $closingBracket + 2));
-        } elseif (false !== ($colon = strrpos($target, ':'))) {
-            $host = substr($target, 0, $colon);
-            $port = self::parseAuthorityPort(substr($target, $colon + 1));
-        }
-
-        if ($host === '' || $port === null) {
+        [$host, $port] = $parsed;
+        if ($port === null) {
             return null;
         }
 
         try {
-            Uri::assertValidHost($host);
-
-            return new Uri('//'.$host.':'.$port);
+            return new Uri('//'.self::composeAuthority($host, $port));
         } catch (\InvalidArgumentException $e) {
             return null;
         }
-    }
-
-    private static function parseAuthorityPort(string $port): ?int
-    {
-        if ($port === '' || !ctype_digit($port)) {
-            return null;
-        }
-
-        $port = ltrim($port, '0');
-        if ($port === '') {
-            return null;
-        }
-
-        if (strlen($port) > 5 || (int) $port > 0xFFFF) {
-            return null;
-        }
-
-        return (int) $port;
     }
 
     /**

--- a/src/Rfc7230.php
+++ b/src/Rfc7230.php
@@ -28,7 +28,7 @@ final class Rfc7230
     /**
      * @return array{0: string, 1: int|null}|null
      */
-    public static function parseHostHeader(string $authority, bool $allowPortZero): ?array
+    public static function parseHostHeader(string $authority): ?array
     {
         if ($authority === '') {
             return null;
@@ -50,14 +50,14 @@ final class Rfc7230
                     return null;
                 }
 
-                $port = self::parseAuthorityPort(substr($remainder, 1), $allowPortZero);
+                $port = self::parseAuthorityPort(substr($remainder, 1));
                 if ($port === null) {
                     return null;
                 }
             }
         } elseif (false !== ($colon = strpos($authority, ':'))) {
             $host = substr($authority, 0, $colon);
-            $port = self::parseAuthorityPort(substr($authority, $colon + 1), $allowPortZero);
+            $port = self::parseAuthorityPort(substr($authority, $colon + 1));
             if ($port === null) {
                 return null;
             }
@@ -90,7 +90,7 @@ final class Rfc7230
         return strpos($host, ':') === false;
     }
 
-    private static function parseAuthorityPort(string $port, bool $allowPortZero): ?int
+    private static function parseAuthorityPort(string $port): ?int
     {
         if ($port === '' || !ctype_digit($port)) {
             return null;
@@ -98,7 +98,7 @@ final class Rfc7230
 
         $normalized = ltrim($port, '0');
         if ($normalized === '') {
-            return $allowPortZero ? 0 : null;
+            return null;
         }
 
         if (strlen($normalized) > 5 || (int) $normalized > 0xFFFF) {

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -347,7 +347,7 @@ class ServerRequest extends Request implements ServerRequestInterface
      */
     private static function extractHostAndPortFromAuthority(string $authority): array
     {
-        return Rfc7230::parseHostHeader($authority, false) ?? [null, null];
+        return Rfc7230::parseHostHeader($authority) ?? [null, null];
     }
 
     private static function parseServerPort(string $port): int

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -129,6 +129,8 @@ class MessageTest extends TestCase
         yield 'tab' => ["bad\thost"];
         yield 'control character' => ['example'.chr(1).'com'];
         yield 'delete' => ['example'.chr(0x7F).'com'];
+        yield 'zero port' => ['foo.com:0'];
+        yield 'zero padded zero port' => ['foo.com:0000'];
         yield 'empty port' => ['example.com:'];
         yield 'non numeric port' => ['example.com:abc'];
         yield 'leading plus port' => ['example.com:+443'];
@@ -138,6 +140,8 @@ class MessageTest extends TestCase
         yield 'missing closing bracket' => ['[::1'];
         yield 'unexpected bracket suffix' => ['[::1]x'];
         yield 'invalid ip literal' => ['[bad]'];
+        yield 'ipv6 zero port' => ['[::1]:0'];
+        yield 'ipv6 zero padded zero port' => ['[::1]:0000'];
         yield 'ipv6 empty port' => ['[::1]:'];
         yield 'ipv6 non numeric port' => ['[::1]:abc'];
         yield 'ipv6 out of range port' => ['[::1]:65536'];
@@ -172,6 +176,10 @@ class MessageTest extends TestCase
         yield 'host' => ['foo.com', 'http://foo.com/'];
         yield 'https default port' => ['foo.com:443', 'https://foo.com/'];
         yield 'non-default port' => ['foo.com:8080', 'http://foo.com:8080/'];
+        yield 'https leading zero default port' => ['foo.com:000443', 'https://foo.com/'];
+        yield 'http leading zero default port' => ['foo.com:000080', 'http://foo.com/'];
+        yield 'leading zero non-default port' => ['foo.com:0008080', 'http://foo.com:8080/'];
+        yield 'maximum port' => ['foo.com:65535', 'http://foo.com:65535/'];
         yield 'ipv6' => ['[::1]', 'http://[::1]/'];
         yield 'ipv6 port' => ['[::1]:443', 'https://[::1]/'];
     }
@@ -206,6 +214,24 @@ class MessageTest extends TestCase
         self::assertSame('foo.com', $request->getHeaderLine('Host'));
         self::assertSame('', (string) $request->getBody());
         self::assertSame('http://foo.com', (string) $request->getUri());
+    }
+
+    public function testParsesOptionsAsteriskFormRequestTargetWithLeadingZeroHttpsPort(): void
+    {
+        $request = Psr7\Message::parseRequest("OPTIONS * HTTP/1.1\r\nHost: foo.com:000443\r\n\r\n");
+
+        self::assertSame('*', $request->getRequestTarget());
+        self::assertSame('foo.com:000443', $request->getHeaderLine('Host'));
+        self::assertSame('https://foo.com', (string) $request->getUri());
+    }
+
+    public function testParsesOptionsAsteriskFormRequestTargetWithIpv6HttpsPort(): void
+    {
+        $request = Psr7\Message::parseRequest("OPTIONS * HTTP/1.1\r\nHost: [::1]:443\r\n\r\n");
+
+        self::assertSame('*', $request->getRequestTarget());
+        self::assertSame('[::1]:443', $request->getHeaderLine('Host'));
+        self::assertSame('https://[::1]', (string) $request->getUri());
     }
 
     public function testParsesOptionsAsteriskFormRequestTargetWithoutHost(): void
@@ -335,6 +361,7 @@ class MessageTest extends TestCase
         yield 'mixed-case connect authority-form' => ['CoNnEcT up.example:443 HTTP/1.1'];
         yield 'connect missing port' => ['CONNECT up.example HTTP/1.1'];
         yield 'connect zero port' => ['CONNECT up.example:0 HTTP/1.1'];
+        yield 'connect ipv6 zero port' => ['CONNECT [::1]:0 HTTP/1.1'];
         yield 'connect user info' => ['CONNECT user@up.example:443 HTTP/1.1'];
         yield 'connect path' => ['CONNECT up.example:443/ HTTP/1.1'];
         yield 'connect query' => ['CONNECT up.example:443?x=1 HTTP/1.1'];


### PR DESCRIPTION
This applies the stricter 3.0 Host authority rules to raw request parsing. Message::parseRequest() now rejects zero-port Host authorities, normalizes leading-zero Host ports while reconstructing URIs, and uses the shared RFC 7230 authority parser for CONNECT targets.