### PR TITLE
Make FnStream close and detach terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rewind seekable stream-backed uploaded files before copying them in `UploadedFile::moveTo()`
 - Reject negative stream read lengths consistently across stream implementations
 - Validate `LimitStream` offset and limit values and track non-seekable offsets by bytes actually skipped
+- Invoke `FnStream` close callbacks at most once across explicit `close()` calls and destruction
 - Normalize multiple leading slashes to one slash in `Uri::getPath()` and URI-derived `Request::getRequestTarget()` values
 - Harden URI host validation for delimiters, backslashes, and invalid IPv6/IP literals; reject schemes not beginning with a letter
 - Redact all non-empty URI userinfo in `Utils::redactUserInfo()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rewind seekable stream-backed uploaded files before copying them in `UploadedFile::moveTo()`
 - Reject negative stream read lengths consistently across stream implementations
 - Validate `LimitStream` offset and limit values and track non-seekable offsets by bytes actually skipped
-- Invoke `FnStream` close callbacks at most once across explicit `close()` calls and destruction
+- Make `FnStream` close and detach terminal, preventing later operation forwarding and invoking close callbacks at most once
 - Normalize multiple leading slashes to one slash in `Uri::getPath()` and URI-derived `Request::getRequestTarget()` values
 - Harden URI host validation for delimiters, backslashes, and invalid IPv6/IP literals; reject schemes not beginning with a letter
 - Redact all non-empty URI userinfo in `Utils::redactUserInfo()`

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -344,6 +344,14 @@ $stream = Utils::streamFor(new ArrayIterator([false, 'body']));
 $stream = Utils::streamFor(new ArrayIterator(['body']));
 ```
 
+#### Stream Lifecycle
+
+`FnStream` now treats `close()` and successful `detach()` calls as terminal
+lifecycle operations. Its configured `close` callback is invoked at most once;
+repeated `close()` calls are no-ops, destruction after explicit close no longer
+invokes the close callback, and closed or detached streams no longer forward
+read, write, seek, metadata, or stringification callbacks.
+
 #### Multipart Part Headers and Metadata
 
 `MultipartStream` no longer adds default `Content-Length` headers to individual
@@ -625,12 +633,6 @@ some returned sliced data, and some behavior varied by PHP version.
 non-seekable streams, offsets are tracked by the number of bytes actually
 skipped. Short reads are retried until the offset is reached, EOF is reached, or
 the decorated stream stops making progress.
-
-`FnStream` now treats `close()` and successful `detach()` calls as terminal
-lifecycle operations. Its configured `close` callback is invoked at most once;
-repeated `close()` calls are no-ops, destruction after explicit close no longer
-invokes the close callback, and closed or detached streams no longer forward
-read, write, seek, metadata, or stringification callbacks.
 
 Timed-out stream operations now throw
 `GuzzleHttp\Psr7\Exception\TimeoutException`, which extends

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -626,6 +626,10 @@ non-seekable streams, offsets are tracked by the number of bytes actually
 skipped. Short reads are retried until the offset is reached, EOF is reached, or
 the decorated stream stops making progress.
 
+`FnStream` now invokes its configured `close` callback at most once. Calling
+`close()` explicitly suppresses the destructor close callback, and repeated
+`close()` calls after the first close are no-ops.
+
 Timed-out stream operations now throw
 `GuzzleHttp\Psr7\Exception\TimeoutException`, which extends
 `RuntimeException`. `Stream::read()`, `Utils::copyToStream()`,

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -626,9 +626,11 @@ non-seekable streams, offsets are tracked by the number of bytes actually
 skipped. Short reads are retried until the offset is reached, EOF is reached, or
 the decorated stream stops making progress.
 
-`FnStream` now invokes its configured `close` callback at most once. Calling
-`close()` explicitly suppresses the destructor close callback, and repeated
-`close()` calls after the first close are no-ops.
+`FnStream` now treats `close()` and successful `detach()` calls as terminal
+lifecycle operations. Its configured `close` callback is invoked at most once;
+repeated `close()` calls are no-ops, destruction after explicit close no longer
+invokes the close callback, and closed or detached streams no longer forward
+read, write, seek, metadata, or stringification callbacks.
 
 Timed-out stream operations now throw
 `GuzzleHttp\Psr7\Exception\TimeoutException`, which extends

--- a/src/FnStream.php
+++ b/src/FnStream.php
@@ -24,6 +24,8 @@ final class FnStream implements StreamInterface
     /** @var array<string, callable> */
     private array $methods;
 
+    private bool $closed = false;
+
     /**
      * @param array<string, callable> $methods Hash of method name to a callable.
      */
@@ -53,8 +55,8 @@ final class FnStream implements StreamInterface
      */
     public function __destruct()
     {
-        if (isset($this->_fn_close)) {
-            ($this->_fn_close)();
+        if (!$this->closed && isset($this->_fn_close)) {
+            $this->close();
         }
     }
 
@@ -96,7 +98,13 @@ final class FnStream implements StreamInterface
 
     public function close(): void
     {
-        ($this->_fn_close)();
+        if ($this->closed) {
+            return;
+        }
+
+        $close = $this->_fn_close;
+        $this->closed = true;
+        $close();
     }
 
     public function detach()

--- a/src/FnStream.php
+++ b/src/FnStream.php
@@ -24,7 +24,7 @@ final class FnStream implements StreamInterface
     /** @var array<string, callable> */
     private array $methods;
 
-    private bool $closed = false;
+    private bool $detached = false;
 
     /**
      * @param array<string, callable> $methods Hash of method name to a callable.
@@ -55,7 +55,7 @@ final class FnStream implements StreamInterface
      */
     public function __destruct()
     {
-        if (!$this->closed && isset($this->_fn_close)) {
+        if (!$this->detached && isset($this->_fn_close)) {
             $this->close();
         }
     }
@@ -92,73 +92,111 @@ final class FnStream implements StreamInterface
 
     public function __toString(): string
     {
+        $this->assertAttached();
+
         /** @var string */
         return ($this->_fn___toString)();
     }
 
     public function close(): void
     {
-        if ($this->closed) {
+        if ($this->detached) {
             return;
         }
 
         $close = $this->_fn_close;
-        $this->closed = true;
+        $this->detached = true;
         $close();
     }
 
     public function detach()
     {
-        return ($this->_fn_detach)();
+        if ($this->detached) {
+            return null;
+        }
+
+        $detach = $this->_fn_detach;
+        $result = $detach();
+        $this->detached = true;
+
+        return $result;
     }
 
     public function getSize(): ?int
     {
+        if ($this->detached) {
+            return null;
+        }
+
         return ($this->_fn_getSize)();
     }
 
     public function tell(): int
     {
+        $this->assertAttached();
+
         return ($this->_fn_tell)();
     }
 
     public function eof(): bool
     {
+        $this->assertAttached();
+
         return ($this->_fn_eof)();
     }
 
     public function isSeekable(): bool
     {
+        if ($this->detached) {
+            return false;
+        }
+
         return ($this->_fn_isSeekable)();
     }
 
     public function rewind(): void
     {
+        $this->assertAttached();
+
         ($this->_fn_rewind)();
     }
 
     public function seek(int $offset, int $whence = SEEK_SET): void
     {
+        $this->assertAttached();
+
         ($this->_fn_seek)($offset, $whence);
     }
 
     public function isWritable(): bool
     {
+        if ($this->detached) {
+            return false;
+        }
+
         return ($this->_fn_isWritable)();
     }
 
     public function write(string $string): int
     {
+        $this->assertAttached();
+
         return ($this->_fn_write)($string);
     }
 
     public function isReadable(): bool
     {
+        if ($this->detached) {
+            return false;
+        }
+
         return ($this->_fn_isReadable)();
     }
 
     public function read(int $length): string
     {
+        $this->assertAttached();
+
         if ($length < 0) {
             throw new \RuntimeException('Length parameter cannot be negative');
         }
@@ -168,6 +206,8 @@ final class FnStream implements StreamInterface
 
     public function getContents(): string
     {
+        $this->assertAttached();
+
         return ($this->_fn_getContents)();
     }
 
@@ -176,6 +216,17 @@ final class FnStream implements StreamInterface
      */
     public function getMetadata(?string $key = null)
     {
+        if ($this->detached) {
+            return $key === null ? [] : null;
+        }
+
         return ($this->_fn_getMetadata)($key);
+    }
+
+    private function assertAttached(): void
+    {
+        if ($this->detached) {
+            throw new \RuntimeException('Stream is detached');
+        }
     }
 }

--- a/tests/FnStreamTest.php
+++ b/tests/FnStreamTest.php
@@ -136,6 +136,21 @@ class FnStreamTest extends TestCase
         self::assertSame(1, $called);
     }
 
+    public function testCloseTerminatesStreamAndPreventsFurtherDelegation(): void
+    {
+        $called = [];
+        $s = $this->createInstrumentedStream($called);
+
+        $s->close();
+        $s->close();
+
+        self::assertSame(['close'], $called);
+
+        $this->assertFnStreamIsDetached($s);
+
+        self::assertSame(['close'], $called);
+    }
+
     public function testCloseFailureIsNotRetried(): void
     {
         $called = 0;
@@ -155,9 +170,12 @@ class FnStreamTest extends TestCase
         }
 
         $s->close();
-        unset($s);
+
+        $this->assertFnStreamIsDetached($s);
 
         self::assertSame(1, $called);
+
+        unset($s);
     }
 
     public function testCloseStillThrowsWhenNotImplemented(): void
@@ -168,22 +186,67 @@ class FnStreamTest extends TestCase
         (new FnStream([]))->close();
     }
 
-    public function testCanDetachUsingCallable(): void
+    public function testDetachStillThrowsWhenNotImplemented(): void
     {
-        $called = false;
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage('detach() is not implemented in the FnStream');
+
+        (new FnStream([]))->detach();
+    }
+
+    public function testDetachTerminatesStreamAndPreventsFurtherDelegation(): void
+    {
+        $called = [];
         $resource = fopen('php://temp', 'r+');
-        $s = new FnStream([
+        $s = $this->createInstrumentedStream($called, [
             'detach' => function () use (&$called, $resource) {
-                $called = true;
+                $called[] = 'detach';
 
                 return $resource;
             },
         ]);
 
-        self::assertSame($resource, $s->detach());
-        self::assertTrue($called);
+        try {
+            self::assertSame($resource, $s->detach());
+            self::assertSame(['detach'], $called);
 
-        fclose($resource);
+            $this->assertFnStreamIsDetached($s);
+
+            self::assertSame(['detach'], $called);
+
+            unset($s);
+
+            self::assertSame(['detach'], $called);
+        } finally {
+            if (is_resource($resource)) {
+                fclose($resource);
+            }
+        }
+    }
+
+    public function testDetachFailureDoesNotTerminateStream(): void
+    {
+        $called = 0;
+        $s = new FnStream([
+            'detach' => function () use (&$called): void {
+                ++$called;
+
+                throw new \RuntimeException('detach failed');
+            },
+            'read' => function (int $length): string {
+                return str_repeat('x', $length);
+            },
+        ]);
+
+        try {
+            $s->detach();
+            self::fail('Expected detach to fail');
+        } catch (\RuntimeException $e) {
+            self::assertSame('detach failed', $e->getMessage());
+        }
+
+        self::assertSame(1, $called);
+        self::assertSame('xxx', $s->read(3));
     }
 
     public function testDoesNotRequireClose(): void
@@ -215,8 +278,12 @@ class FnStreamTest extends TestCase
         $b->seek(0, SEEK_END);
         $b->write('bar');
         self::assertSame('foobar', (string) $b);
-        self::assertIsResource($b->detach());
+
+        $resource = $b->detach();
+        self::assertIsResource($resource);
         $b->close();
+
+        fclose($resource);
     }
 
     public function testDecoratesWithCustomizations(): void
@@ -255,5 +322,138 @@ class FnStreamTest extends TestCase
         $this->expectExceptionMessage('foo');
 
         (string) $a;
+    }
+
+    private function assertFnStreamIsDetached(FnStream $stream): void
+    {
+        self::assertNull($stream->getSize());
+        self::assertFalse($stream->isReadable());
+        self::assertFalse($stream->isWritable());
+        self::assertFalse($stream->isSeekable());
+        self::assertSame([], $stream->getMetadata());
+        self::assertNull($stream->getMetadata('foo'));
+
+        $this->assertDetachedOperationThrows(static function () use ($stream): void {
+            (string) $stream;
+        });
+        $this->assertDetachedOperationThrows(static function () use ($stream): void {
+            $stream->getContents();
+        });
+        $this->assertDetachedOperationThrows(static function () use ($stream): void {
+            $stream->read(1);
+        });
+        $this->assertDetachedOperationThrows(static function () use ($stream): void {
+            $stream->read(-1);
+        });
+        $this->assertDetachedOperationThrows(static function () use ($stream): void {
+            $stream->write('foo');
+        });
+        $this->assertDetachedOperationThrows(static function () use ($stream): void {
+            $stream->seek(0);
+        });
+        $this->assertDetachedOperationThrows(static function () use ($stream): void {
+            $stream->rewind();
+        });
+        $this->assertDetachedOperationThrows(static function () use ($stream): void {
+            $stream->tell();
+        });
+        $this->assertDetachedOperationThrows(static function () use ($stream): void {
+            $stream->eof();
+        });
+
+        self::assertNull($stream->detach());
+        $stream->close();
+    }
+
+    private function assertDetachedOperationThrows(callable $operation): void
+    {
+        try {
+            $operation();
+        } catch (\RuntimeException $e) {
+            self::assertSame('Stream is detached', $e->getMessage());
+
+            return;
+        }
+
+        self::fail('Expected stream to be detached');
+    }
+
+    /**
+     * @param list<string>            $called
+     * @param array<string, callable> $overrides
+     */
+    private function createInstrumentedStream(array &$called, array $overrides = []): FnStream
+    {
+        return new FnStream($overrides + [
+            '__toString' => static function () use (&$called): string {
+                $called[] = '__toString';
+
+                return 'stream';
+            },
+            'close' => static function () use (&$called): void {
+                $called[] = 'close';
+            },
+            'detach' => static function () use (&$called) {
+                $called[] = 'detach';
+
+                return null;
+            },
+            'getSize' => static function () use (&$called): ?int {
+                $called[] = 'getSize';
+
+                return 3;
+            },
+            'tell' => static function () use (&$called): int {
+                $called[] = 'tell';
+
+                return 0;
+            },
+            'eof' => static function () use (&$called): bool {
+                $called[] = 'eof';
+
+                return false;
+            },
+            'isSeekable' => static function () use (&$called): bool {
+                $called[] = 'isSeekable';
+
+                return true;
+            },
+            'rewind' => static function () use (&$called): void {
+                $called[] = 'rewind';
+            },
+            'seek' => static function (int $offset, int $whence = SEEK_SET) use (&$called): void {
+                $called[] = 'seek';
+            },
+            'isWritable' => static function () use (&$called): bool {
+                $called[] = 'isWritable';
+
+                return true;
+            },
+            'write' => static function (string $string) use (&$called): int {
+                $called[] = 'write';
+
+                return strlen($string);
+            },
+            'isReadable' => static function () use (&$called): bool {
+                $called[] = 'isReadable';
+
+                return true;
+            },
+            'read' => static function (int $length) use (&$called): string {
+                $called[] = 'read';
+
+                return str_repeat('x', $length);
+            },
+            'getContents' => static function () use (&$called): string {
+                $called[] = 'getContents';
+
+                return 'contents';
+            },
+            'getMetadata' => static function (?string $key = null) use (&$called) {
+                $called[] = 'getMetadata';
+
+                return $key === null ? ['foo' => 'bar'] : 'bar';
+            },
+        ]);
     }
 }

--- a/tests/FnStreamTest.php
+++ b/tests/FnStreamTest.php
@@ -151,6 +151,18 @@ class FnStreamTest extends TestCase
         self::assertSame(['close'], $called);
     }
 
+    public function testDetachAfterCloseDoesNotRequireDetachCallback(): void
+    {
+        $s = new FnStream([
+            'close' => function (): void {
+            },
+        ]);
+
+        $s->close();
+
+        self::assertNull($s->detach());
+    }
+
     public function testCloseFailureIsNotRetried(): void
     {
         $called = 0;
@@ -224,6 +236,27 @@ class FnStreamTest extends TestCase
         }
     }
 
+    public function testCloseAfterDetachDoesNotRequireCloseCallback(): void
+    {
+        $resource = fopen('php://temp', 'r+');
+        $s = new FnStream([
+            'detach' => function () use ($resource) {
+                return $resource;
+            },
+        ]);
+
+        try {
+            self::assertSame($resource, $s->detach());
+
+            $s->close();
+            unset($s);
+        } finally {
+            if (is_resource($resource)) {
+                fclose($resource);
+            }
+        }
+    }
+
     public function testDetachFailureDoesNotTerminateStream(): void
     {
         $called = 0;
@@ -281,9 +314,12 @@ class FnStreamTest extends TestCase
 
         $resource = $b->detach();
         self::assertIsResource($resource);
-        $b->close();
 
-        fclose($resource);
+        try {
+            $b->close();
+        } finally {
+            fclose($resource);
+        }
     }
 
     public function testDecoratesWithCustomizations(): void

--- a/tests/FnStreamTest.php
+++ b/tests/FnStreamTest.php
@@ -81,28 +81,91 @@ class FnStreamTest extends TestCase
 
     public function testCanCloseOnDestruct(): void
     {
-        $called = false;
+        $called = 0;
         $s = new FnStream([
             'close' => function () use (&$called): void {
-                $called = true;
+                ++$called;
             },
         ]);
         unset($s);
-        self::assertTrue($called);
+        self::assertSame(1, $called);
     }
 
     public function testCanCloseUsingCallable(): void
     {
-        $called = false;
+        $called = 0;
         $s = new FnStream([
             'close' => function () use (&$called): void {
-                $called = true;
+                ++$called;
             },
         ]);
 
         $s->close();
 
-        self::assertTrue($called);
+        self::assertSame(1, $called);
+    }
+
+    public function testExplicitCloseAndDestructorOnlyCloseOnce(): void
+    {
+        $called = 0;
+        $s = new FnStream([
+            'close' => function () use (&$called): void {
+                ++$called;
+            },
+        ]);
+
+        $s->close();
+        unset($s);
+
+        self::assertSame(1, $called);
+    }
+
+    public function testCloseIsIdempotent(): void
+    {
+        $called = 0;
+        $s = new FnStream([
+            'close' => function () use (&$called): void {
+                ++$called;
+            },
+        ]);
+
+        $s->close();
+        $s->close();
+        unset($s);
+
+        self::assertSame(1, $called);
+    }
+
+    public function testCloseFailureIsNotRetried(): void
+    {
+        $called = 0;
+        $s = new FnStream([
+            'close' => function () use (&$called): void {
+                ++$called;
+
+                throw new \RuntimeException('close failed');
+            },
+        ]);
+
+        try {
+            $s->close();
+            self::fail('Expected close to fail');
+        } catch (\RuntimeException $e) {
+            self::assertSame('close failed', $e->getMessage());
+        }
+
+        $s->close();
+        unset($s);
+
+        self::assertSame(1, $called);
+    }
+
+    public function testCloseStillThrowsWhenNotImplemented(): void
+    {
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage('close() is not implemented in the FnStream');
+
+        (new FnStream([]))->close();
     }
 
     public function testCanDetachUsingCallable(): void


### PR DESCRIPTION
FnStream now treats close() and successful detach() calls as terminal lifecycle operations. A close callback is resolved before the stream is marked detached so missing close callbacks still report the existing BadMethodCallException, then the callback runs at most once across explicit close calls and destruction. If that callback fails, the failure still reaches the caller but the destructor will not retry it later.

Successful detach calls now return their detach result once and then leave the FnStream detached, so later close calls are no-ops and the destructor does not close after detach. Once detached, FnStream no longer forwards read, write, seek, metadata, stringification, or other operational calls to user callables. Its closed-state shape now matches the main Stream behavior: capability checks are false, size and keyed metadata are null, full metadata is empty, repeated detach returns null, and operations that require an attached stream throw RuntimeException with Stream is detached.