### PR TITLE
Fix LimitStream size past stream end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Apply `UriNormalizer` percent-encoding normalizations to URI fragments
+- Make `LimitStream::getSize()` return `0` for slices past the underlying stream end
 - Make `AppendStream::read()` return an empty string when no streams are attached
 - Prevent `CachingStream::seek()` from looping indefinitely when the remote stream makes no progress
 

--- a/src/LimitStream.php
+++ b/src/LimitStream.php
@@ -61,11 +61,15 @@ final class LimitStream implements StreamInterface
     {
         if (null === ($length = $this->stream->getSize())) {
             return null;
-        } elseif ($this->limit === -1) {
-            return $length - $this->offset;
         }
 
-        return min($this->limit, $length - $this->offset);
+        $size = $length - $this->offset;
+
+        if ($this->limit !== -1) {
+            $size = min($this->limit, $size);
+        }
+
+        return max(0, $size);
     }
 
     /**

--- a/tests/LimitStreamTest.php
+++ b/tests/LimitStreamTest.php
@@ -165,14 +165,14 @@ class LimitStreamTest extends TestCase
 
     public function testSizeIsZeroWhenOffsetExceedsUnderlyingSizeWithoutLimit(): void
     {
-        $a = Psr7\Utils::streamFor('foo');
+        $a = new NoSeekStream(Psr7\Utils::streamFor('foo'));
         $b = new LimitStream($a, -1, 4);
         self::assertSame(0, $b->getSize());
     }
 
     public function testSizeIsZeroWhenOffsetExceedsUnderlyingSizeWithLimit(): void
     {
-        $a = Psr7\Utils::streamFor('foo');
+        $a = new NoSeekStream(Psr7\Utils::streamFor('foo'));
         $b = new LimitStream($a, 5, 4);
         self::assertSame(0, $b->getSize());
     }

--- a/tests/LimitStreamTest.php
+++ b/tests/LimitStreamTest.php
@@ -162,4 +162,18 @@ class LimitStreamTest extends TestCase
         $b = new LimitStream($a, -1, 4);
         self::assertSame(3, $b->getSize());
     }
+
+    public function testSizeIsZeroWhenOffsetExceedsUnderlyingSizeWithoutLimit(): void
+    {
+        $a = Psr7\Utils::streamFor('foo');
+        $b = new LimitStream($a, -1, 4);
+        self::assertSame(0, $b->getSize());
+    }
+
+    public function testSizeIsZeroWhenOffsetExceedsUnderlyingSizeWithLimit(): void
+    {
+        $a = Psr7\Utils::streamFor('foo');
+        $b = new LimitStream($a, 5, 4);
+        self::assertSame(0, $b->getSize());
+    }
 }


### PR DESCRIPTION
This fixes LimitStream::getSize() for slices that start past the end of the underlying stream. The method now preserves unknown sizes as null and clamps known slice sizes to zero, so it no longer reports invalid negative byte sizes. The changelog records the fix under 2.10.4.