### PR TITLE
Characterize stream lifecycle behavior

### DIFF
--- a/tests/BufferStreamTest.php
+++ b/tests/BufferStreamTest.php
@@ -54,6 +54,19 @@ class BufferStreamTest extends TestCase
         self::assertSame('abc', $b->read(10));
     }
 
+    public function testCloseClearsBuffer(): void
+    {
+        $b = new BufferStream();
+        $b->write('foo');
+
+        $b->close();
+
+        self::assertTrue($b->eof());
+        self::assertSame(0, $b->getSize());
+        self::assertSame(3, $b->write('abc'));
+        self::assertSame('abc', $b->read(10));
+    }
+
     public function testExceedingHighwaterMarkReturnsFalseButStillBuffers(): void
     {
         $b = new BufferStream(5);

--- a/tests/FnStreamTest.php
+++ b/tests/FnStreamTest.php
@@ -70,6 +70,38 @@ class FnStreamTest extends TestCase
         self::assertTrue($called);
     }
 
+    public function testCanCloseUsingCallable(): void
+    {
+        $called = false;
+        $s = new FnStream([
+            'close' => function () use (&$called): void {
+                $called = true;
+            },
+        ]);
+
+        $s->close();
+
+        self::assertTrue($called);
+    }
+
+    public function testCanDetachUsingCallable(): void
+    {
+        $called = false;
+        $resource = fopen('php://temp', 'r+');
+        $s = new FnStream([
+            'detach' => function () use (&$called, $resource) {
+                $called = true;
+
+                return $resource;
+            },
+        ]);
+
+        self::assertSame($resource, $s->detach());
+        self::assertTrue($called);
+
+        fclose($resource);
+    }
+
     public function testDoesNotRequireClose(): void
     {
         $s = new FnStream([]);

--- a/tests/LimitStreamTest.php
+++ b/tests/LimitStreamTest.php
@@ -122,6 +122,16 @@ class LimitStreamTest extends TestCase
         self::assertSame('foo_bar', $c->getContents());
     }
 
+    public function testCloseClosesDecoratedStream(): void
+    {
+        $handle = fopen('php://temp', 'r+');
+        $stream = new LimitStream(Psr7\Utils::streamFor($handle));
+
+        $stream->close();
+
+        self::assertFalse(is_resource($handle));
+    }
+
     public function testClaimsConsumedWhenReadLimitIsReached(): void
     {
         self::assertFalse($this->body->eof());

--- a/tests/NoSeekStreamTest.php
+++ b/tests/NoSeekStreamTest.php
@@ -35,4 +35,16 @@ class NoSeekStreamTest extends TestCase
 
         $wrapped->close();
     }
+
+    public function testDetachDelegatesToDecoratedStream(): void
+    {
+        $resource = fopen('php://temp', 'r+');
+        $wrapped = new NoSeekStream(\GuzzleHttp\Psr7\Utils::streamFor($resource));
+
+        self::assertFalse($wrapped->isSeekable());
+        self::assertSame($resource, $wrapped->detach());
+        self::assertNull($wrapped->detach());
+
+        fclose($resource);
+    }
 }

--- a/tests/PumpStreamTest.php
+++ b/tests/PumpStreamTest.php
@@ -152,6 +152,21 @@ class PumpStreamTest extends TestCase
         }
     }
 
+    public function testCloseDetachesSourceButLeavesBufferedBytesReadable(): void
+    {
+        $p = new PumpStream(function (): string {
+            return 'abc';
+        });
+
+        self::assertSame('a', $p->read(1));
+
+        $p->close();
+
+        self::assertTrue($p->eof());
+        self::assertSame('bc', $p->read(10));
+        self::assertSame(2, $p->tell());
+    }
+
     public function testThatConvertingStreamToStringWillThrowException(): void
     {
         $p = Psr7\Utils::streamFor(function ($size): void {


### PR DESCRIPTION
This adds missing lifecycle characterization in the existing test files that correspond to each stream implementation, instead of introducing a cross-cutting lifecycle test file.

The new coverage documents close and detach behavior for BufferStream, FnStream, LimitStream, NoSeekStream, and PumpStream. One intentionally odd behavior is captured rather than changed: PumpStream detaches its source on close, but bytes already buffered before close remain readable afterward.