### PR TITLE
Cover malformed IPv6 literals with embedded IPv4

### DIFF
--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -1051,6 +1051,22 @@ class UriTest extends TestCase
         ];
     }
 
+    /**
+     * @dataProvider getMalformedIpv6LiteralsWithEmbeddedIpv4
+     */
+    public function testParseUriRejectsMalformedIpv6LiteralsWithEmbeddedIpv4(string $uri): void
+    {
+        $this->expectException(MalformedUriException::class);
+
+        new Uri($uri);
+    }
+
+    public static function getMalformedIpv6LiteralsWithEmbeddedIpv4(): iterable
+    {
+        yield 'out of range ipv4 octet' => ['http://[::ffff:999.0.2.128]/'];
+        yield 'incomplete embedded ipv4 address' => ['http://[1:2.3]/'];
+    }
+
     public function testJsonSerializable(): void
     {
         $uri = new Uri('https://example.com');


### PR DESCRIPTION
This adds 3.0 test coverage proving malformed bracketed IPv6 literals with dotted IPv4-looking tails are rejected by URI parsing. It covers an out-of-range embedded IPv4 octet and an incomplete dotted tail, ensuring the parser fix from 2.10 still flows through the stricter 3.0 host validation.