### PR TITLE
Reject duplicate raw Host headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Redact all non-empty URI userinfo in `Utils::redactUserInfo()`
 - Reject zero-port `HTTP_HOST` authorities and malformed `SERVER_PORT` values in `ServerRequest::getUriFromGlobals()`
 - Reject zero-port `Host` authorities and normalize leading-zero ports in `Message::parseRequest()` URI derivation
+- Reject duplicate `Host` field lines in `Message::parseRequest()`
 - Normalize server request URI reconstruction from globals, including `REQUEST_METHOD` values used for request-target parsing
 - Accept `OPTIONS *` and `CONNECT` authority-form request targets in `Message::parseRequest()`
 - Reject malformed HTTP start-line fields

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -210,6 +210,8 @@ malformed `SERVER_PORT` values when reconstructing the URI from server globals.
 `Message::parseRequest()` now applies 3.0 authority rules when deriving a URI
 from an origin-form or asterisk-form request target. Host ports with leading
 zeroes are normalized for URI reconstruction, and port zero is rejected.
+It also rejects duplicate `Host` field lines, including case-insensitive
+duplicates.
 
 Applications that need to reject malformed inbound `Host` headers should
 validate the request host before calling `getUriFromGlobals()` or inspect the

--- a/src/Message.php
+++ b/src/Message.php
@@ -274,23 +274,44 @@ final class Message
      */
     private static function getHostFromHeaders(array $headers): ?string
     {
-        $hostKey = array_filter(array_keys($headers), function ($k): bool {
-            // Numeric array keys are converted to int by PHP.
-            $k = (string) $k;
-
-            return strtolower($k) === 'host';
-        });
-
-        if (!$hostKey) {
+        $host = self::getSingleHostHeader($headers);
+        if ($host === null) {
             return null;
         }
 
-        $host = $headers[reset($hostKey)][0];
+        self::parseHostHeaderAuthority($host);
+
+        return $host;
+    }
+
+    /**
+     * @param array $headers Array of headers (each value an array).
+     */
+    private static function getSingleHostHeader(array $headers): ?string
+    {
+        $host = null;
+        $found = false;
+
+        foreach ($headers as $name => $values) {
+            if (strtolower((string) $name) !== 'host') {
+                continue;
+            }
+
+            if ($found || !is_array($values) || count($values) !== 1) {
+                throw new \InvalidArgumentException('Invalid request string');
+            }
+
+            $found = true;
+            $host = reset($values);
+        }
+
+        if (!$found) {
+            return null;
+        }
+
         if (!is_string($host)) {
             throw new \InvalidArgumentException('Invalid request string');
         }
-
-        self::parseHostHeaderAuthority($host);
 
         return $host;
     }
@@ -323,6 +344,8 @@ final class Message
         if (!preg_match('/^(?P<method>[!#$%&\'*+.^_`|~0-9A-Za-z-]+) (?P<target>[^\x00-\x20\x7F]+) HTTP\/(?P<version>\d+(?:\.\d+)?)$/D', $data['start-line'], $matches)) {
             throw new \InvalidArgumentException('Invalid request string');
         }
+
+        self::getSingleHostHeader($data['headers']);
 
         if ($matches['target'][0] === '/') {
             return new Request(

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -151,6 +151,46 @@ class MessageTest extends TestCase
     }
 
     /**
+     * @dataProvider duplicateHostHeaderProvider
+     */
+    public function testParseRequestRejectsDuplicateHostHeaders(string $message): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        Psr7\Message::parseRequest($message);
+    }
+
+    public static function duplicateHostHeaderProvider(): iterable
+    {
+        yield 'duplicate same case' => [
+            "GET / HTTP/1.1\r\nHost: one.example\r\nHost: two.example\r\n\r\n",
+        ];
+
+        yield 'duplicate different case' => [
+            "GET / HTTP/1.1\r\nHost: one.example\r\nhost: two.example\r\n\r\n",
+        ];
+
+        yield 'duplicate on options asterisk' => [
+            "OPTIONS * HTTP/1.1\r\nHost: one.example\r\nHost: two.example\r\n\r\n",
+        ];
+
+        yield 'duplicate on absolute form' => [
+            "GET https://up.example/ HTTP/1.1\r\nHost: one.example\r\nHost: two.example\r\n\r\n",
+        ];
+
+        yield 'duplicate on connect authority form' => [
+            "CONNECT up.example:443 HTTP/1.1\r\nHost: one.example\r\nHost: two.example\r\n\r\n",
+        ];
+    }
+
+    public function testParseRequestUriRejectsMultipleHostValues(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        Psr7\Message::parseRequestUri('/', ['Host' => ['one.example', 'two.example']]);
+    }
+
+    /**
      * @dataProvider invalidHostHeaderProvider
      */
     public function testParseOptionsAsteriskRejectsInvalidHostHeader(string $host): void


### PR DESCRIPTION
Message::parseRequest() now rejects duplicate raw Host field lines before constructing a request. The check is case-insensitive and also rejects multiple values under one Host key when deriving request URIs, matching the stricter 3.0 Host authority parsing rules documented for raw request parsing.