### PR TITLE
Centralize host validation in Rfc3986

### DIFF
--- a/src/Rfc3986.php
+++ b/src/Rfc3986.php
@@ -44,13 +44,6 @@ final class Rfc3986
         return strpos($host, ':') === false;
     }
 
-    public static function assertValidHost(string $host): void
-    {
-        if (!self::isValidHost($host)) {
-            throw new \InvalidArgumentException(sprintf('Invalid host: "%s"', $host));
-        }
-    }
-
     private static function isValidIpLiteralHost(string $host): bool
     {
         if ($host[0] !== '[' || substr($host, -1) !== ']') {

--- a/src/Rfc3986.php
+++ b/src/Rfc3986.php
@@ -26,4 +26,42 @@ final class Rfc3986
      * @see https://datatracker.ietf.org/doc/html/rfc3986#section-2.3
      */
     public const CHAR_UNRESERVED = 'a-zA-Z0-9_\-\.~';
+
+    public static function isValidHost(string $host): bool
+    {
+        if ($host === '') {
+            return true;
+        }
+
+        if (preg_match('/[\x00-\x20\x7F\/\?#@\\\\]/', $host)) {
+            return false;
+        }
+
+        if (strpos($host, '[') !== false || strpos($host, ']') !== false) {
+            return self::isValidIpLiteralHost($host);
+        }
+
+        return strpos($host, ':') === false;
+    }
+
+    public static function assertValidHost(string $host): void
+    {
+        if (!self::isValidHost($host)) {
+            throw new \InvalidArgumentException(sprintf('Invalid host: "%s"', $host));
+        }
+    }
+
+    private static function isValidIpLiteralHost(string $host): bool
+    {
+        if ($host[0] !== '[' || substr($host, -1) !== ']') {
+            return false;
+        }
+
+        $address = substr($host, 1, -1);
+        if (\filter_var($address, \FILTER_VALIDATE_IP, \FILTER_FLAG_IPV6) !== false) {
+            return true;
+        }
+
+        return preg_match('/^v[0-9a-f]+\.['.self::CHAR_UNRESERVED.self::CHAR_SUB_DELIMS.':]+$/iD', $address) === 1;
+    }
 }

--- a/src/Rfc7230.php
+++ b/src/Rfc7230.php
@@ -63,31 +63,11 @@ final class Rfc7230
             }
         }
 
-        if ($host === '' || !self::isValidHostHeaderHost($host)) {
+        if ($host === '' || !Rfc3986::isValidHost($host)) {
             return null;
         }
 
         return [$host, $port];
-    }
-
-    private static function isValidHostHeaderHost(string $host): bool
-    {
-        if (preg_match('/[\x00-\x20\x7F\/\?#@\\\\]/', $host)) {
-            return false;
-        }
-
-        if (strpos($host, '[') !== false || strpos($host, ']') !== false) {
-            if ($host[0] !== '[' || substr($host, -1) !== ']') {
-                return false;
-            }
-
-            $address = substr($host, 1, -1);
-
-            return filter_var($address, \FILTER_VALIDATE_IP, \FILTER_FLAG_IPV6) !== false
-                || preg_match('/^v[0-9a-f]+\.['.Rfc3986::CHAR_UNRESERVED.Rfc3986::CHAR_SUB_DELIMS.':]+$/iD', $address) === 1;
-        }
-
-        return strpos($host, ':') === false;
     }
 
     private static function parseAuthorityPort(string $port): ?int

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -402,7 +402,9 @@ class Uri implements UriInterface, \JsonSerializable
      */
     public static function assertValidHost(string $host): void
     {
-        Rfc3986::assertValidHost($host);
+        if (!Rfc3986::isValidHost($host)) {
+            throw new \InvalidArgumentException(sprintf('Invalid host: "%s"', $host));
+        }
     }
 
     public function getScheme(): string

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -402,23 +402,7 @@ class Uri implements UriInterface, \JsonSerializable
      */
     public static function assertValidHost(string $host): void
     {
-        if ($host === '') {
-            return;
-        }
-
-        if (preg_match('/[\x00-\x20\x7F\/\?#@\\\\]/', $host)) {
-            throw new \InvalidArgumentException(sprintf('Invalid host: "%s"', $host));
-        }
-
-        if (strpos($host, '[') !== false || strpos($host, ']') !== false) {
-            self::assertValidIpLiteralHost($host);
-
-            return;
-        }
-
-        if (strpos($host, ':') !== false) {
-            throw new \InvalidArgumentException(sprintf('Invalid host: "%s"', $host));
-        }
+        Rfc3986::assertValidHost($host);
     }
 
     public function getScheme(): string
@@ -657,24 +641,6 @@ class Uri implements UriInterface, \JsonSerializable
         self::assertValidHost($host);
 
         return $host;
-    }
-
-    private static function assertValidIpLiteralHost(string $host): void
-    {
-        if ($host[0] !== '[' || substr($host, -1) !== ']') {
-            throw new \InvalidArgumentException(sprintf('Invalid host: "%s"', $host));
-        }
-
-        $address = substr($host, 1, -1);
-        if (\filter_var($address, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false) {
-            return;
-        }
-
-        if (preg_match('/^v[0-9a-f]+\.['.Rfc3986::CHAR_UNRESERVED.Rfc3986::CHAR_SUB_DELIMS.':]+$/iD', $address)) {
-            return;
-        }
-
-        throw new \InvalidArgumentException(sprintf('Invalid host: "%s"', $host));
     }
 
     /**


### PR DESCRIPTION
Host syntax validation now lives in Rfc3986 and is shared by Uri and Rfc7230. Uri keeps its assertion API and exception behavior, while Rfc7230 uses the lower-level RFC 3986 predicate directly to avoid duplicated validation logic and keep the dependency direction toward the shared helper.