### PR TITLE
Make Rfc3986 non-instantiable

### DIFF
--- a/src/Rfc3986.php
+++ b/src/Rfc3986.php
@@ -9,6 +9,10 @@ namespace GuzzleHttp\Psr7;
  */
 final class Rfc3986
 {
+    private function __construct()
+    {
+    }
+
     /**
      * Sub-delims for use in a regex.
      *


### PR DESCRIPTION
Rfc3986 is an internal static utility class, so it now has a private constructor like Rfc7230. This makes both RFC helper classes consistently non-instantiable without changing runtime behavior.