### PR TITLE
Fix Header parameter splitting with escaped quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deprecated relying on automatic uppercasing of explicitly provided HTTP request methods; guzzlehttp/psr7 3.0 preserves request method casing
 - Deprecated invalid `Utils::modifyRequest()` change values that guzzlehttp/psr7 3.0 will reject
 
+### Fixed
+
+- Fixed `Header::parse()` handling of escaped quotes in semicolon-separated parameters
+
 ## 2.10.4 - Upcoming
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed `Header::parse()` handling of escaped quotes in semicolon-separated parameters
+- Fixed `Header::parse()` splitting of semicolon-separated parameters with escaped quotes
 
 ## 2.10.4 - Upcoming
 

--- a/src/Header.php
+++ b/src/Header.php
@@ -50,16 +50,31 @@ final class Header
     {
         $values = [];
         $start = 0;
-        $quotesRemaining = \substr_count($value, '"');
+        $isQuoted = false;
+        $isEscaped = false;
 
         for ($i = 0, $max = \strlen($value); $i < $max; ++$i) {
-            if ($value[$i] === '"') {
-                --$quotesRemaining;
+            $char = $value[$i];
+
+            if ($isEscaped) {
+                $isEscaped = false;
 
                 continue;
             }
 
-            if ($value[$i] === ';' && $quotesRemaining % 2 === 0) {
+            if ($isQuoted && $char === '\\') {
+                $isEscaped = true;
+
+                continue;
+            }
+
+            if ($char === '"') {
+                $isQuoted = !$isQuoted;
+
+                continue;
+            }
+
+            if (!$isQuoted && $char === ';') {
                 $values[] = \substr($value, $start, $i - $start);
                 $start = $i + 1;
             }

--- a/tests/HeaderTest.php
+++ b/tests/HeaderTest.php
@@ -60,6 +60,30 @@ class HeaderTest extends TestCase
                 ],
             ],
             [
+                'foo="a;b\\"c"; bar=baz',
+                [
+                    ['foo' => 'a;b\\"c', 'bar' => 'baz'],
+                ],
+            ],
+            [
+                'foo="a;b\\"c"',
+                [
+                    ['foo' => 'a;b\\"c'],
+                ],
+            ],
+            [
+                'foo="a\\";b"; bar=baz',
+                [
+                    ['foo' => 'a\\";b', 'bar' => 'baz'],
+                ],
+            ],
+            [
+                'foo="a\\\\;b"; bar=baz',
+                [
+                    ['foo' => 'a\\\\;b', 'bar' => 'baz'],
+                ],
+            ],
+            [
                 'foo=bar;;baz=qux',
                 [
                     ['foo' => 'bar', 'baz' => 'qux'],


### PR DESCRIPTION
This fixes Header::parse() when splitting semicolon-separated parameters that contain escaped quotes inside quoted strings. The parameter splitter now tracks quoted and escaped state instead of counting quote characters, so semicolons inside quoted values remain part of the parameter even when the value contains a quoted-pair escape. The changelog records the fix under 2.11.0.