### PR TITLE
Normalize URI fragment percent-encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Apply `UriNormalizer` percent-encoding normalizations to URI fragments
 - Make `AppendStream::read()` return an empty string when no streams are attached
 - Prevent `CachingStream::seek()` from looping indefinitely when the remote stream makes no progress
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -261,13 +261,7 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$path of method Psr\\Http\\Message\\UriInterface\:\:withPath\(\) expects string, string\|null given\.$#'
 			identifier: argument.type
-			count: 3
-			path: src/UriNormalizer.php
-
-		-
-			message: '#^Parameter \#1 \$query of method Psr\\Http\\Message\\UriInterface\:\:withQuery\(\) expects string, string\|null given\.$#'
-			identifier: argument.type
-			count: 2
+			count: 1
 			path: src/UriNormalizer.php
 
 		-

--- a/src/UriNormalizer.php
+++ b/src/UriNormalizer.php
@@ -189,12 +189,10 @@ final class UriNormalizer
             return strtoupper($match[0]);
         };
 
-        return
-            $uri->withPath(
-                preg_replace_callback($regex, $callback, $uri->getPath())
-            )->withQuery(
-                preg_replace_callback($regex, $callback, $uri->getQuery())
-            );
+        return $uri
+            ->withPath(self::normalizePercentEncodingInComponent($uri->getPath(), $regex, $callback))
+            ->withQuery(self::normalizePercentEncodingInComponent($uri->getQuery(), $regex, $callback))
+            ->withFragment(self::normalizePercentEncodingInComponent($uri->getFragment(), $regex, $callback));
     }
 
     private static function decodeUnreservedCharacters(UriInterface $uri): UriInterface
@@ -205,12 +203,24 @@ final class UriNormalizer
             return rawurldecode($match[0]);
         };
 
-        return
-            $uri->withPath(
-                preg_replace_callback($regex, $callback, $uri->getPath())
-            )->withQuery(
-                preg_replace_callback($regex, $callback, $uri->getQuery())
-            );
+        return $uri
+            ->withPath(self::normalizePercentEncodingInComponent($uri->getPath(), $regex, $callback))
+            ->withQuery(self::normalizePercentEncodingInComponent($uri->getQuery(), $regex, $callback))
+            ->withFragment(self::normalizePercentEncodingInComponent($uri->getFragment(), $regex, $callback));
+    }
+
+    /**
+     * @param callable(array): string $callback
+     */
+    private static function normalizePercentEncodingInComponent(string $component, string $regex, callable $callback): string
+    {
+        $normalized = preg_replace_callback($regex, $callback, $component);
+
+        if ($normalized === null) {
+            throw new \RuntimeException('Unable to normalize URI component percent-encoding');
+        }
+
+        return $normalized;
     }
 
     private function __construct()

--- a/tests/UriNormalizerTest.php
+++ b/tests/UriNormalizerTest.php
@@ -18,14 +18,17 @@ class UriNormalizerTest extends TestCase
     {
         $actualEncoding = 'a%c2%7A%5eb%25%fa%fA%Fa';
         $expectEncoding = 'a%C2%7A%5Eb%25%FA%FA%FA';
-        $uri = (new Uri())->withPath("/$actualEncoding")->withQuery($actualEncoding);
+        $uri = (new Uri())
+            ->withPath("/$actualEncoding")
+            ->withQuery($actualEncoding)
+            ->withFragment($actualEncoding);
 
-        self::assertSame("/$actualEncoding?$actualEncoding", (string) $uri, 'Not normalized automatically beforehand');
+        self::assertSame("/$actualEncoding?$actualEncoding#$actualEncoding", (string) $uri, 'Not normalized automatically beforehand');
 
         $normalizedUri = UriNormalizer::normalize($uri, UriNormalizer::CAPITALIZE_PERCENT_ENCODING);
 
         self::assertInstanceOf(UriInterface::class, $normalizedUri);
-        self::assertSame("/$expectEncoding?$expectEncoding", (string) $normalizedUri);
+        self::assertSame("/$expectEncoding?$expectEncoding#$expectEncoding", (string) $normalizedUri);
     }
 
     /**
@@ -37,14 +40,17 @@ class UriNormalizerTest extends TestCase
         // Add encoded reserved characters to test that those are not decoded and include the percent-encoded
         // unreserved character both in lower and upper case to test the decoding is case-insensitive.
         $encodedChars = $percentEncoded.'%2F%5B'.strtoupper($percentEncoded);
-        $uri = (new Uri())->withPath("/$encodedChars")->withQuery($encodedChars);
+        $uri = (new Uri())
+            ->withPath("/$encodedChars")
+            ->withQuery($encodedChars)
+            ->withFragment($encodedChars);
 
-        self::assertSame("/$encodedChars?$encodedChars", (string) $uri, 'Not normalized automatically beforehand');
+        self::assertSame("/$encodedChars?$encodedChars#$encodedChars", (string) $uri, 'Not normalized automatically beforehand');
 
         $normalizedUri = UriNormalizer::normalize($uri, UriNormalizer::DECODE_UNRESERVED_CHARACTERS);
 
         self::assertInstanceOf(UriInterface::class, $normalizedUri);
-        self::assertSame("/$char%2F%5B$char?$char%2F%5B$char", (string) $normalizedUri);
+        self::assertSame("/$char%2F%5B$char?$char%2F%5B$char#$char%2F%5B$char", (string) $normalizedUri);
     }
 
     public static function getUnreservedCharacters(): iterable
@@ -170,6 +176,7 @@ class UriNormalizerTest extends TestCase
             ['http://example.org/path?#', 'http://example.org/path', true],
             ['http://example.org:80', 'http://example.org/', true],
             ['http://example.org/../a/.././p%61th?%7a=%5e', 'http://example.org/path?z=%5E', true],
+            ['http://example.org/path#fr%61g%c2%b1', 'http://example.org/path#frag%C2%B1', true],
             ['https://example.org/', 'http://example.org/', false],
             ['https://example.org/', '//example.org/', false],
             ['//example.org/', '//example.org/', true],


### PR DESCRIPTION
This change extends `UriNormalizer`'s existing percent-encoding normalization to URI fragments. Fragments now receive the same percent-triplet capitalization and unreserved-character decoding that path and query components already receive, which makes `normalize()` and `isEquivalent()` consistent across URI components.

The implementation also cleans up the local percent-encoding replacement flow and removes stale PHPStan baseline entries that are no longer needed. Regression coverage now exercises fragment normalization and equivalent fragments with mixed percent-encoding.