### PR TITLE
Clear PumpStream buffer on close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rewind seekable stream-backed uploaded files before copying them in `UploadedFile::moveTo()`
 - Reject negative stream read lengths consistently across stream implementations
 - Reject empty strings returned by `PumpStream` source callables to prevent no-progress read loops
+- Make `PumpStream::close()` and `PumpStream::detach()` discard internally buffered unread bytes
 - Restore the original body cursor after `Message::bodySummary()` reads seekable bodies
 - Validate `LimitStream` offset and limit values and track non-seekable offsets by bytes actually skipped
 - Make `FnStream` close and detach terminal, preventing later operation forwarding and invoking close callbacks at most once

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -383,6 +383,10 @@ still closes the remote stream owned by the `CachingStream`, but it no longer
 closes the detached cache resource returned to the caller. Repeated `close()`
 calls are no-ops.
 
+`PumpStream::close()` and `PumpStream::detach()` now discard internally buffered
+unread bytes. If a callable or iterator source returns more bytes than a read
+requested, drain the stream before closing it if you need those buffered bytes.
+
 #### Multipart Part Headers and Metadata
 
 `MultipartStream` no longer adds default `Content-Length` headers to individual

--- a/src/PumpStream.php
+++ b/src/PumpStream.php
@@ -68,6 +68,7 @@ final class PumpStream implements StreamInterface
     {
         $this->tellPos = 0;
         $this->source = null;
+        $this->buffer->close();
 
         return null;
     }

--- a/tests/PumpStreamTest.php
+++ b/tests/PumpStreamTest.php
@@ -255,19 +255,40 @@ class PumpStreamTest extends TestCase
         }
     }
 
-    public function testCloseDetachesSourceButLeavesBufferedBytesReadable(): void
+    public function testCloseClearsBufferedBytesAndResetsPosition(): void
     {
         $p = new PumpStream(function (): string {
             return 'abc';
         });
 
         self::assertSame('a', $p->read(1));
+        self::assertSame(1, $p->tell());
 
         $p->close();
 
         self::assertTrue($p->eof());
-        self::assertSame('bc', $p->read(10));
-        self::assertSame(2, $p->tell());
+        self::assertSame(0, $p->tell());
+        self::assertSame('', $p->read(10));
+        self::assertSame(0, $p->tell());
+        self::assertSame('', $p->getContents());
+    }
+
+    public function testDetachClearsBufferedBytesAndResetsPosition(): void
+    {
+        $p = new PumpStream(function (): string {
+            return 'abc';
+        });
+
+        self::assertSame('a', $p->read(1));
+        self::assertSame(1, $p->tell());
+
+        self::assertNull($p->detach());
+
+        self::assertTrue($p->eof());
+        self::assertSame(0, $p->tell());
+        self::assertSame('', $p->getContents());
+        self::assertSame('', $p->read(10));
+        self::assertSame(0, $p->tell());
     }
 
     public function testThatConvertingStreamToStringWillThrowException(): void

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -808,6 +808,32 @@ class UtilsTest extends TestCase
         self::assertTrue($stream->eof());
     }
 
+    public function testCallableStreamCloseClearsBufferedBytes(): void
+    {
+        $stream = Psr7\Utils::streamFor(static function (): string {
+            return 'abc';
+        });
+
+        self::assertSame('a', $stream->read(1));
+
+        $stream->close();
+
+        self::assertSame('', $stream->read(10));
+        self::assertTrue($stream->eof());
+    }
+
+    public function testIteratorStreamCloseClearsBufferedBytes(): void
+    {
+        $stream = Psr7\Utils::streamFor(new \ArrayIterator(['abc']));
+
+        self::assertSame('a', $stream->read(1));
+
+        $stream->close();
+
+        self::assertSame('', $stream->read(10));
+        self::assertTrue($stream->eof());
+    }
+
     public function testIteratorBasedStreamRejectsArrayValues(): void
     {
         $stream = Psr7\Utils::streamFor(new \ArrayIterator([['x']]));


### PR DESCRIPTION
PumpStream now clears internally buffered unread bytes when it is closed or detached. This keeps close() and detach() from leaving direct reads able to drain bytes after the source has been detached and the stream reports EOF.

The PumpStream lifecycle tests now assert that close() and detach() reset the position and discard buffered bytes, and Utils stream factory coverage verifies the same behavior for callable-backed and iterator-backed streams. The changelog and upgrade guide document the behavior change for callers that need to drain buffered bytes before closing.