### PR TITLE
Translate StreamWrapper runtime failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reject invalid `Utils::modifyRequest()` change values before applying request modifications
 - Use PHP debug type names in type error messages
 - Throw `TimeoutException` when stream read, copy, hash, and line operations detect timeout metadata
+- Translate `StreamWrapper` runtime failures to PHP stream failure values
 - Stop adding default `Content-Length` headers to `multipart/form-data` parts to comply with RFC 7578 section 4.8
 - Escape generated multipart `Content-Disposition` parameters and reject unsafe multipart boundary and part header metadata
 - Made static utility classes non-instantiable

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -602,9 +602,10 @@ PSR-7 stream into PHP stream-wrapper failure values. When using a resource from
 instead of propagating the PSR-7 stream exception. Call the PSR-7 stream directly
 if you need exception-based failure handling.
 
-The `StreamWrapper::stream_read()` and `StreamWrapper::stream_tell()` callback
-methods no longer declare native return types so they can return `false`
-according to PHP stream-wrapper failure semantics.
+The `StreamWrapper::stream_read()` callback no longer declares a native return
+type so read failures can return `false`. The `StreamWrapper::stream_tell()`
+callback no longer declares a native return type so post-seek position lookup
+failures can make `fseek()` fail.
 
 Several stream `__toString()` implementations now allow exceptions thrown during
 stringification to be rethrown. Avoid relying on `(string) $stream` to hide read

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -595,6 +595,17 @@ custom stream implementations that do not expose `timed_out` metadata continue
 to behave as before. Previously, timed-out reads could be treated as EOF or
 return partial results.
 
+`StreamWrapper` now translates `RuntimeException` failures from the wrapped
+PSR-7 stream into PHP stream-wrapper failure values. When using a resource from
+`StreamWrapper::getResource()`, functions such as `fread()`, `fwrite()`,
+`fseek()`, `feof()`, and `fstat()` may now return normal PHP failure values
+instead of propagating the PSR-7 stream exception. Call the PSR-7 stream directly
+if you need exception-based failure handling.
+
+The `StreamWrapper::stream_read()` and `StreamWrapper::stream_tell()` callback
+methods no longer declare native return types so they can return `false`
+according to PHP stream-wrapper failure semantics.
+
 Several stream `__toString()` implementations now allow exceptions thrown during
 stringification to be rethrown. Avoid relying on `(string) $stream` to hide read
 failures; call `getContents()` or `read()` and handle exceptions when failures

--- a/src/StreamWrapper.php
+++ b/src/StreamWrapper.php
@@ -77,40 +77,67 @@ final class StreamWrapper
     public function stream_open(string $path, string $mode, int $options, ?string &$opened_path = null): bool
     {
         $options = stream_context_get_options($this->context);
+        $stream = $options['guzzle']['stream'] ?? null;
 
-        if (!isset($options['guzzle']['stream'])) {
+        if (!$stream instanceof StreamInterface) {
             return false;
         }
 
         $this->mode = $mode;
-        $this->stream = $options['guzzle']['stream'];
+        $this->stream = $stream;
 
         return true;
     }
 
-    public function stream_read(int $count): string
+    /**
+     * @return string|false
+     */
+    public function stream_read(int $count)
     {
-        return $this->stream->read($count);
+        try {
+            return $this->stream->read($count);
+        } catch (\RuntimeException $e) {
+            return false;
+        }
     }
 
     public function stream_write(string $data): int
     {
-        return $this->stream->write($data);
+        try {
+            return $this->stream->write($data);
+        } catch (\RuntimeException $e) {
+            return -1;
+        }
     }
 
-    public function stream_tell(): int
+    /**
+     * @return int|false
+     */
+    public function stream_tell()
     {
-        return $this->stream->tell();
+        try {
+            return $this->stream->tell();
+        } catch (\RuntimeException $e) {
+            return false;
+        }
     }
 
     public function stream_eof(): bool
     {
-        return $this->stream->eof();
+        try {
+            return $this->stream->eof();
+        } catch (\RuntimeException $e) {
+            return true;
+        }
     }
 
     public function stream_seek(int $offset, int $whence): bool
     {
-        $this->stream->seek($offset, $whence);
+        try {
+            $this->stream->seek($offset, $whence);
+        } catch (\RuntimeException $e) {
+            return false;
+        }
 
         return true;
     }
@@ -120,8 +147,12 @@ final class StreamWrapper
      */
     public function stream_cast(int $cast_as)
     {
-        $stream = clone $this->stream;
-        $resource = $stream->detach();
+        try {
+            $stream = clone $this->stream;
+            $resource = $stream->detach();
+        } catch (\RuntimeException $e) {
+            return false;
+        }
 
         return $resource ?? false;
     }
@@ -145,7 +176,13 @@ final class StreamWrapper
      */
     public function stream_stat()
     {
-        if ($this->stream->getSize() === null) {
+        try {
+            $size = $this->stream->getSize();
+        } catch (\RuntimeException $e) {
+            return false;
+        }
+
+        if ($size === null) {
             return false;
         }
 
@@ -160,12 +197,12 @@ final class StreamWrapper
         return [
             'dev' => 0,
             'ino' => 0,
-            'mode' => $modeMap[$this->mode],
+            'mode' => $modeMap[$this->mode] ?? 0,
             'nlink' => 0,
             'uid' => 0,
             'gid' => 0,
             'rdev' => 0,
-            'size' => $this->stream->getSize() ?: 0,
+            'size' => $size,
             'atime' => 0,
             'mtime' => 0,
             'ctime' => 0,

--- a/tests/StreamWrapperTest.php
+++ b/tests/StreamWrapperTest.php
@@ -100,6 +100,17 @@ class StreamWrapperTest extends TestCase
         self::assertFalse($result);
     }
 
+    public function testReturnsFalseWhenStreamContextDoesNotContainStream(): void
+    {
+        StreamWrapper::register();
+
+        $context = stream_context_create([
+            'guzzle' => ['stream' => 'not a stream'],
+        ]);
+
+        self::assertFalse(@fopen('guzzle://stream', 'r', false, $context));
+    }
+
     /**
      * @runInSeparateProcess
      *
@@ -131,6 +142,91 @@ class StreamWrapperTest extends TestCase
         $r = StreamWrapper::getResource($stream);
         self::assertIsResource($r);
         fclose($r);
+    }
+
+    public function testReadFailureReturnsFalse(): void
+    {
+        $stream = $this->createMock(StreamInterface::class);
+        $stream->method('isReadable')->willReturn(true);
+        $stream->method('isWritable')->willReturn(false);
+        $stream->method('read')->willThrowException(new \RuntimeException('read failed'));
+
+        $resource = StreamWrapper::getResource($stream);
+
+        self::assertFalse(fread($resource, 1));
+    }
+
+    public function testWriteFailureReturnsFalse(): void
+    {
+        $stream = $this->createMock(StreamInterface::class);
+        $stream->method('isReadable')->willReturn(false);
+        $stream->method('isWritable')->willReturn(true);
+        $stream->method('write')->willThrowException(new \RuntimeException('write failed'));
+
+        $resource = StreamWrapper::getResource($stream);
+
+        self::assertFalse(fwrite($resource, 'x'));
+    }
+
+    public function testSeekFailureReturnsMinusOne(): void
+    {
+        $stream = $this->createMock(StreamInterface::class);
+        $stream->method('isReadable')->willReturn(true);
+        $stream->method('isWritable')->willReturn(false);
+        $stream->method('seek')->willThrowException(new \RuntimeException('seek failed'));
+
+        $resource = StreamWrapper::getResource($stream);
+
+        self::assertSame(-1, fseek($resource, 0));
+    }
+
+    public function testTellFailureMakesSeekReturnMinusOne(): void
+    {
+        $stream = $this->createMock(StreamInterface::class);
+        $stream->method('isReadable')->willReturn(true);
+        $stream->method('isWritable')->willReturn(false);
+        $stream->method('tell')->willThrowException(new \RuntimeException('tell failed'));
+
+        $resource = StreamWrapper::getResource($stream);
+
+        self::assertSame(-1, fseek($resource, 0));
+    }
+
+    public function testEofFailureReturnsTrue(): void
+    {
+        $stream = $this->createMock(StreamInterface::class);
+        $stream->method('isReadable')->willReturn(true);
+        $stream->method('isWritable')->willReturn(false);
+        $stream->method('eof')->willThrowException(new \RuntimeException('eof failed'));
+
+        $resource = StreamWrapper::getResource($stream);
+
+        self::assertTrue(feof($resource));
+    }
+
+    public function testStatFailureReturnsFalse(): void
+    {
+        $stream = $this->createMock(StreamInterface::class);
+        $stream->method('isReadable')->willReturn(true);
+        $stream->method('isWritable')->willReturn(false);
+        $stream->method('getSize')->willThrowException(new \RuntimeException('size failed'));
+
+        $resource = StreamWrapper::getResource($stream);
+
+        self::assertFalse(fstat($resource));
+    }
+
+    public function testNonRuntimeReadFailuresStillPropagate(): void
+    {
+        $stream = $this->createMock(StreamInterface::class);
+        $stream->method('isReadable')->willReturn(true);
+        $stream->method('isWritable')->willReturn(false);
+        $stream->method('read')->willThrowException(new \Error('read failed'));
+
+        $resource = StreamWrapper::getResource($stream);
+
+        $this->expectException(\Error::class);
+        fread($resource, 1);
     }
 
     public function testUrlStat(): void

--- a/tests/StreamWrapperTest.php
+++ b/tests/StreamWrapperTest.php
@@ -80,6 +80,23 @@ class StreamWrapperTest extends TestCase
         self::assertIsInt(stream_select($streams, $write, $except, 0));
     }
 
+    public function testStreamCastFailureRemovesStreamFromSelection(): void
+    {
+        $stream = $this->createMock(StreamInterface::class);
+        $stream->method('isReadable')->willReturn(true);
+        $stream->method('isWritable')->willReturn(false);
+        $stream->method('detach')->willThrowException(new \RuntimeException('detach failed'));
+
+        $failed = StreamWrapper::getResource($stream);
+        $valid = StreamWrapper::getResource(Utils::streamFor('foo'));
+        $streams = [$failed, $valid];
+        $write = null;
+        $except = null;
+
+        self::assertSame(1, @stream_select($streams, $write, $except, 0));
+        self::assertSame([$valid], \array_values($streams));
+    }
+
     public function testValidatesStream(): void
     {
         $stream = $this->createMock(StreamInterface::class);


### PR DESCRIPTION
This updates StreamWrapper so resources created with StreamWrapper::getResource() translate RuntimeException failures from the wrapped PSR-7 stream into PHP stream-wrapper failure values. Direct PSR-7 stream method calls continue to throw, and non-runtime errors still propagate.