### PR TITLE
Parse IPv6 literals with embedded IPv4 addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed URI parsing for IPv6 literals containing embedded IPv4 addresses
 - Fixed malformed UTF-8 URI strings being parsed as empty URIs
 
 ## 2.10.2 - 2026-05-25

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -101,7 +101,7 @@ class Uri implements UriInterface, \JsonSerializable
 
         // Preserve bracketed IPv6 literals before encoding, including dotted IPv4 tails.
         $prefix = '';
-        if (preg_match('%^(.*://\[[0-9:.a-fA-F]+\])(.*?)$%', $url, $matches)) {
+        if (preg_match('%^([0-9A-Za-z+.-]+://\[[0-9:.a-fA-F]+\])(.*?)$%', $url, $matches)) {
             /** @var array{0:string, 1:string, 2:string} $matches */
             $prefix = $matches[1];
             $url = $matches[2];

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -99,9 +99,9 @@ class Uri implements UriInterface, \JsonSerializable
             return self::parsePathNoSchemeReference($url);
         }
 
-        // If IPv6
+        // Preserve bracketed IPv6 literals before encoding, including dotted IPv4 tails.
         $prefix = '';
-        if (preg_match('%^(.*://\[[0-9:a-fA-F]+\])(.*?)$%', $url, $matches)) {
+        if (preg_match('%^(.*://\[[0-9:.a-fA-F]+\])(.*?)$%', $url, $matches)) {
             /** @var array{0:string, 1:string, 2:string} $matches */
             $prefix = $matches[1];
             $url = $matches[2];

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -851,6 +851,70 @@ class UriTest extends TestCase
         self::assertSame('frag', $uri->getFragment());
     }
 
+    /**
+     * @dataProvider getUrisWithIpv6EmbeddedIpv4Literals
+     */
+    public function testCanParseIpv6LiteralsWithEmbeddedIpv4(string $uri, string $expectedUri, string $expectedHost, ?int $expectedPort): void
+    {
+        $parsed = new Uri($uri);
+
+        self::assertSame($expectedUri, (string) $parsed);
+        self::assertSame($expectedHost, $parsed->getHost());
+        self::assertSame($expectedPort, $parsed->getPort());
+    }
+
+    public static function getUrisWithIpv6EmbeddedIpv4Literals(): iterable
+    {
+        yield 'ipv4 mapped' => [
+            'http://[::ffff:192.0.2.128]/',
+            'http://[::ffff:192.0.2.128]/',
+            '[::ffff:192.0.2.128]',
+            null,
+        ];
+
+        yield 'ipv4 compatible' => [
+            'http://[::192.0.2.128]/path',
+            'http://[::192.0.2.128]/path',
+            '[::192.0.2.128]',
+            null,
+        ];
+
+        yield 'embedded ipv4 after hextets' => [
+            'http://[2001:db8:3:4::192.0.2.33]/',
+            'http://[2001:db8:3:4::192.0.2.33]/',
+            '[2001:db8:3:4::192.0.2.33]',
+            null,
+        ];
+
+        yield 'uppercase hex is normalized' => [
+            'http://[::FFFF:192.0.2.128]/',
+            'http://[::ffff:192.0.2.128]/',
+            '[::ffff:192.0.2.128]',
+            null,
+        ];
+
+        yield 'non-default port' => [
+            'http://[::ffff:192.0.2.128]:8080/path?x=1',
+            'http://[::ffff:192.0.2.128]:8080/path?x=1',
+            '[::ffff:192.0.2.128]',
+            8080,
+        ];
+
+        yield 'default http port is removed' => [
+            'http://[::ffff:192.0.2.128]:80/path',
+            'http://[::ffff:192.0.2.128]/path',
+            '[::ffff:192.0.2.128]',
+            null,
+        ];
+
+        yield 'default https port is removed' => [
+            'https://[::ffff:192.0.2.128]:443/path',
+            'https://[::ffff:192.0.2.128]/path',
+            '[::ffff:192.0.2.128]',
+            null,
+        ];
+    }
+
     public function testJsonSerializable(): void
     {
         $uri = new Uri('https://example.com');

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -124,6 +124,9 @@ class UriTest extends TestCase
             ['#f'."\xC3"],
             ['urn:path'."\xC3"],
             ['http://[::1]/'."\xC3"],
+            ['http://[::ffff:192.0.2.128]/'."\xC3"],
+            ['http://example.com/'."\xC3".'://[::ffff:127.0.0.1]/'],
+            ['foo:'."\xC3".'://[::ffff:127.0.0.1]/'],
         ];
     }
 


### PR DESCRIPTION
This updates the URI parsing pre-scan so bracketed IPv6 literals with embedded dotted IPv4 tails are preserved before the generic encoding pass runs. It lets URI strings such as `http://[::ffff:192.0.2.128]/` parse correctly on the 2.10 branch without changing the broader host validation rules.