### PR TITLE
Prefer target authority before fallback server port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Harden URI host validation for delimiters, backslashes, and invalid IPv6/IP literals; reject schemes not beginning with a letter
 - Redact all non-empty URI userinfo in `Utils::redactUserInfo()`
 - Reject zero-port `HTTP_HOST` authorities and malformed `SERVER_PORT` values in `ServerRequest::getUriFromGlobals()`
+- Use valid absolute-form and CONNECT request-target authorities before validating fallback `SERVER_PORT` in `ServerRequest::getUriFromGlobals()`
 - Reject zero-port `Host` authorities and normalize leading-zero ports in `Message::parseRequest()` URI derivation
 - Reject duplicate `Host` field lines in `Message::parseRequest()`
 - Validate present raw `Host` field values in `Message::parseRequest()` for all request-target forms

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -205,7 +205,12 @@ update a `Host` header.
 `ServerRequest::getUriFromGlobals()` now falls back to `SERVER_NAME`, then
 `SERVER_ADDR`, then the existing default host behavior for malformed
 `HTTP_HOST` values. It also rejects zero-port `HTTP_HOST` authorities and
-malformed `SERVER_PORT` values when reconstructing the URI from server globals.
+malformed `SERVER_PORT` values when fallback authority reconstruction needs the
+server port. When `REQUEST_URI` is absolute-form or CONNECT authority-form and
+supplies a valid authority, that authority is used before fallback `SERVER_PORT`
+validation. Origin-form, asterisk-form, missing `REQUEST_URI`, and fallback
+reconstruction paths still reject malformed `SERVER_PORT` values when fallback
+authority reconstruction needs the server port.
 
 `Message::parseRequest()` now applies 3.0 authority rules when deriving a URI
 from an origin-form or asterisk-form request target. Host ports with leading

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -460,7 +460,7 @@ class ServerRequest extends Request implements ServerRequestInterface
                     $targetUri = null;
                 }
 
-                if ($targetUri !== null && $targetUri->getHost() !== '') {
+                if ($targetUri !== null && $targetUri->getHost() !== '' && $targetUri->getPort() !== 0) {
                     $requestTarget = self::removeRequestTargetFragment($requestUri);
                     if (strpos($requestTarget, '?') === false && $queryString !== null && $queryString !== '') {
                         $targetUri = $targetUri->withQuery($queryString);
@@ -469,7 +469,10 @@ class ServerRequest extends Request implements ServerRequestInterface
 
                     // Preserve the received absolute-form target unless it cannot be used
                     // as a PSR-7 request target without normalization.
-                    return [$targetUri, preg_match('/[\x00-\x20\x7F]/', $requestTarget) ? (string) $targetUri : $requestTarget];
+                    $normalizeRequestTarget = preg_match('/[\x00-\x20\x7F]/', $requestTarget) === 1
+                        || self::hasEmptyPortInAbsoluteFormRequestTarget($requestTarget);
+
+                    return [$targetUri, $normalizeRequestTarget ? (string) $targetUri : $requestTarget];
                 }
             }
         }
@@ -503,6 +506,37 @@ class ServerRequest extends Request implements ServerRequestInterface
     private static function isAbsoluteFormRequestTarget(string $target): bool
     {
         return preg_match('/^[A-Za-z][A-Za-z0-9+.-]*:\/\//D', $target) === 1;
+    }
+
+    private static function hasEmptyPortInAbsoluteFormRequestTarget(string $target): bool
+    {
+        $authorityStart = strpos($target, '://');
+        if ($authorityStart === false) {
+            return false;
+        }
+
+        $authorityStart += 3;
+        $authority = substr($target, $authorityStart, strcspn($target, '/?#', $authorityStart));
+        if ($authority === '') {
+            return false;
+        }
+
+        $lastAt = strrpos($authority, '@');
+        if ($lastAt !== false) {
+            $authority = substr($authority, $lastAt + 1);
+        }
+
+        if ($authority === '') {
+            return false;
+        }
+
+        if ($authority[0] === '[') {
+            $closingBracket = strpos($authority, ']');
+
+            return $closingBracket !== false && substr($authority, $closingBracket + 1) === ':';
+        }
+
+        return substr($authority, -1) === ':';
     }
 
     private static function isAsteriskFormRequestTarget(string $method, string $target): bool

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -381,12 +381,18 @@ class ServerRequest extends Request implements ServerRequestInterface
         }
     }
 
-    private static function getAuthorityUriFromGlobals(): UriInterface
+    private static function getUriWithSchemeFromGlobals(): UriInterface
     {
         $uri = new Uri('');
 
         $https = self::getServerParam('HTTPS');
-        $uri = $uri->withScheme(!empty($https) && $https !== 'off' ? 'https' : 'http');
+
+        return $uri->withScheme(!empty($https) && $https !== 'off' ? 'https' : 'http');
+    }
+
+    private static function getAuthorityUriFromGlobals(): UriInterface
+    {
+        $uri = self::getUriWithSchemeFromGlobals();
 
         $hasPort = false;
         $hasHost = false;
@@ -432,9 +438,43 @@ class ServerRequest extends Request implements ServerRequestInterface
      */
     private static function getUriAndRequestTargetFromGlobals(string $method): array
     {
-        $uri = self::getAuthorityUriFromGlobals();
         $requestUri = self::getServerParam('REQUEST_URI');
         $queryString = self::getServerParam('QUERY_STRING');
+
+        if ($requestUri !== null) {
+            $connectAuthority = self::parseConnectAuthorityFormRequestTarget($method, $requestUri);
+            if ($connectAuthority !== null) {
+                [$host, $port] = $connectAuthority;
+                $uri = self::getUriWithSchemeFromGlobals();
+
+                return [
+                    $uri->withHost($host)->withPort($port)->withPath('')->withQuery(''),
+                    $requestUri,
+                ];
+            }
+
+            if (self::isAbsoluteFormRequestTarget($requestUri)) {
+                try {
+                    $targetUri = (new Uri($requestUri))->withFragment('');
+                } catch (InvalidArgumentException $e) {
+                    $targetUri = null;
+                }
+
+                if ($targetUri !== null && $targetUri->getHost() !== '') {
+                    $requestTarget = self::removeRequestTargetFragment($requestUri);
+                    if (strpos($requestTarget, '?') === false && $queryString !== null && $queryString !== '') {
+                        $targetUri = $targetUri->withQuery($queryString);
+                        $requestTarget .= '?'.$queryString;
+                    }
+
+                    // Preserve the received absolute-form target unless it cannot be used
+                    // as a PSR-7 request target without normalization.
+                    return [$targetUri, preg_match('/[\x00-\x20\x7F]/', $requestTarget) ? (string) $targetUri : $requestTarget];
+                }
+            }
+        }
+
+        $uri = self::getAuthorityUriFromGlobals();
 
         if ($requestUri === null) {
             if ($queryString !== null) {
@@ -446,36 +486,6 @@ class ServerRequest extends Request implements ServerRequestInterface
 
         if (self::isAsteriskFormRequestTarget($method, $requestUri)) {
             return [$uri->withPath('')->withQuery(''), '*'];
-        }
-
-        $connectAuthority = self::parseConnectAuthorityFormRequestTarget($method, $requestUri);
-        if ($connectAuthority !== null) {
-            [$host, $port] = $connectAuthority;
-
-            return [
-                $uri->withHost($host)->withPort($port)->withPath('')->withQuery(''),
-                $requestUri,
-            ];
-        }
-
-        if (self::isAbsoluteFormRequestTarget($requestUri)) {
-            try {
-                $targetUri = (new Uri($requestUri))->withFragment('');
-            } catch (InvalidArgumentException $e) {
-                $targetUri = null;
-            }
-
-            if ($targetUri !== null && $targetUri->getHost() !== '') {
-                $requestTarget = self::removeRequestTargetFragment($requestUri);
-                if (strpos($requestTarget, '?') === false && $queryString !== null && $queryString !== '') {
-                    $targetUri = $targetUri->withQuery($queryString);
-                    $requestTarget .= '?'.$queryString;
-                }
-
-                // Preserve the received absolute-form target unless it cannot be used
-                // as a PSR-7 request target without normalization.
-                return [$targetUri, preg_match('/[\x00-\x20\x7F]/', $requestTarget) ? (string) $targetUri : $requestTarget];
-            }
         }
 
         [$path, $query, $hasQuery] = self::splitRequestTargetQuery($requestUri);

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -460,7 +460,7 @@ class ServerRequest extends Request implements ServerRequestInterface
                     $targetUri = null;
                 }
 
-                if ($targetUri !== null && $targetUri->getHost() !== '' && $targetUri->getPort() !== 0) {
+                if ($targetUri !== null && $targetUri->getHost() !== '') {
                     $requestTarget = self::removeRequestTargetFragment($requestUri);
                     if (strpos($requestTarget, '?') === false && $queryString !== null && $queryString !== '') {
                         $targetUri = $targetUri->withQuery($queryString);

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -629,6 +629,24 @@ class ServerRequestTest extends TestCase
             '',
         ];
 
+        yield 'absolute-form zero port target supplies authority before malformed SERVER_PORT' => [
+            ['REQUEST_URI' => 'http://up.example:0/admin', 'HTTP_HOST' => 'good.example', 'SERVER_PORT' => '+443'],
+            'http://up.example:0/admin',
+            'up.example',
+            0,
+            '/admin',
+            '',
+        ];
+
+        yield 'absolute-form zero padded zero port target supplies authority before malformed SERVER_PORT' => [
+            ['REQUEST_URI' => 'http://up.example:0000/admin', 'HTTP_HOST' => 'good.example', 'SERVER_PORT' => '+443'],
+            'http://up.example:0/admin',
+            'up.example',
+            0,
+            '/admin',
+            '',
+        ];
+
         yield 'absolute-form ipv6 target supplies authority before malformed SERVER_PORT' => [
             ['REQUEST_URI' => 'http://[::1]:8080/admin?x=1', 'HTTP_HOST' => 'good.example', 'SERVER_PORT' => '+443'],
             'http://[::1]:8080/admin?x=1',
@@ -817,6 +835,18 @@ class ServerRequestTest extends TestCase
             ['REQUEST_METHOD' => 'GET', 'REQUEST_URI' => 'http://up.example:/admin', 'HTTP_HOST' => 'good.example', 'SERVER_PORT' => '+443'],
             'http://up.example/admin',
             'http://up.example/admin',
+        ];
+
+        yield 'absolute-form zero port target is preserved before malformed SERVER_PORT' => [
+            ['REQUEST_METHOD' => 'GET', 'REQUEST_URI' => 'http://up.example:0/admin', 'HTTP_HOST' => 'good.example', 'SERVER_PORT' => '+443'],
+            'http://up.example:0/admin',
+            'http://up.example:0/admin',
+        ];
+
+        yield 'absolute-form zero padded zero port target is preserved before malformed SERVER_PORT' => [
+            ['REQUEST_METHOD' => 'GET', 'REQUEST_URI' => 'http://up.example:0000/admin', 'HTTP_HOST' => 'good.example', 'SERVER_PORT' => '+443'],
+            'http://up.example:0000/admin',
+            'http://up.example:0/admin',
         ];
 
         yield 'absolute-form ipv6 target is preserved before malformed SERVER_PORT' => [
@@ -1059,7 +1089,7 @@ class ServerRequestTest extends TestCase
         ServerRequest::getUriFromGlobals();
     }
 
-    public function testGetUriFromGlobalsRejectsInvalidServerPortForAbsoluteFormZeroPortFallback(): void
+    public function testGetUriFromGlobalsAcceptsAbsoluteFormZeroPortBeforeMalformedServerPort(): void
     {
         $_SERVER = [
             'REQUEST_URI' => 'http://up.example:0/admin',
@@ -1067,13 +1097,15 @@ class ServerRequestTest extends TestCase
             'SERVER_PORT' => '+443',
         ];
 
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid SERVER_PORT');
+        $uri = ServerRequest::getUriFromGlobals();
 
-        ServerRequest::getUriFromGlobals();
+        self::assertSame('http://up.example:0/admin', (string) $uri);
+        self::assertSame('up.example', $uri->getHost());
+        self::assertSame(0, $uri->getPort());
+        self::assertSame('/admin', $uri->getPath());
     }
 
-    public function testGetUriFromGlobalsRejectsInvalidServerPortForAbsoluteFormZeroPaddedZeroPortFallback(): void
+    public function testGetUriFromGlobalsAcceptsAbsoluteFormZeroPaddedZeroPortBeforeMalformedServerPort(): void
     {
         $_SERVER = [
             'REQUEST_URI' => 'http://up.example:0000/admin',
@@ -1081,10 +1113,12 @@ class ServerRequestTest extends TestCase
             'SERVER_PORT' => '+443',
         ];
 
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid SERVER_PORT');
+        $uri = ServerRequest::getUriFromGlobals();
 
-        ServerRequest::getUriFromGlobals();
+        self::assertSame('http://up.example:0/admin', (string) $uri);
+        self::assertSame('up.example', $uri->getHost());
+        self::assertSame(0, $uri->getPort());
+        self::assertSame('/admin', $uri->getPath());
     }
 
     public function testGetUriFromGlobalsRejectsInvalidServerPortForMalformedConnectFallback(): void
@@ -1135,18 +1169,6 @@ class ServerRequestTest extends TestCase
         yield 'malformed absolute-form port' => [
             [
                 'REQUEST_URI' => 'http://up.example:bad/admin',
-            ],
-        ];
-
-        yield 'absolute-form zero port' => [
-            [
-                'REQUEST_URI' => 'http://up.example:0/admin',
-            ],
-        ];
-
-        yield 'absolute-form zero padded zero port' => [
-            [
-                'REQUEST_URI' => 'http://up.example:0000/admin',
             ],
         ];
 

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -611,8 +611,26 @@ class ServerRequestTest extends TestCase
             'x=1',
         ];
 
+        yield 'absolute-form target supplies authority before malformed SERVER_PORT' => [
+            ['REQUEST_URI' => 'http://up.example:8080/admin?x=1', 'HTTP_HOST' => 'good.example', 'SERVER_PORT' => '+443'],
+            'http://up.example:8080/admin?x=1',
+            'up.example',
+            8080,
+            '/admin',
+            'x=1',
+        ];
+
         yield 'absolute-form uses QUERY_STRING when request uri has no query' => [
             ['REQUEST_URI' => 'http://up.example/admin', 'QUERY_STRING' => 'x=1', 'HTTP_HOST' => 'good.example'],
+            'http://up.example/admin?x=1',
+            'up.example',
+            null,
+            '/admin',
+            'x=1',
+        ];
+
+        yield 'absolute-form target uses QUERY_STRING before malformed SERVER_PORT' => [
+            ['REQUEST_URI' => 'http://up.example/admin', 'QUERY_STRING' => 'x=1', 'HTTP_HOST' => 'good.example', 'SERVER_PORT' => '+443'],
             'http://up.example/admin?x=1',
             'up.example',
             null,
@@ -661,6 +679,24 @@ class ServerRequestTest extends TestCase
             'http://up.example:443',
             'up.example',
             443,
+            '',
+            '',
+        ];
+
+        yield 'connect authority-form supplies authority before malformed SERVER_PORT' => [
+            ['REQUEST_METHOD' => 'CONNECT', 'REQUEST_URI' => 'up.example:443', 'HTTP_HOST' => 'good.example', 'SERVER_PORT' => '+443'],
+            'http://up.example:443',
+            'up.example',
+            443,
+            '',
+            '',
+        ];
+
+        yield 'connect authority-form https default port is normalized before malformed SERVER_PORT' => [
+            ['REQUEST_METHOD' => 'CONNECT', 'REQUEST_URI' => 'up.example:443', 'HTTP_HOST' => 'good.example', 'SERVER_PORT' => '+443', 'HTTPS' => 'on'],
+            'https://up.example',
+            'up.example',
+            null,
             '',
             '',
         ];
@@ -744,6 +780,12 @@ class ServerRequestTest extends TestCase
             'http://up.example:8080/admin?x=1',
         ];
 
+        yield 'absolute-form target is preserved before malformed SERVER_PORT' => [
+            ['REQUEST_METHOD' => 'GET', 'REQUEST_URI' => 'http://up.example:8080/admin?x=1', 'HTTP_HOST' => 'good.example', 'SERVER_PORT' => '+443'],
+            'http://up.example:8080/admin?x=1',
+            'http://up.example:8080/admin?x=1',
+        ];
+
         yield 'absolute-form target uses query string fallback' => [
             ['REQUEST_METHOD' => 'GET', 'REQUEST_URI' => 'http://up.example/admin', 'QUERY_STRING' => 'x=1', 'HTTP_HOST' => 'good.example'],
             'http://up.example/admin?x=1',
@@ -778,6 +820,18 @@ class ServerRequestTest extends TestCase
             ['REQUEST_METHOD' => 'CONNECT', 'REQUEST_URI' => 'up.example:443', 'HTTP_HOST' => 'good.example'],
             'up.example:443',
             'http://up.example:443',
+        ];
+
+        yield 'connect authority-form target is preserved before malformed SERVER_PORT' => [
+            ['REQUEST_METHOD' => 'CONNECT', 'REQUEST_URI' => 'up.example:443', 'HTTP_HOST' => 'good.example', 'SERVER_PORT' => '+443'],
+            'up.example:443',
+            'http://up.example:443',
+        ];
+
+        yield 'connect authority-form https default port is normalized before malformed SERVER_PORT' => [
+            ['REQUEST_METHOD' => 'CONNECT', 'REQUEST_URI' => 'up.example:443', 'HTTP_HOST' => 'good.example', 'SERVER_PORT' => '+443', 'HTTPS' => 'on'],
+            'up.example:443',
+            'https://up.example',
         ];
 
         yield 'connect authority-form target with lowercase method is normalized from globals' => [
@@ -882,6 +936,63 @@ class ServerRequestTest extends TestCase
             'QUERY_STRING' => 'id=10&user=foo',
             'HTTP_HOST' => 'www.example.org',
             'HTTPS' => 'on',
+        ];
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid SERVER_PORT');
+
+        ServerRequest::getUriFromGlobals();
+    }
+
+    public function testGetUriFromGlobalsRejectsInvalidServerPortForAsteriskForm(): void
+    {
+        $_SERVER = [
+            'REQUEST_METHOD' => 'OPTIONS',
+            'REQUEST_URI' => '*',
+            'HTTP_HOST' => 'www.example.org',
+            'SERVER_PORT' => '+443',
+        ];
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid SERVER_PORT');
+
+        ServerRequest::getUriFromGlobals();
+    }
+
+    public function testGetUriFromGlobalsRejectsInvalidServerPortWhenRequestUriIsMissing(): void
+    {
+        $_SERVER = [
+            'HTTP_HOST' => 'www.example.org',
+            'SERVER_PORT' => '+443',
+        ];
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid SERVER_PORT');
+
+        ServerRequest::getUriFromGlobals();
+    }
+
+    public function testGetUriFromGlobalsRejectsInvalidServerPortForMalformedAbsoluteFormFallback(): void
+    {
+        $_SERVER = [
+            'REQUEST_URI' => 'http://up.example:bad/admin',
+            'HTTP_HOST' => 'www.example.org',
+            'SERVER_PORT' => '+443',
+        ];
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid SERVER_PORT');
+
+        ServerRequest::getUriFromGlobals();
+    }
+
+    public function testGetUriFromGlobalsRejectsInvalidServerPortForMalformedConnectFallback(): void
+    {
+        $_SERVER = [
+            'REQUEST_METHOD' => 'CONNECT',
+            'REQUEST_URI' => 'up.example:not-a-port',
+            'HTTP_HOST' => 'www.example.org',
+            'SERVER_PORT' => '+443',
         ];
 
         $this->expectException(\InvalidArgumentException::class);

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -620,6 +620,24 @@ class ServerRequestTest extends TestCase
             'x=1',
         ];
 
+        yield 'absolute-form empty port target supplies authority before malformed SERVER_PORT' => [
+            ['REQUEST_URI' => 'http://up.example:/admin', 'HTTP_HOST' => 'good.example', 'SERVER_PORT' => '+443'],
+            'http://up.example/admin',
+            'up.example',
+            null,
+            '/admin',
+            '',
+        ];
+
+        yield 'absolute-form ipv6 target supplies authority before malformed SERVER_PORT' => [
+            ['REQUEST_URI' => 'http://[::1]:8080/admin?x=1', 'HTTP_HOST' => 'good.example', 'SERVER_PORT' => '+443'],
+            'http://[::1]:8080/admin?x=1',
+            '[::1]',
+            8080,
+            '/admin',
+            'x=1',
+        ];
+
         yield 'absolute-form uses QUERY_STRING when request uri has no query' => [
             ['REQUEST_URI' => 'http://up.example/admin', 'QUERY_STRING' => 'x=1', 'HTTP_HOST' => 'good.example'],
             'http://up.example/admin?x=1',
@@ -697,6 +715,15 @@ class ServerRequestTest extends TestCase
             'https://up.example',
             'up.example',
             null,
+            '',
+            '',
+        ];
+
+        yield 'connect authority-form ipv6 supplies authority before malformed SERVER_PORT' => [
+            ['REQUEST_METHOD' => 'CONNECT', 'REQUEST_URI' => '[::1]:443', 'HTTP_HOST' => 'good.example', 'SERVER_PORT' => '+443'],
+            'http://[::1]:443',
+            '[::1]',
+            443,
             '',
             '',
         ];
@@ -786,8 +813,26 @@ class ServerRequestTest extends TestCase
             'http://up.example:8080/admin?x=1',
         ];
 
+        yield 'absolute-form empty port target is normalized before malformed SERVER_PORT' => [
+            ['REQUEST_METHOD' => 'GET', 'REQUEST_URI' => 'http://up.example:/admin', 'HTTP_HOST' => 'good.example', 'SERVER_PORT' => '+443'],
+            'http://up.example/admin',
+            'http://up.example/admin',
+        ];
+
+        yield 'absolute-form ipv6 target is preserved before malformed SERVER_PORT' => [
+            ['REQUEST_METHOD' => 'GET', 'REQUEST_URI' => 'http://[::1]:8080/admin?x=1', 'HTTP_HOST' => 'good.example', 'SERVER_PORT' => '+443'],
+            'http://[::1]:8080/admin?x=1',
+            'http://[::1]:8080/admin?x=1',
+        ];
+
         yield 'absolute-form target uses query string fallback' => [
             ['REQUEST_METHOD' => 'GET', 'REQUEST_URI' => 'http://up.example/admin', 'QUERY_STRING' => 'x=1', 'HTTP_HOST' => 'good.example'],
+            'http://up.example/admin?x=1',
+            'http://up.example/admin?x=1',
+        ];
+
+        yield 'absolute-form target uses query string fallback before malformed SERVER_PORT' => [
+            ['REQUEST_METHOD' => 'GET', 'REQUEST_URI' => 'http://up.example/admin', 'QUERY_STRING' => 'x=1', 'HTTP_HOST' => 'good.example', 'SERVER_PORT' => '+443'],
             'http://up.example/admin?x=1',
             'http://up.example/admin?x=1',
         ];
@@ -832,6 +877,12 @@ class ServerRequestTest extends TestCase
             ['REQUEST_METHOD' => 'CONNECT', 'REQUEST_URI' => 'up.example:443', 'HTTP_HOST' => 'good.example', 'SERVER_PORT' => '+443', 'HTTPS' => 'on'],
             'up.example:443',
             'https://up.example',
+        ];
+
+        yield 'connect authority-form ipv6 target is preserved before malformed SERVER_PORT' => [
+            ['REQUEST_METHOD' => 'CONNECT', 'REQUEST_URI' => '[::1]:443', 'HTTP_HOST' => 'good.example', 'SERVER_PORT' => '+443'],
+            '[::1]:443',
+            'http://[::1]:443',
         ];
 
         yield 'connect authority-form target with lowercase method is normalized from globals' => [
@@ -885,6 +936,28 @@ class ServerRequestTest extends TestCase
         self::assertSame('up.example', $request->getUri()->getHost());
         self::assertSame('good.example', $request->getHeaderLine('Host'));
         self::assertSame('http://up.example:8080/admin?x=1', $request->getRequestTarget());
+    }
+
+    public function testFromGlobalsKeepsValidHostHeaderWhenConnectAuthorityDiffers(): void
+    {
+        if (\function_exists('apache_request_headers')) {
+            self::markTestSkipped('apache_request_headers() is available.');
+        }
+
+        $_SERVER = [
+            'REQUEST_METHOD' => 'CONNECT',
+            'REQUEST_URI' => 'up.example:443',
+            'HTTP_HOST' => 'good.example',
+            'SERVER_PORT' => '+443',
+        ];
+        $_COOKIE = $_POST = $_GET = $_FILES = [];
+
+        $request = ServerRequest::fromGlobals();
+
+        self::assertSame('up.example', $request->getUri()->getHost());
+        self::assertSame('up.example:443', $request->getRequestTarget());
+        self::assertSame('good.example', $request->getHeaderLine('Host'));
+        self::assertSame('http://up.example:443', (string) $request->getUri());
     }
 
     public function testFromGlobalsNormalizesAbsoluteFormRequestTargetWithControlCharacter(): void
@@ -986,6 +1059,34 @@ class ServerRequestTest extends TestCase
         ServerRequest::getUriFromGlobals();
     }
 
+    public function testGetUriFromGlobalsRejectsInvalidServerPortForAbsoluteFormZeroPortFallback(): void
+    {
+        $_SERVER = [
+            'REQUEST_URI' => 'http://up.example:0/admin',
+            'HTTP_HOST' => 'www.example.org',
+            'SERVER_PORT' => '+443',
+        ];
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid SERVER_PORT');
+
+        ServerRequest::getUriFromGlobals();
+    }
+
+    public function testGetUriFromGlobalsRejectsInvalidServerPortForAbsoluteFormZeroPaddedZeroPortFallback(): void
+    {
+        $_SERVER = [
+            'REQUEST_URI' => 'http://up.example:0000/admin',
+            'HTTP_HOST' => 'www.example.org',
+            'SERVER_PORT' => '+443',
+        ];
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid SERVER_PORT');
+
+        ServerRequest::getUriFromGlobals();
+    }
+
     public function testGetUriFromGlobalsRejectsInvalidServerPortForMalformedConnectFallback(): void
     {
         $_SERVER = [
@@ -999,6 +1100,62 @@ class ServerRequestTest extends TestCase
         $this->expectExceptionMessage('Invalid SERVER_PORT');
 
         ServerRequest::getUriFromGlobals();
+    }
+
+    /**
+     * @dataProvider dataFromGlobalsRejectsInvalidServerPortForRequestTargetFallback
+     */
+    public function testFromGlobalsRejectsInvalidServerPortForRequestTargetFallback(array $serverParams): void
+    {
+        $_SERVER = $serverParams + [
+            'HTTP_HOST' => 'www.example.org',
+            'SERVER_PORT' => '+443',
+        ];
+        $_COOKIE = $_POST = $_GET = $_FILES = [];
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid SERVER_PORT');
+
+        ServerRequest::fromGlobals();
+    }
+
+    public static function dataFromGlobalsRejectsInvalidServerPortForRequestTargetFallback(): iterable
+    {
+        yield 'asterisk-form' => [
+            [
+                'REQUEST_METHOD' => 'OPTIONS',
+                'REQUEST_URI' => '*',
+            ],
+        ];
+
+        yield 'missing request uri' => [
+            [],
+        ];
+
+        yield 'malformed absolute-form port' => [
+            [
+                'REQUEST_URI' => 'http://up.example:bad/admin',
+            ],
+        ];
+
+        yield 'absolute-form zero port' => [
+            [
+                'REQUEST_URI' => 'http://up.example:0/admin',
+            ],
+        ];
+
+        yield 'absolute-form zero padded zero port' => [
+            [
+                'REQUEST_URI' => 'http://up.example:0000/admin',
+            ],
+        ];
+
+        yield 'malformed connect port' => [
+            [
+                'REQUEST_METHOD' => 'CONNECT',
+                'REQUEST_URI' => 'up.example:not-a-port',
+            ],
+        ];
     }
 
     public function testFromGlobals(): void


### PR DESCRIPTION
This updates ServerRequest URI reconstruction from globals so valid absolute-form and CONNECT request targets supply authority before fallback SERVER_PORT is validated. Origin-form, asterisk-form, missing REQUEST_URI, and fallback reconstruction paths continue to reject malformed SERVER_PORT values when fallback authority reconstruction needs the server port.