### PR TITLE
Limit UriComparator default ports to HTTP and HTTPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed `Utils::copyToStream()` to retry short destination writes and throw when destination streams cannot make progress
 - Changed `Utils::modifyRequest()` to reject conflicting URI and `Host` header changes in the same call
 - Changed `Header::parse()` to split semicolon-separated parameters without repeated regular expression lookaheads
+- Changed `UriComparator::isCrossOrigin()` so only HTTP and HTTPS missing ports receive implicit default ports
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -729,7 +729,7 @@ provided key are removed.
 
 Determines if a modified URL should be considered cross-origin with respect to an original URL.
 
-Two URLs are cross-origin when their scheme, host, or effective port differ. Host comparison is case-insensitive, and missing ports use the default port for `http` or `https`.
+Two URLs are cross-origin when their scheme, host, or effective port differ. Host comparison is case-insensitive, and missing ports use the default port for `http` or `https`. Other schemes do not receive implicit default ports.
 
 This helper only compares URI origins. It does not implement redirect handling or credential policy.
 

--- a/src/UriComparator.php
+++ b/src/UriComparator.php
@@ -34,7 +34,7 @@ final class UriComparator
         return false;
     }
 
-    private static function computePort(UriInterface $uri): int
+    private static function computePort(UriInterface $uri): ?int
     {
         $port = $uri->getPort();
 
@@ -42,7 +42,15 @@ final class UriComparator
             return $port;
         }
 
-        return 'https' === $uri->getScheme() ? 443 : 80;
+        if ('http' === $uri->getScheme()) {
+            return 80;
+        }
+
+        if ('https' === $uri->getScheme()) {
+            return 443;
+        }
+
+        return null;
     }
 
     private function __construct()

--- a/tests/UriComparatorTest.php
+++ b/tests/UriComparatorTest.php
@@ -7,6 +7,7 @@ namespace GuzzleHttp\Tests\Psr7;
 use GuzzleHttp\Psr7\Uri;
 use GuzzleHttp\Psr7\UriComparator;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\UriInterface;
 
 /**
  * @covers \GuzzleHttp\Psr7\UriComparator
@@ -40,6 +41,26 @@ class UriComparatorTest extends TestCase
             ['https://example.com/123', 'https://www.example.com/', true],
             ['https://example.com/123', 'https://example.com:444/', true],
             ['https://example.com:443/123', 'https://example.com:444/', true],
+            ['custom://example.com/', 'custom://example.com:80/', true],
+            ['custom://example.com/', 'custom://example.com/other', false],
+            ['ftp://example.com/', 'ftp://example.com:80/', true],
+            ['ws://example.com/', 'ws://example.com:80/', true],
+            ['wss://example.com/', 'wss://example.com:443/', true],
         ];
+    }
+
+    public function testNonHttpSchemeMissingPortDoesNotUseSchemeDefault(): void
+    {
+        $original = $this->createMock(UriInterface::class);
+        $original->method('getHost')->willReturn('example.com');
+        $original->method('getScheme')->willReturn('ftp');
+        $original->method('getPort')->willReturn(null);
+
+        $modified = $this->createMock(UriInterface::class);
+        $modified->method('getHost')->willReturn('example.com');
+        $modified->method('getScheme')->willReturn('ftp');
+        $modified->method('getPort')->willReturn(21);
+
+        self::assertTrue(UriComparator::isCrossOrigin($original, $modified));
     }
 }


### PR DESCRIPTION
This change narrows UriComparator's implicit default-port handling to HTTP and HTTPS. Previously, any URI without an explicit port was treated as port 80 unless the scheme was HTTPS, which made custom and non-HTTP schemes compare as if they had an HTTP default port.

The new behavior preserves existing HTTP and HTTPS origin comparisons, while non-HTTP schemes now compare only the ports that are actually present on the URI. This better matches the comparator's intended HTTP-origin use without assigning arbitrary defaults to unrelated schemes.