### PR TITLE
Fix AppendStream reads without streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Make `AppendStream::read()` return an empty string when no streams are attached
 - Prevent `CachingStream::seek()` from looping indefinitely when the remote stream makes no progress
 
 ## 2.10.3 - 2026-05-27

--- a/src/AppendStream.php
+++ b/src/AppendStream.php
@@ -187,6 +187,10 @@ final class AppendStream implements StreamInterface
      */
     public function read($length): string
     {
+        if ($this->streams === []) {
+            return '';
+        }
+
         $buffer = '';
         $total = count($this->streams) - 1;
         $remaining = $length;

--- a/tests/AppendStreamTest.php
+++ b/tests/AppendStreamTest.php
@@ -139,6 +139,35 @@ class AppendStreamTest extends TestCase
         self::assertSame('', (string) $a);
     }
 
+    public function testReadWithoutStreamsReturnsEmptyString(): void
+    {
+        $stream = new AppendStream();
+
+        self::assertSame('', $stream->read(1));
+        self::assertSame(0, $stream->tell());
+        self::assertTrue($stream->eof());
+    }
+
+    public function testReadAfterCloseReturnsEmptyString(): void
+    {
+        $stream = new AppendStream([Psr7\Utils::streamFor('foo')]);
+
+        $stream->close();
+
+        self::assertSame('', $stream->read(1));
+        self::assertTrue($stream->eof());
+    }
+
+    public function testReadAfterDetachReturnsEmptyString(): void
+    {
+        $stream = new AppendStream([Psr7\Utils::streamFor('foo')]);
+
+        $stream->detach();
+
+        self::assertSame('', $stream->read(1));
+        self::assertTrue($stream->eof());
+    }
+
     public function testCanReadFromMultipleStreams(): void
     {
         $a = new AppendStream([


### PR DESCRIPTION
Return an empty string from `AppendStream::read()` when no streams are attached. Cover empty, closed, and detached `AppendStream` reads.
