### PR TITLE
Include URI ports in synthesized Host headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reject duplicate `Host` field lines in `Message::parseRequest()`
 - Validate present raw `Host` field values in `Message::parseRequest()` for all request-target forms
 - Apply PSR-7 Host header synchronization in `Request::withUri()` for same-instance URIs and empty Host headers
+- Include URI ports when `Message::toString()` synthesizes a missing `Host` header
 - Normalize server request URI reconstruction from globals, including `REQUEST_METHOD` values used for request-target parsing
 - Accept `OPTIONS *` and `CONNECT` authority-form request targets in `Message::parseRequest()`
 - Reject malformed HTTP start-line fields

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -251,6 +251,10 @@ $updated->getHeaderLine('Host'); // example.com:8124
 If your application intentionally sends an empty or stale Host header, set it
 after calling `withUri()` or preserve a non-empty Host header explicitly.
 
+`Message::toString()` now applies the same URI host and port synthesis when
+serializing a request without a `Host` header. Generated `Host` lines include
+non-null URI ports.
+
 #### URI Paths and Request Targets
 
 `Uri::getPath()` now normalizes multiple leading slashes to one slash when

--- a/src/Message.php
+++ b/src/Message.php
@@ -7,6 +7,7 @@ namespace GuzzleHttp\Psr7;
 use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\UriInterface;
 
 final class Message
 {
@@ -26,7 +27,7 @@ final class Message
                     .$message->getRequestTarget())
                 .' HTTP/'.$message->getProtocolVersion();
             if (!$message->hasHeader('host')) {
-                $msg .= "\r\nHost: ".$message->getUri()->getHost();
+                $msg .= "\r\nHost: ".self::hostHeaderFromUri($message->getUri());
             }
         } elseif ($message instanceof ResponseInterface) {
             $msg = 'HTTP/'.$message->getProtocolVersion().' '
@@ -47,6 +48,21 @@ final class Message
         }
 
         return "{$msg}\r\n\r\n".$message->getBody();
+    }
+
+    private static function hostHeaderFromUri(UriInterface $uri): string
+    {
+        $host = $uri->getHost();
+
+        if ($host === '') {
+            return '';
+        }
+
+        if (($port = $uri->getPort()) !== null) {
+            $host .= ':'.$port;
+        }
+
+        return $host;
     }
 
     /**

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -22,6 +22,46 @@ class MessageTest extends TestCase
         );
     }
 
+    public function testConvertsRequestWithoutHostHeaderToStringWithUriPort(): void
+    {
+        $request = (new Psr7\Request('GET', 'http://foo.com:8124/hi'))->withoutHeader('Host');
+
+        self::assertSame(
+            "GET /hi HTTP/1.1\r\nHost: foo.com:8124\r\n\r\n",
+            Psr7\Message::toString($request)
+        );
+    }
+
+    public function testConvertsRequestWithoutHostHeaderToStringWithIpv6UriPort(): void
+    {
+        $request = (new Psr7\Request('GET', 'http://[::1]:8124/'))->withoutHeader('Host');
+
+        self::assertSame(
+            "GET / HTTP/1.1\r\nHost: [::1]:8124\r\n\r\n",
+            Psr7\Message::toString($request)
+        );
+    }
+
+    public function testConvertsRequestWithoutHostHeaderToStringWithoutUriUserInfo(): void
+    {
+        $request = (new Psr7\Request('GET', 'http://user:pass@foo.com:8124/hi'))->withoutHeader('Host');
+
+        self::assertSame(
+            "GET /hi HTTP/1.1\r\nHost: foo.com:8124\r\n\r\n",
+            Psr7\Message::toString($request)
+        );
+    }
+
+    public function testConvertsRequestWithHostHeaderToStringWithoutOverwritingHost(): void
+    {
+        $request = new Psr7\Request('GET', 'http://foo.com:8124/hi', ['Host' => 'custom.example']);
+
+        self::assertSame(
+            "GET /hi HTTP/1.1\r\nHost: custom.example\r\n\r\n",
+            Psr7\Message::toString($request)
+        );
+    }
+
     public function testConvertsResponsesToStrings(): void
     {
         $response = new Psr7\Response(200, [


### PR DESCRIPTION
This change makes Message::toString() include the URI port when it serializes a request that does not already have a Host header. The generated Host value is still built from the URI host and port only, so URI userinfo is not included and existing Host headers are not overwritten.

This keeps request string serialization aligned with the Host header synthesis used elsewhere in the request implementation while avoiding a new validation path in Message::toString().