### PR TITLE
Reject empty PumpStream source chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reject malformed uploaded file specifications missing `tmp_name`, `size`, or `error`
 - Rewind seekable stream-backed uploaded files before copying them in `UploadedFile::moveTo()`
 - Reject negative stream read lengths consistently across stream implementations
+- Reject empty strings returned by `PumpStream` source callables to prevent no-progress read loops
 - Validate `LimitStream` offset and limit values and track non-seekable offsets by bytes actually skipped
 - Make `FnStream` close and detach terminal, preventing later operation forwarding and invoking close callbacks at most once
 - Normalize multiple leading slashes to one slash in `Uri::getPath()` and URI-derived `Request::getRequestTarget()` values

--- a/README.md
+++ b/README.md
@@ -249,8 +249,10 @@ When invoking the provided callable, the PumpStream will pass the suggested
 number of bytes to read to the callable. The callable can choose to ignore
 this value and return fewer or more bytes than requested. Any extra data
 returned by the provided callable is buffered internally until drained using
-the read() function of the PumpStream. The provided callable MUST return
-false or null when there is no more data to read.
+the read() function of the PumpStream. The provided callable MUST return a
+non-empty string to provide data, and MUST return false or null when there is
+no more data to read. Returning an empty string causes a RuntimeException
+because it cannot satisfy a positive-length read.
 
 Userland callables that declare no parameters are tolerated by PHP, but
 length-aware callables remain the recommended formal shape.
@@ -567,8 +569,9 @@ This method accepts the following `$resource` types:
   stream object will be created that wraps the given iterable. Each time the
   stream is read from, data from the iterator will fill a buffer and will be
   continuously called until the buffer is equal to the requested read size.
-  Subsequent read calls will first read from the buffer and then call `next`
-  on the underlying iterator until it is exhausted.
+  Values that stringify to an empty string are skipped while the iterator
+  advances. Subsequent read calls will first read from the buffer and then call
+  `next` on the underlying iterator until it is exhausted.
 - `object` with `__toString()`: If the object has the `__toString()` method,
   the object will be cast to a string and then a stream will be returned that
   uses the string value.
@@ -577,10 +580,10 @@ This method accepts the following `$resource` types:
   no earlier resource or object rule applies, a read-only stream object will be
   created that invokes the given callable. The callable is invoked with the
   suggested number of bytes to read. The callable can return fewer or more bytes
-  than requested, but MUST return `false` or `null` when there is no more data
-  to return. Any additional bytes will be buffered and used in subsequent reads.
-  String inputs are always treated as string bodies, even when they name
-  callable functions.
+  than requested, but MUST return a non-empty string to provide data and MUST
+  return `false` or `null` when there is no more data to return. Any additional
+  bytes will be buffered and used in subsequent reads. String inputs are always
+  treated as string bodies, even when they name callable functions.
 
 ```php
 $stream = GuzzleHttp\Psr7\Utils::streamFor('foo');

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -324,6 +324,16 @@ Query::build(['tag' => ['a', 'b']]);
 // tag=a&tag=b
 ```
 
+#### PumpStream Source Callables
+
+`PumpStream` source callables must now return a non-empty string when producing
+data. Returning an empty string now throws `RuntimeException` instead of being
+retried indefinitely. Return `false` or `null` to signal EOF.
+
+If your callable used `''` to mean "temporarily no data", update it to wait
+until data is available, return a non-empty string, or return `false` or `null`
+when the stream is complete.
+
 #### Iterator-backed Streams
 
 `Utils::streamFor()` now validates values yielded by `Iterator` instances before
@@ -332,15 +342,19 @@ objects are converted to string chunks. Arrays, resources, and non-stringable
 objects now throw `UnexpectedValueException`.
 
 Iterator exhaustion is now the only EOF signal for iterator-backed streams.
-Yielding `false` or `null` no longer ends the stream; those values are converted
-to empty string chunks instead. If your iterator yielded `false` or `null` to
-stop streaming, update it to finish iteration instead.
+Yielding `false`, `null`, or an empty string no longer ends the stream; those
+values are zero-length chunks and are skipped while the iterator advances. If
+your iterator yielded `false` or `null` to stop streaming, update it to finish
+iteration instead.
+
+Avoid iterators that yield only zero-length chunks indefinitely. Such iterators
+never produce bytes and never reach EOF, so they cannot satisfy stream reads.
 
 ```php
 // Before: yielding false or null could stop an iterator-backed stream early.
 $stream = Utils::streamFor(new ArrayIterator([false, 'body']));
 
-// After: false and null are stream chunks. End the iterator to signal EOF.
+// After: false and null are skipped chunks. End the iterator to signal EOF.
 $stream = Utils::streamFor(new ArrayIterator(['body']));
 ```
 

--- a/src/PumpStream.php
+++ b/src/PumpStream.php
@@ -13,8 +13,9 @@ use Psr\Http\Message\StreamInterface;
  * number of bytes to read to the callable. The callable can choose to ignore
  * this value and return fewer or more bytes than requested. Any extra data
  * returned by the callable is buffered internally until drained using the
- * read() function of the PumpStream. The callable MUST return false or null
- * when there is no more data to read.
+ * read() function of the PumpStream. The callable MUST return a non-empty
+ * string when data is available, or false or null when there is no more data
+ * to read.
  *
  * Userland callables that declare no parameters are tolerated by PHP, but
  * length-aware callables remain the recommended formal shape.
@@ -33,17 +34,17 @@ final class PumpStream implements StreamInterface
     private BufferStream $buffer;
 
     /**
-     * @param (callable(): (string|false|null))|(callable(int): (string|false|null)) $source  Source of the stream data. The callable receives
-     *                                                                                        the suggested number of bytes to read, may ignore
-     *                                                                                        that value, and may return fewer or more bytes.
-     *                                                                                        Extra bytes are buffered. The callable MUST return
-     *                                                                                        a string when called, or false|null on error or EOF.
-     *                                                                                        Userland callables that declare no parameters are
-     *                                                                                        tolerated by PHP, but length-aware callables remain
-     *                                                                                        the recommended formal shape.
-     * @param array{size?: int, metadata?: array}                                    $options Stream options:
-     *                                                                                        - metadata: Hash of metadata to use with stream.
-     *                                                                                        - size: Size of the stream, if known.
+     * @param (callable(): (non-empty-string|false|null))|(callable(int): (non-empty-string|false|null)) $source  Source of the stream data. The callable receives
+     *                                                                                                            the suggested number of bytes to read, may ignore
+     *                                                                                                            that value, and may return fewer or more bytes.
+     *                                                                                                            Extra bytes are buffered. The callable MUST return
+     *                                                                                                            a non-empty string when producing data, or false|null
+     *                                                                                                            on error or EOF. Userland callables that declare no
+     *                                                                                                            parameters are tolerated by PHP, but length-aware
+     *                                                                                                            callables remain the recommended formal shape.
+     * @param array{size?: int, metadata?: array}                                                        $options Stream options:
+     *                                                                                                            - metadata: Hash of metadata to use with stream.
+     *                                                                                                            - size: Size of the stream, if known.
      */
     public function __construct(callable $source, array $options = [])
     {
@@ -164,6 +165,11 @@ final class PumpStream implements StreamInterface
 
                     return;
                 }
+
+                if ($data === '') {
+                    throw new \RuntimeException('PumpStream source returned an empty string');
+                }
+
                 $this->buffer->write($data);
                 $length -= strlen($data);
             } while ($length > 0);

--- a/src/PumpStream.php
+++ b/src/PumpStream.php
@@ -123,16 +123,14 @@ final class PumpStream implements StreamInterface
             throw new \RuntimeException('Length parameter cannot be negative');
         }
 
-        $data = $this->buffer->read($length);
-        $readLen = strlen($data);
-        $this->tellPos += $readLen;
-        $remaining = $length - $readLen;
+        $bufferLength = $this->buffer->getSize() ?? 0;
 
-        if ($remaining) {
-            $this->pump($remaining);
-            $data .= $this->buffer->read($remaining);
-            $this->tellPos += strlen($data) - $readLen;
+        if ($length > $bufferLength) {
+            $this->pump($length - $bufferLength);
         }
+
+        $data = $this->buffer->read($length);
+        $this->tellPos += strlen($data);
 
         return $data;
     }

--- a/src/PumpStream.php
+++ b/src/PumpStream.php
@@ -34,17 +34,17 @@ final class PumpStream implements StreamInterface
     private BufferStream $buffer;
 
     /**
-     * @param (callable(): (non-empty-string|false|null))|(callable(int): (non-empty-string|false|null)) $source  Source of the stream data. The callable receives
-     *                                                                                                            the suggested number of bytes to read, may ignore
-     *                                                                                                            that value, and may return fewer or more bytes.
-     *                                                                                                            Extra bytes are buffered. The callable MUST return
-     *                                                                                                            a non-empty string when producing data, or false|null
-     *                                                                                                            on error or EOF. Userland callables that declare no
-     *                                                                                                            parameters are tolerated by PHP, but length-aware
-     *                                                                                                            callables remain the recommended formal shape.
-     * @param array{size?: int, metadata?: array}                                                        $options Stream options:
-     *                                                                                                            - metadata: Hash of metadata to use with stream.
-     *                                                                                                            - size: Size of the stream, if known.
+     * @param (callable(): (string|false|null))|(callable(int): (string|false|null)) $source  Source of the stream data. The callable receives
+     *                                                                                        the suggested number of bytes to read, may ignore
+     *                                                                                        that value, and may return fewer or more bytes.
+     *                                                                                        Extra bytes are buffered. The callable MUST return
+     *                                                                                        a non-empty string when producing data, or false|null
+     *                                                                                        on error or EOF. Userland callables that declare no
+     *                                                                                        parameters are tolerated by PHP, but length-aware
+     *                                                                                        callables remain the recommended formal shape.
+     * @param array{size?: int, metadata?: array}                                    $options Stream options:
+     *                                                                                        - metadata: Hash of metadata to use with stream.
+     *                                                                                        - size: Size of the stream, if known.
      */
     public function __construct(callable $source, array $options = [])
     {

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -455,8 +455,9 @@ final class Utils
      *   stream object will be created that wraps the given iterable. Each time the
      *   stream is read from, data from the iterator will fill a buffer and will be
      *   continuously called until the buffer is equal to the requested read size.
-     *   Subsequent read calls will first read from the buffer and then call `next`
-     *   on the underlying iterator until it is exhausted.
+     *   Values that stringify to an empty string are skipped while the iterator
+     *   advances. Subsequent read calls will first read from the buffer and then
+     *   call `next` on the underlying iterator until it is exhausted.
      * - `object` with `__toString()`: If the object has the `__toString()` method,
      *   the object will be cast to a string and then a stream will be returned that
      *   uses the string value.
@@ -465,10 +466,11 @@ final class Utils
      *   and no earlier resource or object rule applies, a read-only stream object
      *   will be created that invokes the given callable. The callable is invoked
      *   with the suggested number of bytes to read. The callable can return fewer
-     *   or more bytes than requested, but MUST return `false` or `null` when there
-     *   is no more data to return. Any additional bytes will be buffered and used
-     *   in subsequent reads. String inputs are always treated as string bodies,
-     *   even when they name callable functions.
+     *   or more bytes than requested, but MUST return a non-empty string when data
+     *   is available and `false` or `null` when there is no more data to return.
+     *   Any additional bytes will be buffered and used in subsequent reads. String
+     *   inputs are always treated as string bodies, even when they name callable
+     *   functions.
      *
      * @param resource|string|int|float|bool|StreamInterface|callable|\Iterator|\Stringable|null $resource Entity body data
      * @param array{size?: int, metadata?: array}                                                $options  Additional options
@@ -509,21 +511,24 @@ final class Utils
                     return $resource;
                 } elseif ($resource instanceof \Iterator) {
                     return new PumpStream(function (int $length) use ($resource) {
-                        if (!$resource->valid()) {
-                            return false;
-                        }
-                        $result = $resource->current();
-                        $resource->next();
+                        while ($resource->valid()) {
+                            $result = $resource->current();
+                            $resource->next();
 
-                        if ($result === null || is_scalar($result)) {
-                            return (string) $result;
+                            if ($result === null || is_scalar($result)) {
+                                $data = (string) $result;
+                            } elseif (is_object($result) && method_exists($result, '__toString')) {
+                                $data = (string) $result;
+                            } else {
+                                throw new \UnexpectedValueException('Iterator must yield scalar, null, or stringable values');
+                            }
+
+                            if ($data !== '') {
+                                return $data;
+                            }
                         }
 
-                        if (is_object($result) && method_exists($result, '__toString')) {
-                            return (string) $result;
-                        }
-
-                        throw new \UnexpectedValueException('Iterator must yield scalar, null, or stringable values');
+                        return false;
                     }, $options);
                 } elseif (method_exists($resource, '__toString')) {
                     return self::streamFor((string) $resource, $options);

--- a/tests/PumpStreamTest.php
+++ b/tests/PumpStreamTest.php
@@ -103,6 +103,31 @@ class PumpStreamTest extends TestCase
         self::assertSame('0', $p->read(1));
     }
 
+    public function testReadFailureDoesNotDiscardBufferedBytes(): void
+    {
+        /** @var list<string|false> $chunks */
+        $chunks = ['abc', '', false];
+
+        $p = new PumpStream(static function (int $length) use (&$chunks) {
+            return array_shift($chunks);
+        });
+
+        self::assertSame('ab', $p->read(2));
+        self::assertSame(2, $p->tell());
+
+        try {
+            $p->read(2);
+            self::fail('Expected empty source chunk to throw.');
+        } catch (\RuntimeException $e) {
+            self::assertSame('PumpStream source returned an empty string', $e->getMessage());
+        }
+
+        self::assertSame(2, $p->tell());
+        self::assertSame('c', $p->read(2));
+        self::assertSame(3, $p->tell());
+        self::assertTrue($p->eof());
+    }
+
     public function testCanReadFromCallableString(): void
     {
         self::$chunks = ['foo', false];

--- a/tests/PumpStreamTest.php
+++ b/tests/PumpStreamTest.php
@@ -69,6 +69,40 @@ class PumpStreamTest extends TestCase
         }
     }
 
+    public function testReadThrowsWhenSourceReturnsEmptyString(): void
+    {
+        /** @var list<string|false> $chunks */
+        $chunks = ['', false];
+
+        $p = new PumpStream(static function (int $length) use (&$chunks) {
+            return array_shift($chunks);
+        });
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('PumpStream source returned an empty string');
+
+        $p->read(1);
+    }
+
+    public function testFalseAndNullStillMeanEof(): void
+    {
+        self::assertSame('', (new PumpStream(static function () {
+            return false;
+        }))->read(1));
+
+        self::assertSame('', (new PumpStream(static function (): void {
+        }))->read(1));
+    }
+
+    public function testReadAcceptsStringZeroFromSource(): void
+    {
+        $p = new PumpStream(static function (): string {
+            return '0';
+        });
+
+        self::assertSame('0', $p->read(1));
+    }
+
     public function testCanReadFromCallableString(): void
     {
         self::$chunks = ['foo', false];

--- a/tests/PumpStreamTest.php
+++ b/tests/PumpStreamTest.php
@@ -128,6 +128,31 @@ class PumpStreamTest extends TestCase
         self::assertTrue($p->eof());
     }
 
+    public function testReadFailureDoesNotDiscardBytesBufferedDuringSameRead(): void
+    {
+        /** @var list<string|false> $chunks */
+        $chunks = ['a', '', false];
+
+        $p = new PumpStream(static function (int $length) use (&$chunks) {
+            return array_shift($chunks);
+        });
+
+        try {
+            $p->read(2);
+            self::fail('Expected empty source chunk to throw.');
+        } catch (\RuntimeException $e) {
+            self::assertSame('PumpStream source returned an empty string', $e->getMessage());
+        }
+
+        self::assertSame(0, $p->tell());
+        self::assertSame('a', $p->read(1));
+        self::assertSame(1, $p->tell());
+        self::assertFalse($p->eof());
+        self::assertSame('', $p->read(1));
+        self::assertSame(1, $p->tell());
+        self::assertTrue($p->eof());
+    }
+
     public function testCanReadFromCallableString(): void
     {
         self::$chunks = ['foo', false];

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -776,6 +776,38 @@ class UtilsTest extends TestCase
         self::assertSame('foobar', $stream->getContents());
     }
 
+    public function testIteratorBasedStreamSkipsEmptyConvertedChunks(): void
+    {
+        $emptyStringable = new class {
+            public function __toString(): string
+            {
+                return '';
+            }
+        };
+
+        $stream = Psr7\Utils::streamFor(new \ArrayIterator([
+            '',
+            false,
+            null,
+            $emptyStringable,
+            'foo',
+            '',
+            'bar',
+            null,
+        ]));
+
+        self::assertSame('foobar', $stream->getContents());
+        self::assertTrue($stream->eof());
+    }
+
+    public function testIteratorBasedStreamTerminatesWhenOnlyEmptyConvertedChunksAreYielded(): void
+    {
+        $stream = Psr7\Utils::streamFor(new \ArrayIterator(['', false, null]));
+
+        self::assertSame('', $stream->getContents());
+        self::assertTrue($stream->eof());
+    }
+
     public function testIteratorBasedStreamRejectsArrayValues(): void
     {
         $stream = Psr7\Utils::streamFor(new \ArrayIterator([['x']]));


### PR DESCRIPTION
This makes PumpStream fail when a source callable returns an empty string while satisfying a positive-length read. Empty strings cannot advance the requested length, so a source that repeatedly returns them can loop indefinitely. PumpStream now pumps before draining its internal buffer when more bytes are needed, so source failures do not discard already buffered bytes or advance the reported position. The iterator-backed stream adapter skips zero-length converted iterator values before returning data to PumpStream, preserving the 3.0 iterator behavior where false and null yields do not signal EOF. The README, upgrade guide, and changelog document the stricter PumpStream source contract.