### PR TITLE
Extract scheme validation into Rfc3986

### DIFF
--- a/src/Rfc3986.php
+++ b/src/Rfc3986.php
@@ -27,6 +27,11 @@ final class Rfc3986
      */
     public const CHAR_UNRESERVED = 'a-zA-Z0-9_\-\.~';
 
+    public static function isValidScheme(string $scheme): bool
+    {
+        return $scheme === '' || preg_match('/^[A-Za-z][A-Za-z0-9.+-]*$/D', $scheme) === 1;
+    }
+
     public static function isValidHost(string $host): bool
     {
         if ($host === '') {

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -615,7 +615,7 @@ class Uri implements UriInterface, \JsonSerializable
     {
         $scheme = \strtr($scheme, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz');
 
-        if ($scheme !== '' && !preg_match('/^[a-z][a-z0-9.+-]*$/D', $scheme)) {
+        if (!Rfc3986::isValidScheme($scheme)) {
             throw new \InvalidArgumentException(sprintf('Invalid scheme: "%s"', $scheme));
         }
 

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -213,6 +213,23 @@ class UriTest extends TestCase
     }
 
     /**
+     * @dataProvider getValidSchemes
+     */
+    public function testSchemeMayBeValid(string $scheme, string $expected): void
+    {
+        $uri = (new Uri())->withScheme($scheme);
+
+        self::assertSame($expected, $uri->getScheme());
+    }
+
+    public static function getValidSchemes(): iterable
+    {
+        yield 'single letter' => ['a', 'a'];
+        yield 'mixed case normalized' => ['HtTpS', 'https'];
+        yield 'plus dot dash digit' => ['a+b.c-1', 'a+b.c-1'];
+    }
+
+    /**
      * @dataProvider getInvalidSchemes
      */
     public function testSchemeMustBeValid(string $scheme): void
@@ -230,6 +247,9 @@ class UriTest extends TestCase
 
         yield 'ascii 0x7F' => ['ht'.chr(0x7F).'tp'];
         yield 'starts with digit' => ['0'];
+        yield 'starts with plus' => ['+http'];
+        yield 'starts with dot' => ['.http'];
+        yield 'starts with dash' => ['-http'];
         yield 'contains underscore' => ['ht_tp'];
     }
 


### PR DESCRIPTION
Scheme syntax validation now lives in Rfc3986 alongside the shared host syntax predicate. Uri still owns scheme normalization and exception messaging, while delegating the pure RFC 3986 syntax check to the lower-level helper.