### PR TITLE
Tighten LimitStream offset handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reject malformed uploaded file specifications missing `tmp_name`, `size`, or `error`
 - Rewind seekable stream-backed uploaded files before copying them in `UploadedFile::moveTo()`
 - Reject negative stream read lengths consistently across stream implementations
+- Validate `LimitStream` offset and limit values and track non-seekable offsets by bytes actually skipped
 - Normalize multiple leading slashes to one slash in `Uri::getPath()` and URI-derived `Request::getRequestTarget()` values
 - Harden URI host validation for delimiters, backslashes, and invalid IPv6/IP literals; reject schemes not beginning with a letter
 - Redact all non-empty URI userinfo in `Utils::redactUserInfo()`

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -621,6 +621,11 @@ All stream implementations now reject negative `read()` lengths with
 `RuntimeException`. In 2.x, some decorators passed negative lengths through,
 some returned sliced data, and some behavior varied by PHP version.
 
+`LimitStream` now rejects negative offsets and limits below `-1`. For
+non-seekable streams, offsets are tracked by the number of bytes actually
+skipped. Short reads are retried until the offset is reached, EOF is reached, or
+the decorated stream stops making progress.
+
 Timed-out stream operations now throw
 `GuzzleHttp\Psr7\Exception\TimeoutException`, which extends
 `RuntimeException`. `Stream::read()`, `Utils::copyToStream()`,

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -103,6 +103,12 @@ parameters:
 			path: src/Header.php
 
 		-
+			message: '#^If condition is always false\.$#'
+			identifier: if.alwaysFalse
+			count: 1
+			path: src/LimitStream.php
+
+		-
 			message: '#^PHPDoc tag @var with type array\<array\> is not subtype of native type list\<array\<string\>\>\.$#'
 			identifier: varTag.nativeType
 			count: 1

--- a/src/LimitStream.php
+++ b/src/LimitStream.php
@@ -112,17 +112,50 @@ final class LimitStream implements StreamInterface
      */
     public function setOffset(int $offset): void
     {
+        if ($offset < 0) {
+            throw new \InvalidArgumentException('Offset must be a non-negative integer');
+        }
+
         $current = $this->stream->tell();
 
-        if ($current !== $offset) {
-            // If the stream cannot seek to the offset position, then read to it
-            if ($this->stream->isSeekable()) {
-                $this->stream->seek($offset);
-            } elseif ($current > $offset) {
-                throw new \RuntimeException("Could not seek to stream offset $offset");
-            } else {
-                $this->stream->read($offset - $current);
+        if ($current === $offset) {
+            $this->offset = $offset;
+
+            return;
+        }
+
+        // If the stream cannot seek to the offset position, then read to it.
+        if ($this->stream->isSeekable()) {
+            $this->stream->seek($offset);
+            $this->offset = $offset;
+
+            return;
+        }
+
+        if ($current > $offset) {
+            throw new \RuntimeException("Could not seek to stream offset $offset");
+        }
+
+        while ($current < $offset) {
+            if ($this->stream->eof()) {
+                $this->offset = $current;
+
+                return;
             }
+
+            $result = $this->stream->read($offset - $current);
+
+            if ($result === '') {
+                if ($this->stream->eof()) {
+                    $this->offset = $current;
+
+                    return;
+                }
+
+                throw new \RuntimeException("Could not seek to stream offset $offset");
+            }
+
+            $current += strlen($result);
         }
 
         $this->offset = $offset;
@@ -137,6 +170,10 @@ final class LimitStream implements StreamInterface
      */
     public function setLimit(int $limit): void
     {
+        if ($limit < -1) {
+            throw new \InvalidArgumentException('Limit must be -1 or a non-negative integer');
+        }
+
         $this->limit = $limit;
     }
 

--- a/tests/LimitStreamTest.php
+++ b/tests/LimitStreamTest.php
@@ -114,6 +114,105 @@ class LimitStreamTest extends TestCase
         $c->setOffset(2);
     }
 
+    public function testSkipsShortNonSeekableReadsUntilOffsetIsReached(): void
+    {
+        $position = 0;
+        $chunks = ['a', 'b', 'c', 'd'];
+        $stream = new FnStream([
+            'tell' => function () use (&$position): int {
+                return $position;
+            },
+            'isSeekable' => function (): bool {
+                return false;
+            },
+            'eof' => function () use (&$chunks): bool {
+                return $chunks === [];
+            },
+            'read' => function () use (&$chunks, &$position): string {
+                $chunk = array_shift($chunks) ?? '';
+                $position += strlen($chunk);
+
+                return $chunk;
+            },
+        ]);
+
+        $limited = new LimitStream($stream, -1, 3);
+
+        self::assertSame(0, $limited->tell());
+        self::assertSame('d', $limited->read(1));
+    }
+
+    public function testOffsetPastEndOfNonSeekableStreamStopsAtEnd(): void
+    {
+        $position = 0;
+        $chunks = ['a', 'b', 'c'];
+        $stream = new FnStream([
+            'tell' => function () use (&$position): int {
+                return $position;
+            },
+            'isSeekable' => function (): bool {
+                return false;
+            },
+            'eof' => function () use (&$chunks): bool {
+                return $chunks === [];
+            },
+            'read' => function () use (&$chunks, &$position): string {
+                $chunk = array_shift($chunks) ?? '';
+                $position += strlen($chunk);
+
+                return $chunk;
+            },
+            'getSize' => function (): int {
+                return 3;
+            },
+        ]);
+
+        $limited = new LimitStream($stream, -1, 4);
+
+        self::assertSame(0, $limited->tell());
+        self::assertSame(0, $limited->getSize());
+        self::assertSame('', $limited->read(1));
+    }
+
+    public function testThrowsWhenNonSeekableReadMakesNoProgressBeforeEnd(): void
+    {
+        $stream = new FnStream([
+            'tell' => function (): int {
+                return 0;
+            },
+            'isSeekable' => function (): bool {
+                return false;
+            },
+            'eof' => function (): bool {
+                return false;
+            },
+            'read' => function (): string {
+                return '';
+            },
+        ]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Could not seek to stream offset 3');
+
+        new LimitStream($stream, -1, 3);
+    }
+
+    public function testRejectsNegativeOffset(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Offset must be a non-negative integer');
+
+        new LimitStream(Psr7\Utils::streamFor('foo'), -1, -1);
+    }
+
+    public function testRejectsInvalidLimit(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Limit must be -1 or a non-negative integer');
+
+        new LimitStream(Psr7\Utils::streamFor('foo'), -2);
+    }
+
     public function testCanGetContentsWithoutSeeking(): void
     {
         $a = Psr7\Utils::streamFor('foo_bar');


### PR DESCRIPTION
This makes LimitStream track non-seekable offsets by the bytes actually skipped instead of assuming a single read reached the requested offset. Short reads are retried, offset-past-EOF remains an empty limited stream, and no-progress reads before EOF still fail instead of looping or corrupting the logical position.

It also rejects negative offsets and limits below -1 explicitly, and documents the 3.0 behavior change in the changelog and upgrade guide.