### PR TITLE
Validate raw Host headers for all request targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reject zero-port `HTTP_HOST` authorities and malformed `SERVER_PORT` values in `ServerRequest::getUriFromGlobals()`
 - Reject zero-port `Host` authorities and normalize leading-zero ports in `Message::parseRequest()` URI derivation
 - Reject duplicate `Host` field lines in `Message::parseRequest()`
+- Validate present raw `Host` field values in `Message::parseRequest()` for all request-target forms
 - Normalize server request URI reconstruction from globals, including `REQUEST_METHOD` values used for request-target parsing
 - Accept `OPTIONS *` and `CONNECT` authority-form request targets in `Message::parseRequest()`
 - Reject malformed HTTP start-line fields

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -211,11 +211,14 @@ malformed `SERVER_PORT` values when reconstructing the URI from server globals.
 from an origin-form or asterisk-form request target. Host ports with leading
 zeroes are normalized for URI reconstruction, and port zero is rejected.
 It also rejects duplicate `Host` field lines, including case-insensitive
-duplicates.
+duplicates. Any present raw `Host` field is validated before returning a parsed
+request, even when the request target supplies the URI authority, such as
+absolute-form and CONNECT requests. Valid `Host` values may still differ from
+the absolute-form or CONNECT request-target authority.
 
-Applications that need to reject malformed inbound `Host` headers should
-validate the request host before calling `getUriFromGlobals()` or inspect the
-original server parameters.
+For server globals, applications that need to reject malformed inbound `Host`
+headers should validate the original server parameters before calling
+`getUriFromGlobals()` or inspect them afterward.
 
 #### URI Paths and Request Targets
 

--- a/src/Message.php
+++ b/src/Message.php
@@ -345,7 +345,7 @@ final class Message
             throw new \InvalidArgumentException('Invalid request string');
         }
 
-        self::getSingleHostHeader($data['headers']);
+        self::getHostFromHeaders($data['headers']);
 
         if ($matches['target'][0] === '/') {
             return new Request(

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -245,13 +245,32 @@ class MessageTest extends TestCase
         self::assertSame('https://www.google.com/search?q=foobar', (string) $request->getUri());
     }
 
-    public function testParseRequestAbsoluteFormIgnoresInvalidHostHeaderWhenUriComesFromTarget(): void
+    /**
+     * @dataProvider invalidHostHeaderProvider
+     */
+    public function testParseAbsoluteFormRejectsInvalidHostHeader(string $host): void
     {
-        $request = Psr7\Message::parseRequest("GET https://good.example/admin HTTP/1.1\r\nHost: trusted.example@evil.example\r\n\r\n");
+        $this->expectException(\InvalidArgumentException::class);
 
-        self::assertSame('https://good.example/admin', $request->getRequestTarget());
-        self::assertSame('trusted.example@evil.example', $request->getHeaderLine('Host'));
-        self::assertSame('https://good.example/admin', (string) $request->getUri());
+        Psr7\Message::parseRequest("GET https://good.example/admin HTTP/1.1\r\nHost: {$host}\r\n\r\n");
+    }
+
+    public function testParseAbsoluteFormAllowsValidHostDifferentFromTargetAuthority(): void
+    {
+        $request = Psr7\Message::parseRequest("GET https://up.example/admin HTTP/1.1\r\nHost: good.example\r\n\r\n");
+
+        self::assertSame('https://up.example/admin', $request->getRequestTarget());
+        self::assertSame('good.example', $request->getHeaderLine('Host'));
+        self::assertSame('https://up.example/admin', (string) $request->getUri());
+    }
+
+    public function testParseAbsoluteFormAllowsMissingHostHeader(): void
+    {
+        $request = Psr7\Message::parseRequest("GET https://up.example/admin HTTP/1.1\r\n\r\n");
+
+        self::assertSame('https://up.example/admin', $request->getRequestTarget());
+        self::assertSame('up.example', $request->getHeaderLine('Host'));
+        self::assertSame('https://up.example/admin', (string) $request->getUri());
     }
 
     public function testParsesOptionsAsteriskFormRequestTarget(): void
@@ -351,13 +370,33 @@ class MessageTest extends TestCase
         self::assertSame('//[::1]:443', (string) $request->getUri());
     }
 
-    public function testParseConnectAuthorityFormIgnoresInvalidHostHeaderWhenUriComesFromTarget(): void
+    /**
+     * @dataProvider invalidHostHeaderProvider
+     */
+    public function testParseConnectRejectsInvalidHostHeader(string $host): void
     {
-        $request = Psr7\Message::parseRequest("CONNECT up.example:443 HTTP/1.1\r\nHost: trusted.example@evil.example\r\n\r\n");
+        $this->expectException(\InvalidArgumentException::class);
+
+        Psr7\Message::parseRequest("CONNECT up.example:443 HTTP/1.1\r\nHost: {$host}\r\n\r\n");
+    }
+
+    public function testParseConnectAllowsValidHostDifferentFromTargetAuthority(): void
+    {
+        $request = Psr7\Message::parseRequest("CONNECT up.example:443 HTTP/1.1\r\nHost: good.example\r\n\r\n");
 
         self::assertSame('CONNECT', $request->getMethod());
         self::assertSame('up.example:443', $request->getRequestTarget());
-        self::assertSame('trusted.example@evil.example', $request->getHeaderLine('Host'));
+        self::assertSame('good.example', $request->getHeaderLine('Host'));
+        self::assertSame('//up.example:443', (string) $request->getUri());
+    }
+
+    public function testParseConnectAllowsMissingHostHeader(): void
+    {
+        $request = Psr7\Message::parseRequest("CONNECT up.example:443 HTTP/1.1\r\n\r\n");
+
+        self::assertSame('CONNECT', $request->getMethod());
+        self::assertSame('up.example:443', $request->getRequestTarget());
+        self::assertSame('up.example:443', $request->getHeaderLine('Host'));
         self::assertSame('//up.example:443', (string) $request->getUri());
     }
 


### PR DESCRIPTION
This validates any present raw Host field before Message::parseRequest() returns a request, including absolute-form and CONNECT requests where the URI authority comes from the request target. Valid Host values can still differ from the request-target authority, but malformed Host values are no longer preserved on parsed requests.