### PR TITLE
Cover fromParts host control validation

### DIFF
--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -254,6 +254,17 @@ class UriTest extends TestCase
         new Uri("http://example.com\r\nX-Injected:%20yes/");
     }
 
+    public function testFromPartsRejectsHostWithControlCharacter(): void
+    {
+        $this->expectException(MalformedUriException::class);
+
+        Uri::fromParts([
+            'scheme' => 'http',
+            'host' => "example.com\r\nX-Injected: yes",
+            'path' => '/x',
+        ]);
+    }
+
     public function testPathMustHaveCorrectType(): void
     {
         $this->expectException(\InvalidArgumentException::class);


### PR DESCRIPTION
This adds regression coverage confirming `Uri::fromParts()` rejects host components containing control characters. The implementation already routes `fromParts()` host values through the same host filtering path as parsed and mutated URIs, so this PR only adds the missing test coverage.