### PR TITLE
Synchronize Host in Request withUri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reject zero-port `Host` authorities and normalize leading-zero ports in `Message::parseRequest()` URI derivation
 - Reject duplicate `Host` field lines in `Message::parseRequest()`
 - Validate present raw `Host` field values in `Message::parseRequest()` for all request-target forms
+- Apply PSR-7 Host header synchronization in `Request::withUri()` for same-instance URIs and empty Host headers
 - Normalize server request URI reconstruction from globals, including `REQUEST_METHOD` values used for request-target parsing
 - Accept `OPTIONS *` and `CONNECT` authority-form request targets in `Message::parseRequest()`
 - Reject malformed HTTP start-line fields

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -229,6 +229,28 @@ For server globals, applications that need to reject malformed inbound `Host`
 headers should validate the original server parameters before calling
 `getUriFromGlobals()` or inspect them afterward.
 
+#### Request Host Synchronization
+
+`Request::withUri()` now applies PSR-7 Host header synchronization before using
+the same-URI no-op shortcut. When the provided URI is the same object already
+attached to the request, the method may still return a new request if the URI
+has a host and the current Host header is missing, empty, or stale.
+
+With `$preserveHost = true`, a non-empty Host header is still preserved. Missing
+or empty Host headers are treated as absent and are populated from the URI when
+the URI contains a host.
+
+```php
+$request = (new Request('GET', 'http://example.com:8124/'))->withoutHeader('Host');
+
+$updated = $request->withUri($request->getUri());
+
+$updated->getHeaderLine('Host'); // example.com:8124
+```
+
+If your application intentionally sends an empty or stale Host header, set it
+after calling `withUri()` or preserve a non-empty Host header explicitly.
+
 #### URI Paths and Request Targets
 
 `Uri::getPath()` now normalizes multiple leading slashes to one slash when

--- a/src/Request.php
+++ b/src/Request.php
@@ -98,19 +98,28 @@ class Request implements RequestInterface
 
     public function withUri(UriInterface $uri, bool $preserveHost = false): RequestInterface
     {
-        if ($uri === $this->uri) {
-            return $this;
+        $sameUri = $uri === $this->uri;
+
+        if (!$sameUri && $this->requestTarget === null) {
+            self::getRequestTargetFromUri($uri);
         }
 
-        if ($this->requestTarget === null) {
-            self::getRequestTargetFromUri($uri);
+        $currentHost = $this->getHeaderLine('Host');
+        $host = null;
+
+        if (!$preserveHost || $currentHost === '') {
+            $host = $this->getHostFromUri($uri);
+        }
+
+        if ($sameUri && ($host === null || $currentHost === $host)) {
+            return $this;
         }
 
         $new = clone $this;
         $new->uri = $uri;
 
-        if (!$preserveHost || !isset($this->headerNames['host'])) {
-            $new->updateHostFromUri();
+        if ($host !== null) {
+            $new->setHostHeader($host);
         }
 
         return $new;
@@ -118,20 +127,36 @@ class Request implements RequestInterface
 
     private function updateHostFromUri(): void
     {
-        $host = $this->uri->getHost();
+        $host = $this->getHostFromUri($this->uri);
 
-        if ($host == '') {
+        if ($host === null) {
             return;
+        }
+
+        $this->setHostHeader($host);
+    }
+
+    private function getHostFromUri(UriInterface $uri): ?string
+    {
+        $host = $uri->getHost();
+
+        if ($host === '') {
+            return null;
         }
 
         Uri::assertValidHost($host);
 
-        if (($port = $this->uri->getPort()) !== null) {
+        if (($port = $uri->getPort()) !== null) {
             $host .= ':'.$port;
         }
 
         $this->assertValue($host);
 
+        return $host;
+    }
+
+    private function setHostHeader(string $host): void
+    {
         if (isset($this->headerNames['host'])) {
             $header = $this->headerNames['host'];
         } else {

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -179,6 +179,112 @@ class RequestTest extends TestCase
         self::assertSame($r1, $r2);
     }
 
+    public function testSameInstanceWhenSameUriAndHostWithPortIsAlreadySynchronized(): void
+    {
+        $request = new Request('GET', 'http://foo.com:8124/bar');
+
+        $updated = $request->withUri($request->getUri());
+
+        self::assertSame($request, $updated);
+        self::assertSame('foo.com:8124', $updated->getHeaderLine('Host'));
+    }
+
+    public function testWithUriSameInstanceAddsMissingHostHeader(): void
+    {
+        $request = (new Request('GET', 'http://foo.com:8124/bar'))->withoutHeader('Host');
+
+        $updated = $request->withUri($request->getUri());
+
+        self::assertNotSame($request, $updated);
+        self::assertFalse($request->hasHeader('Host'));
+        self::assertSame('foo.com:8124', $updated->getHeaderLine('Host'));
+    }
+
+    public function testWithUriSameInstancePreserveHostAddsMissingHostHeader(): void
+    {
+        $request = (new Request('GET', 'http://foo.com:8124/bar'))->withoutHeader('Host');
+
+        $updated = $request->withUri($request->getUri(), true);
+
+        self::assertNotSame($request, $updated);
+        self::assertSame('foo.com:8124', $updated->getHeaderLine('Host'));
+    }
+
+    public function testWithUriSameInstanceOverridesStaleHostWhenNotPreservingHost(): void
+    {
+        $request = new Request('GET', 'http://foo.com:8124/bar', ['Host' => 'wrong.example']);
+
+        $updated = $request->withUri($request->getUri());
+
+        self::assertNotSame($request, $updated);
+        self::assertSame('wrong.example', $request->getHeaderLine('Host'));
+        self::assertSame('foo.com:8124', $updated->getHeaderLine('Host'));
+    }
+
+    public function testWithUriSameInstancePreserveHostUpdatesEmptyHostHeader(): void
+    {
+        $request = new Request('GET', 'http://foo.com:8124/bar', ['Host' => '']);
+
+        $updated = $request->withUri($request->getUri(), true);
+
+        self::assertNotSame($request, $updated);
+        self::assertSame('', $request->getHeaderLine('Host'));
+        self::assertSame('foo.com:8124', $updated->getHeaderLine('Host'));
+    }
+
+    public function testWithUriSameInstancePreserveHostKeepsNonEmptyHost(): void
+    {
+        $request = new Request('GET', 'http://foo.com:8124/bar', ['Host' => 'custom.example']);
+
+        $updated = $request->withUri($request->getUri(), true);
+
+        self::assertSame($request, $updated);
+        self::assertSame('custom.example', $updated->getHeaderLine('Host'));
+    }
+
+    public function testWithUriPreserveHostUpdatesEmptyHostHeaderForDifferentUri(): void
+    {
+        $request = new Request('GET', 'http://foo.com/bar', ['Host' => '']);
+
+        $updated = $request->withUri(new Uri('http://bar.com:8125/baz'), true);
+
+        self::assertNotSame($request, $updated);
+        self::assertSame('bar.com:8125', $updated->getHeaderLine('Host'));
+        self::assertSame('http://bar.com:8125/baz', (string) $updated->getUri());
+    }
+
+    public function testWithUriPreserveHostDoesNotReadUriHostWhenHostIsNonEmpty(): void
+    {
+        $uri = $this->createMock(UriInterface::class);
+        $uri->method('getPath')->willReturn('/new');
+        $uri->method('getQuery')->willReturn('');
+        $uri->expects(self::never())->method('getHost');
+        $uri->expects(self::never())->method('getPort');
+
+        $request = new Request('GET', 'http://foo.com', ['Host' => 'custom.example']);
+
+        $updated = $request->withUri($uri, true);
+
+        self::assertNotSame($request, $updated);
+        self::assertSame($uri, $updated->getUri());
+        self::assertSame('custom.example', $updated->getHeaderLine('Host'));
+    }
+
+    public function testWithUriSameInstanceRejectsInvalidUriHostWhenHostSynchronizationIsRequired(): void
+    {
+        $uri = $this->createMock(UriInterface::class);
+        $uri->method('getPath')->willReturn('/');
+        $uri->method('getQuery')->willReturn('');
+        $uri->method('getHost')->willReturn("foo\nbar");
+        $uri->method('getPort')->willReturn(null);
+
+        $request = new Request('GET', $uri, ['Host' => 'custom.example']);
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $request->withUri($request->getUri());
+    }
+
     public function testWithRequestTarget(): void
     {
         $r1 = new Request('GET', '/');


### PR DESCRIPTION
This change makes `Request::withUri()` apply PSR-7 Host header synchronization before using the same-URI no-op path. Reapplying the current URI can now repair a missing, empty, or stale Host header when the URI contains a host, while preserving the existing same-instance return when the Host header is already correct or intentionally preserved.

The implementation reuses the existing URI-derived Host validation and header ordering behavior. It also documents the behavior change in the 3.0 upgrade guide because callers that intentionally keep an empty or stale Host header may need to set it after calling `withUri()`.