### PR TITLE
Reject malformed UTF-8 URIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.10.3 - Upcoming
+
+### Fixed
+
+- Fixed malformed UTF-8 URI strings being parsed as empty URIs
+
 ## 2.10.2 - 2026-05-25
 
 ### Security

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -107,7 +107,7 @@ class Uri implements UriInterface, \JsonSerializable
             $url = $matches[2];
         }
 
-        /** @var string */
+        /** @var string|null $encodedUrl */
         $encodedUrl = preg_replace_callback(
             '%[^:/@?&=#]+%usD',
             static function ($matches) {
@@ -115,6 +115,10 @@ class Uri implements UriInterface, \JsonSerializable
             },
             $url
         );
+
+        if ($encodedUrl === null) {
+            return false;
+        }
 
         $result = parse_url($prefix.$encodedUrl);
 

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -107,7 +107,7 @@ class Uri implements UriInterface, \JsonSerializable
             $url = $matches[2];
         }
 
-        /** @var string|null $encodedUrl */
+        /** @var string|null */
         $encodedUrl = preg_replace_callback(
             '%[^:/@?&=#]+%usD',
             static function ($matches) {

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -117,7 +117,21 @@ class UriTest extends TestCase
             // currently invalid as well but should not according to RFC 3986.
             ['http://'],
             ['urn://host:with:colon'], // host cannot contain ":"
+            ['http://example.com/'."\xC3"],
+            ['//example.com/'."\xC3"],
+            ['/'."\xC3"],
+            ['?q='."\xC3"],
+            ['#f'."\xC3"],
+            ['urn:path'."\xC3"],
+            ['http://[::1]/'."\xC3"],
         ];
+    }
+
+    public function testPathNoSchemeReferenceWithMalformedUtf8ByteIsPercentEncoded(): void
+    {
+        $uri = new Uri("relative/\xC3");
+
+        self::assertSame('relative/%C3', (string) $uri);
     }
 
     /**


### PR DESCRIPTION
This fixes `Uri::parse()` so a failed UTF-8 `preg_replace_callback()` result is treated as a parse failure instead of being concatenated into an empty string. Malformed UTF-8 absolute, network-path, query, fragment, URN, and IPv6-host URI inputs now throw `MalformedUriException` through the existing constructor path.