### PR TITLE
Suppress FnStream destructor close failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Restore the original body cursor after `Message::bodySummary()` reads seekable bodies
 - Validate `LimitStream` offset and limit values and track non-seekable offsets by bytes actually skipped
 - Make `FnStream` close and detach terminal, preventing later operation forwarding and invoking close callbacks at most once
+- Suppress exceptions thrown by `FnStream` close callbacks during destructor cleanup
 - Make `CachingStream::close()` idempotent while preserving remote cleanup after cache detachment
 - Normalize multiple leading slashes to one slash in `Uri::getPath()` and URI-derived `Request::getRequestTarget()` values
 - Harden URI host validation for delimiters, backslashes, and invalid IPv6/IP literals; reject schemes not beginning with a letter

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -376,7 +376,9 @@ beginning after summarizing it, call `Message::rewindBody()` explicitly.
 lifecycle operations. Its configured `close` callback is invoked at most once;
 repeated `close()` calls are no-ops, destruction after explicit close no longer
 invokes the close callback, and closed or detached streams no longer forward
-read, write, seek, metadata, or stringification callbacks.
+read, write, seek, metadata, or stringification callbacks. `FnStream` also
+suppresses exceptions thrown by destructor-triggered close callbacks. Call
+`close()` explicitly if cleanup failures must be observed.
 
 `CachingStream::close()` is now idempotent. Calling `close()` after `detach()`
 still closes the remote stream owned by the `CachingStream`, but it no longer

--- a/src/FnStream.php
+++ b/src/FnStream.php
@@ -55,8 +55,14 @@ final class FnStream implements StreamInterface
      */
     public function __destruct()
     {
-        if (!$this->detached && isset($this->_fn_close)) {
+        if ($this->detached || !isset($this->_fn_close)) {
+            return;
+        }
+
+        try {
             $this->close();
+        } catch (\Throwable $e) {
+            // Destructors must not surface cleanup failures.
         }
     }
 

--- a/tests/FnStreamTest.php
+++ b/tests/FnStreamTest.php
@@ -91,6 +91,22 @@ class FnStreamTest extends TestCase
         self::assertSame(1, $called);
     }
 
+    public function testSwallowsCloseExceptionOnDestruct(): void
+    {
+        $called = 0;
+        $s = new FnStream([
+            'close' => function () use (&$called): void {
+                ++$called;
+
+                throw new \RuntimeException('close failed');
+            },
+        ]);
+
+        unset($s);
+
+        self::assertSame(1, $called);
+    }
+
     public function testCanCloseUsingCallable(): void
     {
         $called = 0;


### PR DESCRIPTION
FnStream now treats destructor-triggered close failures as best-effort cleanup. The destructor still invokes the configured close callback when needed, but any Throwable from that destructor path is suppressed so cleanup failures do not escape during object destruction or shutdown.

Explicit close() behavior is unchanged: close callback failures still propagate to callers, the stream is marked detached before the callback runs, and failed explicit close calls are not retried later. The focused test covers a throwing close callback during destruction, and the changelog and upgrade guide document that callers should use explicit close() when cleanup failures need to be observed.