### PR TITLE
Reject conflicting modifyRequest Host changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Changed `Utils::copyToStream()` to retry short destination writes and throw when destination streams cannot make progress
+- Changed `Utils::modifyRequest()` to reject conflicting URI and `Host` header changes in the same call
 - Changed `Header::parse()` to split semicolon-separated parameters without repeated regular expression lookaheads
 
 ### Deprecated

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -192,7 +192,18 @@ final class Utils
             $uri = $request->getUri();
         } else {
             // Remove the host header if one is on the URI
-            if ($host = $changes['uri']->getHost()) {
+            $host = $changes['uri']->getHost();
+            if ($host !== '') {
+                if (isset($changes['set_headers']) && is_array($changes['set_headers'])) {
+                    foreach (array_keys($changes['set_headers']) as $header) {
+                        if (strtolower((string) $header) === 'host') {
+                            throw new \InvalidArgumentException(
+                                'Cannot modify request with both a URI containing a host and an explicit Host header.'
+                            );
+                        }
+                    }
+                }
+
                 $changes['set_headers']['Host'] = $host;
 
                 if ($port = $changes['uri']->getPort()) {

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -452,6 +452,16 @@ class UtilsTest extends TestCase
         self::assertSame('www.foo.com:8000', (string) $r2->getHeaderLine('host'));
     }
 
+    public function testCanModifyRequestWithFalseyUriHost(): void
+    {
+        $r1 = new Psr7\Request('GET', 'http://foo.com');
+        $r2 = Psr7\Utils::modifyRequest($r1, [
+            'uri' => new Psr7\Uri('http://0'),
+        ]);
+        self::assertSame('http://0', (string) $r2->getUri());
+        self::assertSame('0', (string) $r2->getHeaderLine('host'));
+    }
+
     public function testCanModifyRequestWithCaseInsensitiveHeader(): void
     {
         $r1 = new Psr7\Request('GET', 'http://foo.com', ['User-Agent' => 'foo']);
@@ -706,16 +716,68 @@ class UtilsTest extends TestCase
         self::assertSame('1', $modified->getHeaderLine('X-Test'));
     }
 
-    public function testModifyRequestPreservesConstructorStyleHeaderAggregation(): void
+    /**
+     * @dataProvider hostHeaderCaseProvider
+     */
+    public function testModifyRequestRejectsUriAndExplicitHostHeader(string $hostHeader): void
+    {
+        $request = new Psr7\Request('GET', 'http://foo.com');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot modify request with both a URI containing a host and an explicit Host header.');
+
+        Psr7\Utils::modifyRequest($request, [
+            'uri' => new Psr7\Uri('http://bar.com'),
+            'set_headers' => [$hostHeader => 'custom'],
+        ]);
+    }
+
+    public function testModifyRequestRejectsFalseyUriHostAndExplicitHostHeader(): void
+    {
+        $request = new Psr7\Request('GET', 'http://foo.com');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot modify request with both a URI containing a host and an explicit Host header.');
+
+        Psr7\Utils::modifyRequest($request, [
+            'uri' => new Psr7\Uri('http://0'),
+            'set_headers' => ['host' => 'custom'],
+        ]);
+    }
+
+    public function testModifyRequestCanSetExplicitHostHeaderWithoutUriChange(): void
     {
         $request = new Psr7\Request('GET', 'http://foo.com');
 
         $modified = Psr7\Utils::modifyRequest($request, [
-            'uri' => new Psr7\Uri('http://bar.com'),
             'set_headers' => ['host' => 'custom'],
         ]);
 
-        self::assertSame(['host' => ['custom', 'bar.com']], $modified->getHeaders());
+        self::assertSame('custom', $modified->getHeaderLine('Host'));
+    }
+
+    public function testModifyRequestCanSetExplicitHostHeaderWithRelativeUriChange(): void
+    {
+        $request = new Psr7\Request('GET', 'http://foo.com');
+
+        $modified = Psr7\Utils::modifyRequest($request, [
+            'uri' => new Psr7\Uri('/relative'),
+            'set_headers' => ['host' => 'custom'],
+        ]);
+
+        self::assertSame('custom', $modified->getHeaderLine('Host'));
+        self::assertSame('/relative', (string) $modified->getUri());
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function hostHeaderCaseProvider(): iterable
+    {
+        yield 'canonical' => ['Host'];
+        yield 'lowercase' => ['host'];
+        yield 'uppercase' => ['HOST'];
+        yield 'mixed case' => ['HoSt'];
     }
 
     public function testModifyRequestPreservesNumericHeaderNames(): void


### PR DESCRIPTION
This change rejects Utils::modifyRequest() calls that try to change the URI to one with a host while also setting an explicit Host header in the same change set. That combination previously allowed case variants such as host and Host to produce a multi-valued Host header, so callers must now choose one authority source for a single modifyRequest() call. The change preserves explicit Host updates when the URI has no host, including relative URI changes, and keeps URI-derived Host generation working for normal URI updates.