### PR TITLE
Make CachingStream close idempotent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reject empty strings returned by `PumpStream` source callables to prevent no-progress read loops
 - Validate `LimitStream` offset and limit values and track non-seekable offsets by bytes actually skipped
 - Make `FnStream` close and detach terminal, preventing later operation forwarding and invoking close callbacks at most once
+- Make `CachingStream::close()` idempotent while preserving remote cleanup after cache detachment
 - Normalize multiple leading slashes to one slash in `Uri::getPath()` and URI-derived `Request::getRequestTarget()` values
 - Harden URI host validation for delimiters, backslashes, and invalid IPv6/IP literals; reject schemes not beginning with a letter
 - Redact all non-empty URI userinfo in `Utils::redactUserInfo()`

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -366,6 +366,11 @@ repeated `close()` calls are no-ops, destruction after explicit close no longer
 invokes the close callback, and closed or detached streams no longer forward
 read, write, seek, metadata, or stringification callbacks.
 
+`CachingStream::close()` is now idempotent. Calling `close()` after `detach()`
+still closes the remote stream owned by the `CachingStream`, but it no longer
+closes the detached cache resource returned to the caller. Repeated `close()`
+calls are no-ops.
+
 #### Multipart Part Headers and Metadata
 
 `MultipartStream` no longer adds default `Content-Length` headers to individual

--- a/src/CachingStream.php
+++ b/src/CachingStream.php
@@ -184,7 +184,7 @@ final class CachingStream implements StreamInterface
     }
 
     /**
-     * Close both the remote stream and buffer stream
+     * Close the remote stream and any attached cache stream.
      */
     public function close(): void
     {

--- a/src/CachingStream.php
+++ b/src/CachingStream.php
@@ -25,6 +25,8 @@ final class CachingStream implements StreamInterface
 
     private bool $detached = false;
 
+    private bool $closed = false;
+
     /**
      * We will treat the buffer object as the body of the stream
      *
@@ -186,9 +188,35 @@ final class CachingStream implements StreamInterface
      */
     public function close(): void
     {
-        $this->remoteStream->close();
-        $this->stream->close();
+        if ($this->closed) {
+            return;
+        }
+
+        $closeCache = !$this->detached;
+        $this->closed = true;
         $this->detached = true;
+
+        $exception = null;
+
+        try {
+            $this->remoteStream->close();
+        } catch (\Throwable $e) {
+            $exception = $e;
+        }
+
+        if ($closeCache) {
+            try {
+                $this->stream->close();
+            } catch (\Throwable $e) {
+                if ($exception === null) {
+                    $exception = $e;
+                }
+            }
+        }
+
+        if ($exception !== null) {
+            throw $exception;
+        }
     }
 
     private function cacheEntireStream(): int

--- a/tests/CachingStreamTest.php
+++ b/tests/CachingStreamTest.php
@@ -8,6 +8,7 @@ use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\CachingStream;
 use GuzzleHttp\Psr7\Stream;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\StreamInterface;
 
 /**
  * @covers \GuzzleHttp\Psr7\CachingStream
@@ -299,16 +300,21 @@ class CachingStreamTest extends TestCase
 
         $resource = $body->detach();
 
-        self::assertIsResource($resource);
-        self::assertSame(0, ftell($resource));
+        try {
+            self::assertIsResource($resource);
+            self::assertSame(0, ftell($resource));
 
-        $stats = fstat($resource);
-        self::assertIsArray($stats);
-        self::assertSame(strlen('Hello world!'), $stats['size']);
-        self::assertSame('Hello world!', stream_get_contents($resource));
+            $stats = fstat($resource);
+            self::assertIsArray($stats);
+            self::assertSame(strlen('Hello world!'), $stats['size']);
+            self::assertSame('Hello world!', stream_get_contents($resource));
+        } finally {
+            if (is_resource($resource)) {
+                fclose($resource);
+            }
 
-        fclose($resource);
-        $body->close();
+            $body->close();
+        }
     }
 
     public function testDetachReturnsCompleteResourceAfterPartialRead(): void
@@ -319,15 +325,20 @@ class CachingStreamTest extends TestCase
 
         $resource = $body->detach();
 
-        self::assertIsResource($resource);
-        self::assertSame(6, ftell($resource));
-        self::assertSame('world!', stream_get_contents($resource));
+        try {
+            self::assertIsResource($resource);
+            self::assertSame(6, ftell($resource));
+            self::assertSame('world!', stream_get_contents($resource));
 
-        rewind($resource);
-        self::assertSame('Hello world!', stream_get_contents($resource));
+            rewind($resource);
+            self::assertSame('Hello world!', stream_get_contents($resource));
+        } finally {
+            if (is_resource($resource)) {
+                fclose($resource);
+            }
 
-        fclose($resource);
-        $body->close();
+            $body->close();
+        }
     }
 
     public function testDetachPreservesCachedWritesAndUnreadRemoteBytes(): void
@@ -340,12 +351,17 @@ class CachingStreamTest extends TestCase
 
         $resource = $body->detach();
 
-        self::assertIsResource($resource);
-        self::assertSame(0, ftell($resource));
-        self::assertSame('tehiing', stream_get_contents($resource));
+        try {
+            self::assertIsResource($resource);
+            self::assertSame(0, ftell($resource));
+            self::assertSame('tehiing', stream_get_contents($resource));
+        } finally {
+            if (is_resource($resource)) {
+                fclose($resource);
+            }
 
-        fclose($resource);
-        $body->close();
+            $body->close();
+        }
     }
 
     public function testDetachReturnsNullAfterDetach(): void
@@ -415,6 +431,117 @@ class CachingStreamTest extends TestCase
         $d = new CachingStream($a);
         $d->close();
         self::assertFalse(is_resource($s));
+    }
+
+    public function testCloseIsIdempotentAndClosesRemoteAndCacheStreamsOnce(): void
+    {
+        $remote = $this->createMock(StreamInterface::class);
+        $cache = $this->createMock(StreamInterface::class);
+
+        $remote->expects(self::once())->method('close');
+        $cache->expects(self::once())->method('close');
+
+        $stream = new CachingStream($remote, $cache);
+
+        $stream->close();
+        $stream->close();
+
+        self::assertNull($stream->detach());
+    }
+
+    public function testCloseAfterDetachClosesRemoteOnceAndKeepsDetachedResourceOpen(): void
+    {
+        $remote = $this->createMock(StreamInterface::class);
+        $remote->method('eof')->willReturn(true);
+        $remote->method('read')->willReturn('');
+        $remote->method('getMetadata')->willReturn(null);
+        $remote->expects(self::once())->method('close');
+
+        $cacheResource = fopen('php://temp', 'r+');
+        $detached = null;
+
+        try {
+            fwrite($cacheResource, 'cached');
+            rewind($cacheResource);
+
+            $stream = new CachingStream($remote, new Stream($cacheResource));
+            $detached = $stream->detach();
+
+            self::assertIsResource($detached);
+
+            $stream->close();
+            $stream->close();
+
+            self::assertIsResource($detached);
+            rewind($detached);
+            self::assertSame('cached', stream_get_contents($detached));
+        } finally {
+            if (is_resource($detached)) {
+                fclose($detached);
+            } elseif (is_resource($cacheResource)) {
+                fclose($cacheResource);
+            }
+        }
+    }
+
+    public function testCloseDoesNotRetryAfterRemoteCloseFailure(): void
+    {
+        $remote = $this->createMock(StreamInterface::class);
+        $cache = $this->createMock(StreamInterface::class);
+
+        $remote->expects(self::once())
+            ->method('close')
+            ->willThrowException(new \RuntimeException('remote close failed'));
+        $cache->expects(self::once())->method('close');
+
+        $stream = new CachingStream($remote, $cache);
+
+        try {
+            $stream->close();
+            self::fail('Expected close to fail');
+        } catch (\RuntimeException $e) {
+            self::assertSame('remote close failed', $e->getMessage());
+        }
+
+        $stream->close();
+    }
+
+    public function testClosePreservesCacheCloseFailure(): void
+    {
+        $remote = $this->createMock(StreamInterface::class);
+        $cache = $this->createMock(StreamInterface::class);
+
+        $remote->expects(self::once())->method('close');
+        $cache->expects(self::once())
+            ->method('close')
+            ->willThrowException(new \RuntimeException('cache close failed'));
+
+        $stream = new CachingStream($remote, $cache);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('cache close failed');
+
+        $stream->close();
+    }
+
+    public function testRemoteCloseFailureTakesPriorityOverCacheCloseFailure(): void
+    {
+        $remote = $this->createMock(StreamInterface::class);
+        $cache = $this->createMock(StreamInterface::class);
+
+        $remote->expects(self::once())
+            ->method('close')
+            ->willThrowException(new \RuntimeException('remote close failed'));
+        $cache->expects(self::once())
+            ->method('close')
+            ->willThrowException(new \RuntimeException('cache close failed'));
+
+        $stream = new CachingStream($remote, $cache);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('remote close failed');
+
+        $stream->close();
     }
 
     public function testEnsuresValidWhence(): void

--- a/tests/CachingStreamTest.php
+++ b/tests/CachingStreamTest.php
@@ -506,7 +506,7 @@ class CachingStreamTest extends TestCase
         $stream->close();
     }
 
-    public function testClosePreservesCacheCloseFailure(): void
+    public function testCloseDoesNotRetryAfterCacheCloseFailure(): void
     {
         $remote = $this->createMock(StreamInterface::class);
         $cache = $this->createMock(StreamInterface::class);
@@ -518,8 +518,12 @@ class CachingStreamTest extends TestCase
 
         $stream = new CachingStream($remote, $cache);
 
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('cache close failed');
+        try {
+            $stream->close();
+            self::fail('Expected close to fail');
+        } catch (\RuntimeException $e) {
+            self::assertSame('cache close failed', $e->getMessage());
+        }
 
         $stream->close();
     }


### PR DESCRIPTION
CachingStream now tracks close state separately from cache detachment so close() releases owned resources at most once. A normal close still closes both the remote stream and attached cache stream. After detach(), close() still closes the remote stream owned by the CachingStream, but it no longer closes the detached cache resource returned to the caller.

Close failures are handled consistently: the stream is marked closed before cleanup begins, cache cleanup is still attempted after a remote close failure, remote close failures keep priority when both streams fail, and later close() calls are no-ops. The CachingStream tests cover repeated close calls, close after detach, close failure idempotency, exception priority, and exception-safe cleanup for detached cache resources. The changelog and upgrade guide document the lifecycle change.