### PR TITLE
Add host authority edge coverage

### DIFF
--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -222,6 +222,8 @@ class MessageTest extends TestCase
         yield 'maximum port' => ['foo.com:65535', 'http://foo.com:65535/'];
         yield 'ipv6' => ['[::1]', 'http://[::1]/'];
         yield 'ipv6 port' => ['[::1]:443', 'https://[::1]/'];
+        yield 'ipv6 https leading zero default port' => ['[::1]:000443', 'https://[::1]/'];
+        yield 'ipv6 leading zero non-default port' => ['[::1]:0008080', 'http://[::1]:8080/'];
     }
 
     public function testParseRequestAcceptsMissingHostHeader(): void
@@ -241,6 +243,15 @@ class MessageTest extends TestCase
         self::assertSame('www.google.com', $request->getHeaderLine('Host'));
         self::assertSame('', (string) $request->getBody());
         self::assertSame('https://www.google.com/search?q=foobar', (string) $request->getUri());
+    }
+
+    public function testParseRequestAbsoluteFormIgnoresInvalidHostHeaderWhenUriComesFromTarget(): void
+    {
+        $request = Psr7\Message::parseRequest("GET https://good.example/admin HTTP/1.1\r\nHost: trusted.example@evil.example\r\n\r\n");
+
+        self::assertSame('https://good.example/admin', $request->getRequestTarget());
+        self::assertSame('trusted.example@evil.example', $request->getHeaderLine('Host'));
+        self::assertSame('https://good.example/admin', (string) $request->getUri());
     }
 
     public function testParsesOptionsAsteriskFormRequestTarget(): void
@@ -271,6 +282,15 @@ class MessageTest extends TestCase
 
         self::assertSame('*', $request->getRequestTarget());
         self::assertSame('[::1]:443', $request->getHeaderLine('Host'));
+        self::assertSame('https://[::1]', (string) $request->getUri());
+    }
+
+    public function testParsesOptionsAsteriskFormRequestTargetWithIpv6LeadingZeroHttpsPort(): void
+    {
+        $request = Psr7\Message::parseRequest("OPTIONS * HTTP/1.1\r\nHost: [::1]:000443\r\n\r\n");
+
+        self::assertSame('*', $request->getRequestTarget());
+        self::assertSame('[::1]:000443', $request->getHeaderLine('Host'));
         self::assertSame('https://[::1]', (string) $request->getUri());
     }
 
@@ -317,6 +337,27 @@ class MessageTest extends TestCase
         self::assertSame('CONNECT', $request->getMethod());
         self::assertSame('up.example:000443', $request->getRequestTarget());
         self::assertSame('up.example:000443', $request->getHeaderLine('Host'));
+        self::assertSame('//up.example:443', (string) $request->getUri());
+    }
+
+    public function testParsesConnectAuthorityFormRequestTargetWithIpv6LeadingZeroPort(): void
+    {
+        $req = "CONNECT [::1]:000443 HTTP/1.1\r\nHost: [::1]:000443\r\n\r\n";
+        $request = Psr7\Message::parseRequest($req);
+
+        self::assertSame('CONNECT', $request->getMethod());
+        self::assertSame('[::1]:000443', $request->getRequestTarget());
+        self::assertSame('[::1]:000443', $request->getHeaderLine('Host'));
+        self::assertSame('//[::1]:443', (string) $request->getUri());
+    }
+
+    public function testParseConnectAuthorityFormIgnoresInvalidHostHeaderWhenUriComesFromTarget(): void
+    {
+        $request = Psr7\Message::parseRequest("CONNECT up.example:443 HTTP/1.1\r\nHost: trusted.example@evil.example\r\n\r\n");
+
+        self::assertSame('CONNECT', $request->getMethod());
+        self::assertSame('up.example:443', $request->getRequestTarget());
+        self::assertSame('trusted.example@evil.example', $request->getHeaderLine('Host'));
         self::assertSame('//up.example:443', (string) $request->getUri());
     }
 

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -444,6 +444,10 @@ class ServerRequestTest extends TestCase
                 'https://www.example.org:8324/blog/article.php?id=10&user=foo',
                 array_merge($server, ['HTTP_HOST' => 'www.example.org:8324']),
             ],
+            'Host header with leading zero port' => [
+                'https://www.example.org:8324/blog/article.php?id=10&user=foo',
+                array_merge($server, ['HTTP_HOST' => 'www.example.org:008324']),
+            ],
             'Host header with zero port falls back to SERVER_NAME' => [
                 'https://www.example.org/blog/article.php?id=10&user=foo',
                 array_merge($server, ['HTTP_HOST' => 'bad.example.org:0']),
@@ -1070,6 +1074,29 @@ class ServerRequestTest extends TestCase
         self::assertSame('www.example.org', $request->getUri()->getHost());
         self::assertSame(8324, $request->getUri()->getPort());
         self::assertSame('www.example.org:8324', $request->getHeaderLine('Host'));
+    }
+
+    public function testFromGlobalsPreservesLeadingZeroHostHeaderPort(): void
+    {
+        if (\function_exists('apache_request_headers')) {
+            self::markTestSkipped('apache_request_headers() is available.');
+        }
+
+        $_SERVER = [
+            'REQUEST_URI' => '/',
+            'HTTP_HOST' => 'www.example.org:008324',
+            'SERVER_NAME' => 'good.example',
+            'SERVER_PORT' => '443',
+            'HTTPS' => 'on',
+        ];
+
+        $_COOKIE = $_POST = $_GET = $_FILES = [];
+
+        $request = ServerRequest::fromGlobals();
+
+        self::assertSame('www.example.org', $request->getUri()->getHost());
+        self::assertSame(8324, $request->getUri()->getPort());
+        self::assertSame('www.example.org:008324', $request->getHeaderLine('Host'));
     }
 
     public function testFromGlobalsDerivesHostHeaderWhenHostHeaderMissing(): void


### PR DESCRIPTION
This adds final public-surface coverage for Host authority edge cases after the 3.0 parsing changes. The tests cover IPv6 authorities with leading-zero ports, intentional absolute-form and CONNECT boundaries where the request-target supplies the URI authority, and server-global handling that preserves the original Host header while normalizing the URI port.