### PR TITLE
Preserve body cursor in Message bodySummary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rewind seekable stream-backed uploaded files before copying them in `UploadedFile::moveTo()`
 - Reject negative stream read lengths consistently across stream implementations
 - Reject empty strings returned by `PumpStream` source callables to prevent no-progress read loops
+- Restore the original body cursor after `Message::bodySummary()` reads seekable bodies
 - Validate `LimitStream` offset and limit values and track non-seekable offsets by bytes actually skipped
 - Make `FnStream` close and detach terminal, preventing later operation forwarding and invoking close callbacks at most once
 - Make `CachingStream::close()` idempotent while preserving remote cleanup after cache detachment

--- a/README.md
+++ b/README.md
@@ -364,6 +364,9 @@ Get a short summary of the message body.
 
 Will return `null` if the response is not printable.
 
+Reads seekable bodies from the beginning and restores the original cursor
+position before returning.
+
 
 ## `GuzzleHttp\Psr7\Message::rewindBody`
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -358,6 +358,13 @@ $stream = Utils::streamFor(new ArrayIterator([false, 'body']));
 $stream = Utils::streamFor(new ArrayIterator(['body']));
 ```
 
+#### Message Body Summaries
+
+`Message::bodySummary()` now restores the original cursor position after reading
+a seekable body. It still summarizes from the beginning of the body, even when
+the body was already partially read. If your code relied on `bodySummary()` to
+rewind the body for later reads, call `Message::rewindBody()` explicitly.
+
 #### Stream Lifecycle
 
 `FnStream` now treats `close()` and successful `detach()` calls as terminal

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -360,10 +360,15 @@ $stream = Utils::streamFor(new ArrayIterator(['body']));
 
 #### Message Body Summaries
 
-`Message::bodySummary()` now restores the original cursor position after reading
-a seekable body. It still summarizes from the beginning of the body, even when
-the body was already partially read. If your code relied on `bodySummary()` to
-rewind the body for later reads, call `Message::rewindBody()` explicitly.
+`Message::bodySummary()` still summarizes seekable bodies from the beginning,
+even when the body was already partially read. It now restores the body cursor to
+the position it had before the summary was created. In 2.x, calling
+`bodySummary()` left seekable bodies rewound to the beginning.
+
+Most applications do not need to change anything. Check your code only if you
+called `bodySummary()` and then read the same body while relying on
+`bodySummary()` to leave the body rewound. If you need to read the body from the
+beginning after summarizing it, call `Message::rewindBody()` explicitly.
 
 #### Stream Lifecycle
 

--- a/src/Message.php
+++ b/src/Message.php
@@ -87,18 +87,22 @@ final class Message
             return null;
         }
 
-        $body->rewind();
-        $summary = $body->read($truncateAt);
+        $position = $body->tell();
 
-        if ($size > $truncateAt) {
-            if (preg_match('//u', $summary) !== 1) {
-                $summary = self::trimTrailingIncompleteUtf8Character($summary, $body->read(3));
+        try {
+            $body->rewind();
+            $summary = $body->read($truncateAt);
+
+            if ($size > $truncateAt) {
+                if (preg_match('//u', $summary) !== 1) {
+                    $summary = self::trimTrailingIncompleteUtf8Character($summary, $body->read(3));
+                }
+
+                $summary .= ' (truncated...)';
             }
-
-            $summary .= ' (truncated...)';
+        } finally {
+            $body->seek($position);
         }
-
-        $body->rewind();
 
         // Matches any printable character, including unicode characters:
         // letters, marks, numbers, punctuation, spacing, and separators.

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -716,7 +716,62 @@ class MessageTest extends TestCase
     {
         $message = new Psr7\Response(200, [], 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.');
         $message->getBody()->read(10);
+
         self::assertSame('Lorem ipsu (truncated...)', Psr7\Message::bodySummary($message, 10));
+        self::assertSame(10, $message->getBody()->tell());
+    }
+
+    public function testMessageBodySummaryRestoresOriginalPosition(): void
+    {
+        $body = Psr7\Utils::streamFor('abcdef');
+        $body->seek(3);
+        $message = new Psr7\Response(200, [], $body);
+
+        self::assertSame('abcdef', Psr7\Message::bodySummary($message));
+        self::assertSame(3, $body->tell());
+    }
+
+    public function testMessageBodySummaryRestoresOriginalPositionAfterUtf8Lookahead(): void
+    {
+        $body = Psr7\Utils::streamFor('必填性规则校验失败，此字段为必填项');
+        $body->seek(6);
+        $message = new Psr7\Response(200, [], $body);
+
+        self::assertSame('必填性规则校验失 (truncated...)', Psr7\Message::bodySummary($message, 25));
+        self::assertSame(6, $body->tell());
+    }
+
+    public function testMessageBodySummaryRestoresOriginalPositionWhenReturningNull(): void
+    {
+        $body = Psr7\Utils::streamFor("abc\0def");
+        $body->seek(3);
+        $message = new Psr7\Response(200, [], $body);
+
+        self::assertNull(Psr7\Message::bodySummary($message));
+        self::assertSame(3, $body->tell());
+
+        $body = Psr7\Utils::streamFor("abc\xFFdef");
+        $body->seek(2);
+        $message = new Psr7\Response(200, [], $body);
+
+        self::assertNull(Psr7\Message::bodySummary($message, 4));
+        self::assertSame(2, $body->tell());
+    }
+
+    public function testMessageBodySummaryThrowsWhenOriginalPositionCannotBeDetermined(): void
+    {
+        $body = Psr7\Utils::streamFor('abc');
+        $body = FnStream::decorate($body, [
+            'tell' => static function (): int {
+                throw new \RuntimeException('tell failed');
+            },
+        ]);
+        $message = new Psr7\Response(200, [], $body);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('tell failed');
+
+        Psr7\Message::bodySummary($message);
     }
 
     public function testGetResponseBodySummaryOfNonReadableStream(): void


### PR DESCRIPTION
This makes Message::bodySummary() restore the original cursor position after reading a seekable body. The summary is still produced from the beginning of the body, including the existing truncation, UTF-8 lookahead, and printable-body checks, but callers no longer have their stream position reset to the start as a side effect. The README, upgrade guide, and changelog document the 3.0 behavior change.