### PR TITLE
Reject negative stream reads consistently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reject invalid uploaded file trees and invalid parsed body values
 - Reject malformed uploaded file specifications missing `tmp_name`, `size`, or `error`
 - Rewind seekable stream-backed uploaded files before copying them in `UploadedFile::moveTo()`
+- Reject negative stream read lengths consistently across stream implementations
 - Normalize multiple leading slashes to one slash in `Uri::getPath()` and URI-derived `Request::getRequestTarget()` values
 - Harden URI host validation for delimiters, backslashes, and invalid IPv6/IP literals; reject schemes not beginning with a letter
 - Redact all non-empty URI userinfo in `Utils::redactUserInfo()`

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -617,6 +617,10 @@ of depending on package internals.
 its high-water mark. This keeps the method compatible with the `int` return type
 from `StreamInterface::write()`.
 
+All stream implementations now reject negative `read()` lengths with
+`RuntimeException`. In 2.x, some decorators passed negative lengths through,
+some returned sliced data, and some behavior varied by PHP version.
+
 Timed-out stream operations now throw
 `GuzzleHttp\Psr7\Exception\TimeoutException`, which extends
 `RuntimeException`. `Stream::read()`, `Utils::copyToStream()`,

--- a/src/AppendStream.php
+++ b/src/AppendStream.php
@@ -176,6 +176,10 @@ final class AppendStream implements StreamInterface
      */
     public function read(int $length): string
     {
+        if ($length < 0) {
+            throw new \RuntimeException('Length parameter cannot be negative');
+        }
+
         if ($this->streams === []) {
             return '';
         }

--- a/src/BufferStream.php
+++ b/src/BufferStream.php
@@ -102,6 +102,10 @@ final class BufferStream implements StreamInterface
      */
     public function read(int $length): string
     {
+        if ($length < 0) {
+            throw new \RuntimeException('Length parameter cannot be negative');
+        }
+
         $currentLength = strlen($this->buffer);
 
         if ($length >= $currentLength) {

--- a/src/CachingStream.php
+++ b/src/CachingStream.php
@@ -100,6 +100,10 @@ final class CachingStream implements StreamInterface
 
     public function read(int $length): string
     {
+        if ($length < 0) {
+            throw new \RuntimeException('Length parameter cannot be negative');
+        }
+
         // Perform a regular read on any previously read data from the buffer
         $data = $this->stream->read($length);
         $remaining = $length - strlen($data);

--- a/src/FnStream.php
+++ b/src/FnStream.php
@@ -151,6 +151,10 @@ final class FnStream implements StreamInterface
 
     public function read(int $length): string
     {
+        if ($length < 0) {
+            throw new \RuntimeException('Length parameter cannot be negative');
+        }
+
         return ($this->_fn_read)($length);
     }
 

--- a/src/LimitStream.php
+++ b/src/LimitStream.php
@@ -142,6 +142,10 @@ final class LimitStream implements StreamInterface
 
     public function read(int $length): string
     {
+        if ($length < 0) {
+            throw new \RuntimeException('Length parameter cannot be negative');
+        }
+
         if ($this->limit === -1) {
             return $this->stream->read($length);
         }

--- a/src/PumpStream.php
+++ b/src/PumpStream.php
@@ -118,6 +118,10 @@ final class PumpStream implements StreamInterface
 
     public function read(int $length): string
     {
+        if ($length < 0) {
+            throw new \RuntimeException('Length parameter cannot be negative');
+        }
+
         $data = $this->buffer->read($length);
         $readLen = strlen($data);
         $this->tellPos += $readLen;

--- a/src/StreamDecoratorTrait.php
+++ b/src/StreamDecoratorTrait.php
@@ -125,6 +125,10 @@ trait StreamDecoratorTrait
 
     public function read(int $length): string
     {
+        if ($length < 0) {
+            throw new \RuntimeException('Length parameter cannot be negative');
+        }
+
         return $this->stream->read($length);
     }
 

--- a/tests/AppendStreamTest.php
+++ b/tests/AppendStreamTest.php
@@ -148,6 +148,16 @@ class AppendStreamTest extends TestCase
         self::assertTrue($stream->eof());
     }
 
+    public function testReadRejectsNegativeLength(): void
+    {
+        $stream = new AppendStream();
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Length parameter cannot be negative');
+
+        $stream->read(-1);
+    }
+
     public function testReadAfterCloseReturnsEmptyString(): void
     {
         $stream = new AppendStream([Psr7\Utils::streamFor('foo')]);

--- a/tests/BufferStreamTest.php
+++ b/tests/BufferStreamTest.php
@@ -31,6 +31,16 @@ class BufferStreamTest extends TestCase
         self::assertSame('', $b->read(10));
     }
 
+    public function testReadRejectsNegativeLength(): void
+    {
+        $b = new BufferStream();
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Length parameter cannot be negative');
+
+        $b->read(-1);
+    }
+
     public function testCanCastToStringOrGetContents(): void
     {
         $b = new BufferStream();

--- a/tests/CachingStreamTest.php
+++ b/tests/CachingStreamTest.php
@@ -135,6 +135,14 @@ class CachingStreamTest extends TestCase
         self::assertSame('test', $this->body->read(4));
     }
 
+    public function testReadRejectsNegativeLength(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Length parameter cannot be negative');
+
+        $this->body->read(-1);
+    }
+
     public function testReadThrowsWhenRemoteStreamTimesOut(): void
     {
         $remote = new Psr7\FnStream([

--- a/tests/DroppingStreamTest.php
+++ b/tests/DroppingStreamTest.php
@@ -27,4 +27,14 @@ class DroppingStreamTest extends TestCase
         $drop->write('hello');
         self::assertSame(0, $drop->write('test'));
     }
+
+    public function testReadRejectsNegativeLength(): void
+    {
+        $drop = new DroppingStream(new BufferStream(), 5);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Length parameter cannot be negative');
+
+        $drop->read(-1);
+    }
 }

--- a/tests/FnStreamTest.php
+++ b/tests/FnStreamTest.php
@@ -33,6 +33,27 @@ class FnStreamTest extends TestCase
         self::assertSame('foo', $s->read(3));
     }
 
+    public function testReadRejectsNegativeLengthWithoutCallingCallback(): void
+    {
+        $called = false;
+        $s = new FnStream([
+            'read' => function () use (&$called): string {
+                $called = true;
+
+                return 'foo';
+            },
+        ]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Length parameter cannot be negative');
+
+        try {
+            $s->read(-1);
+        } finally {
+            self::assertFalse($called);
+        }
+    }
+
     public function testProxiesToNonClosureCallable(): void
     {
         $s = new FnStream([

--- a/tests/InflateStreamTest.php
+++ b/tests/InflateStreamTest.php
@@ -80,6 +80,16 @@ class InflateStreamTest extends TestCase
         self::assertSame('test', (string) $nonSeekableInflate);
     }
 
+    public function testReadRejectsNegativeLength(): void
+    {
+        $stream = new InflateStream(Psr7\Utils::streamFor(gzencode('test')));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Length parameter cannot be negative');
+
+        $stream->read(-1);
+    }
+
     private function getGzipStringWithFilename(string $original_string): string
     {
         $gzipped = bin2hex(gzencode($original_string));

--- a/tests/LazyOpenStreamTest.php
+++ b/tests/LazyOpenStreamTest.php
@@ -56,6 +56,20 @@ class LazyOpenStreamTest extends TestCase
         $l->close();
     }
 
+    public function testReadRejectsNegativeLengthWithoutOpeningFile(): void
+    {
+        $l = new LazyOpenStream($this->fname, 'r');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Length parameter cannot be negative');
+
+        try {
+            $l->read(-1);
+        } finally {
+            self::assertFileDoesNotExist($this->fname);
+        }
+    }
+
     public function testDetachesUnderlyingStream(): void
     {
         file_put_contents($this->fname, 'foo');

--- a/tests/LimitStreamTest.php
+++ b/tests/LimitStreamTest.php
@@ -132,6 +132,14 @@ class LimitStreamTest extends TestCase
         self::assertFalse(is_resource($handle));
     }
 
+    public function testReadRejectsNegativeLength(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Length parameter cannot be negative');
+
+        $this->body->read(-1);
+    }
+
     public function testClaimsConsumedWhenReadLimitIsReached(): void
     {
         self::assertFalse($this->body->eof());

--- a/tests/NoSeekStreamTest.php
+++ b/tests/NoSeekStreamTest.php
@@ -47,4 +47,14 @@ class NoSeekStreamTest extends TestCase
 
         fclose($resource);
     }
+
+    public function testReadRejectsNegativeLength(): void
+    {
+        $wrapped = new NoSeekStream(\GuzzleHttp\Psr7\Utils::streamFor('foo'));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Length parameter cannot be negative');
+
+        $wrapped->read(-1);
+    }
 }

--- a/tests/PumpStreamTest.php
+++ b/tests/PumpStreamTest.php
@@ -50,6 +50,25 @@ class PumpStreamTest extends TestCase
         self::assertSame(6, $p->tell());
     }
 
+    public function testReadRejectsNegativeLengthWithoutCallingSource(): void
+    {
+        $called = false;
+        $p = new PumpStream(function () use (&$called): string {
+            $called = true;
+
+            return 'abc';
+        });
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Length parameter cannot be negative');
+
+        try {
+            $p->read(-1);
+        } finally {
+            self::assertFalse($called);
+        }
+    }
+
     public function testCanReadFromCallableString(): void
     {
         self::$chunks = ['foo', false];


### PR DESCRIPTION
This changes negative stream reads from implementation-specific behavior into one consistent 3.0 rule. Every stream implementation now rejects read(-1) with the same RuntimeException message already used by Stream.

The earlier characterization exposed different behavior on PHP 7.4 and PHP 8 because BufferStream relied on PHP substr() behavior for negative lengths. This avoids documenting that version split and instead normalizes package behavior across PHP versions and stream implementations.