### PR TITLE
Rewind seekable uploaded streams before moving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reject empty arrays and non-string values as header values
 - Reject invalid uploaded file trees and invalid parsed body values
 - Reject malformed uploaded file specifications missing `tmp_name`, `size`, or `error`
+- Rewind seekable stream-backed uploaded files before copying them in `UploadedFile::moveTo()`
 - Normalize multiple leading slashes to one slash in `Uri::getPath()` and URI-derived `Request::getRequestTarget()` values
 - Harden URI host validation for delimiters, backslashes, and invalid IPv6/IP literals; reject schemes not beginning with a letter
 - Redact all non-empty URI userinfo in `Utils::redactUserInfo()`

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -147,6 +147,12 @@ $files = ['file' => ['tmp_name' => '/tmp/php123', 'error' => '0']];
 $files = ['file' => ['tmp_name' => '/tmp/php123', 'size' => '123', 'error' => '0']];
 ```
 
+For stream-backed uploads, `UploadedFile::moveTo()` now rewinds seekable streams
+before copying them. If application code reads from a seekable uploaded stream
+before calling `moveTo()`, 3.0 writes the full stream contents to the target
+instead of only the unread suffix. Non-seekable stream-backed uploads continue to
+copy from their current position because consumed bytes cannot be replayed.
+
 #### Parsed Body Values
 
 `ServerRequestInterface::withParsedBody()` now rejects values other than

--- a/src/UploadedFile.php
+++ b/src/UploadedFile.php
@@ -148,8 +148,13 @@ class UploadedFile implements UploadedFileInterface
                 ? rename($this->file, $targetPath)
                 : move_uploaded_file($this->file, $targetPath);
         } else {
+            $stream = $this->getStream();
+            if ($stream->isSeekable()) {
+                $stream->rewind();
+            }
+
             Utils::copyToStream(
-                $this->getStream(),
+                $stream,
                 new LazyOpenStream($targetPath, 'w')
             );
 

--- a/tests/UploadedFileTest.php
+++ b/tests/UploadedFileTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GuzzleHttp\Tests\Psr7;
 
+use GuzzleHttp\Psr7\FnStream;
 use GuzzleHttp\Psr7\NoSeekStream;
 use GuzzleHttp\Psr7\Stream;
 use GuzzleHttp\Psr7\UploadedFile;
@@ -256,5 +257,56 @@ class UploadedFileTest extends TestCase
         $uploadedFile->moveTo($to);
 
         self::assertSame('bar!', file_get_contents($to));
+    }
+
+    public function testMoveToCopiesCompleteSeekableStreamBackedUploadAfterPartialRead(): void
+    {
+        $stream = \GuzzleHttp\Psr7\Utils::streamFor('Foo bar!');
+        $uploadedFile = new UploadedFile($stream, $stream->getSize(), UPLOAD_ERR_OK, 'filename.txt', 'text/plain');
+
+        self::assertSame('Foo ', $uploadedFile->getStream()->read(4));
+
+        $this->cleanup[] = $to = tempnam(sys_get_temp_dir(), 'seekable_upload');
+        $uploadedFile->moveTo($to);
+
+        self::assertSame('Foo bar!', file_get_contents($to));
+    }
+
+    public function testMoveToCopiesCompleteSeekableStreamBackedUploadFromEnd(): void
+    {
+        $stream = \GuzzleHttp\Psr7\Utils::streamFor('Foo bar!');
+        $uploadedFile = new UploadedFile($stream, $stream->getSize(), UPLOAD_ERR_OK, 'filename.txt', 'text/plain');
+
+        self::assertSame('Foo bar!', $uploadedFile->getStream()->getContents());
+
+        $this->cleanup[] = $to = tempnam(sys_get_temp_dir(), 'seekable_upload');
+        $uploadedFile->moveTo($to);
+
+        self::assertSame('Foo bar!', file_get_contents($to));
+    }
+
+    public function testMoveToLeavesUploadActiveWhenSeekableStreamCannotRewind(): void
+    {
+        $stream = FnStream::decorate(\GuzzleHttp\Psr7\Utils::streamFor('Foo bar!'), [
+            'isSeekable' => function (): bool {
+                return true;
+            },
+            'rewind' => function (): void {
+                throw new \RuntimeException('Unable to rewind stream');
+            },
+        ]);
+        $uploadedFile = new UploadedFile($stream, 8, UPLOAD_ERR_OK, 'filename.txt', 'text/plain');
+        $this->cleanup[] = $to = tempnam(sys_get_temp_dir(), 'seekable_upload');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Unable to rewind stream');
+
+        try {
+            $uploadedFile->moveTo($to);
+        } catch (\RuntimeException $e) {
+            self::assertFalse($uploadedFile->isMoved());
+
+            throw $e;
+        }
     }
 }


### PR DESCRIPTION
When an UploadedFile is backed by a seekable stream, moveTo() currently copies from whatever cursor position the caller left behind. That means code can read a few bytes for validation and then accidentally persist only the unread suffix.

This changes stream-backed uploads to rewind seekable streams before copying, while leaving file-backed uploads and non-seekable streams alone. If rewind fails, the upload is not marked as moved. The changelog and upgrade guide now call out the behavior change, including the fact that non-seekable streams still copy from their current position because consumed bytes cannot be replayed.