### PR TITLE
Detect Stream write timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Validate unsupported values passed to `Query::build()`
 - Reject invalid `Utils::modifyRequest()` change values before applying request modifications
 - Use PHP debug type names in type error messages
-- Throw `TimeoutException` when stream read, copy, hash, and line operations detect timeout metadata
+- Throw `TimeoutException` when `Stream::read()`, `Stream::write()`, stream copy, hash, and line operations detect timeout metadata
 - Translate `StreamWrapper` runtime failures to PHP stream failure values
 - Stop adding default `Content-Length` headers to `multipart/form-data` parts to comply with RFC 7578 section 4.8
 - Escape generated multipart `Content-Disposition` parameters and reject unsafe multipart boundary and part header metadata

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -358,6 +358,19 @@ $stream = Utils::streamFor(new ArrayIterator([false, 'body']));
 $stream = Utils::streamFor(new ArrayIterator(['body']));
 ```
 
+#### Stream Timeout Detection
+
+Timed-out stream operations now throw
+`GuzzleHttp\Psr7\Exception\TimeoutException`, which extends
+`RuntimeException`. `Stream::read()`, `Stream::write()`,
+`Utils::copyToStream()`, `Utils::copyToString()`, `Utils::hash()`,
+`Utils::readLine()`, and `Utils::tryGetContents()` detect PHP-style stream
+timeout metadata when a read or write operation cannot make progress. Timeout
+detection is best-effort; custom stream implementations that do not expose
+`timed_out` metadata continue to behave as before. Previously, timed-out reads
+could be treated as EOF or return partial results, and timed-out writes could be
+reported as generic write failures or no-progress writes.
+
 #### Message Body Summaries
 
 `Message::bodySummary()` still summarizes seekable bodies from the beginning,
@@ -670,16 +683,6 @@ some returned sliced data, and some behavior varied by PHP version.
 non-seekable streams, offsets are tracked by the number of bytes actually
 skipped. Short reads are retried until the offset is reached, EOF is reached, or
 the decorated stream stops making progress.
-
-Timed-out stream operations now throw
-`GuzzleHttp\Psr7\Exception\TimeoutException`, which extends
-`RuntimeException`. `Stream::read()`, `Utils::copyToStream()`,
-`Utils::copyToString()`, `Utils::hash()`, `Utils::readLine()`, and
-`Utils::tryGetContents()` detect PHP-style stream timeout metadata when a read
-or write operation cannot make progress. Timeout detection is best-effort;
-custom stream implementations that do not expose `timed_out` metadata continue
-to behave as before. Previously, timed-out reads could be treated as EOF or
-return partial results.
 
 `StreamWrapper` now translates `RuntimeException` failures from the wrapped
 PSR-7 stream into PHP stream-wrapper failure values. When using a resource from

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -251,12 +251,35 @@ class Stream implements StreamInterface
             throw new \RuntimeException('Cannot write to a non-writable stream');
         }
 
+        if ($string === '') {
+            return 0;
+        }
+
         // We can't know the size after writing anything
         $this->size = null;
-        $result = fwrite($this->stream, $string);
+
+        try {
+            $result = fwrite($this->stream, $string);
+        } catch (TimeoutException $e) {
+            throw $e;
+        } catch (\Exception $e) {
+            if ($this->writeTimedOut()) {
+                throw new TimeoutException('Unable to write to stream: timed out', 0, $e);
+            }
+
+            throw new \RuntimeException('Unable to write to stream', 0, $e);
+        }
 
         if ($result === false) {
+            if ($this->writeTimedOut()) {
+                throw new TimeoutException('Unable to write to stream: timed out');
+            }
+
             throw new \RuntimeException('Unable to write to stream');
+        }
+
+        if ($result === 0 && $this->writeTimedOut()) {
+            throw new TimeoutException('Unable to write to stream: timed out');
         }
 
         return $result;
@@ -283,5 +306,10 @@ class Stream implements StreamInterface
     private function timedOut(): bool
     {
         return StreamTimeout::isResourceReadTimedOut($this->stream);
+    }
+
+    private function writeTimedOut(): bool
+    {
+        return StreamTimeout::isResourceWriteTimedOut($this->stream);
     }
 }

--- a/src/StreamTimeout.php
+++ b/src/StreamTimeout.php
@@ -51,4 +51,19 @@ final class StreamTimeout
             return false;
         }
     }
+
+    /**
+     * @param resource $resource
+     */
+    public static function isResourceWriteTimedOut($resource): bool
+    {
+        try {
+            /** @var array<string, mixed> $metadata */
+            $metadata = stream_get_meta_data($resource);
+
+            return ($metadata['timed_out'] ?? false) === true;
+        } catch (\Throwable $e) {
+            return false;
+        }
+    }
 }

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GuzzleHttp\Tests\Psr7;
 
+use GuzzleHttp\Psr7\Exception\TimeoutException;
 use GuzzleHttp\Psr7\FnStream;
 use GuzzleHttp\Psr7\Stream;
 use GuzzleHttp\Psr7\StreamWrapper;
@@ -15,6 +16,21 @@ use PHPUnit\Framework\TestCase;
 class StreamTest extends TestCase
 {
     public static bool $isFReadError = false;
+    public static bool $isFWriteError = false;
+    public static bool $isFWriteZero = false;
+    public static bool $isFWriteException = false;
+    public static bool $isStreamTimedOut = false;
+    public static bool $isStreamMetadataError = false;
+
+    protected function tearDown(): void
+    {
+        self::$isFReadError = false;
+        self::$isFWriteError = false;
+        self::$isFWriteZero = false;
+        self::$isFWriteException = false;
+        self::$isStreamTimedOut = false;
+        self::$isStreamMetadataError = false;
+    }
 
     public function testConstructorThrowsExceptionOnInvalidArgument(): void
     {
@@ -302,6 +318,171 @@ class StreamTest extends TestCase
         $stream->read(1);
     }
 
+    public function testStreamWritingFwriteFalseThrowsRuntimeException(): void
+    {
+        self::$isFWriteError = true;
+        $r = fopen('php://temp', 'w+');
+        $stream = new Stream($r);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Unable to write to stream');
+
+        try {
+            $stream->write('x');
+        } finally {
+            $stream->close();
+        }
+    }
+
+    public function testStreamWritingFwriteFalseWhenTimedOutThrowsTimeoutException(): void
+    {
+        self::$isFWriteError = true;
+        self::$isStreamTimedOut = true;
+        $r = fopen('php://temp', 'w+');
+        $stream = new Stream($r);
+
+        $this->expectException(TimeoutException::class);
+        $this->expectExceptionMessage('Unable to write to stream: timed out');
+
+        try {
+            $stream->write('x');
+        } finally {
+            $stream->close();
+        }
+    }
+
+    public function testStreamWritingZeroBytesWhenTimedOutThrowsTimeoutException(): void
+    {
+        self::$isFWriteZero = true;
+        self::$isStreamTimedOut = true;
+        $r = fopen('php://temp', 'w+');
+        $stream = new Stream($r);
+
+        $this->expectException(TimeoutException::class);
+        $this->expectExceptionMessage('Unable to write to stream: timed out');
+
+        try {
+            $stream->write('x');
+        } finally {
+            $stream->close();
+        }
+    }
+
+    public function testStreamWritingZeroBytesWithoutTimeoutReturnsZero(): void
+    {
+        self::$isFWriteZero = true;
+        $r = fopen('php://temp', 'w+');
+        $stream = new Stream($r);
+
+        try {
+            self::assertSame(0, $stream->write('x'));
+        } finally {
+            $stream->close();
+        }
+    }
+
+    public function testStreamWritingEmptyStringReturnsZeroWithoutWritingOrInvalidatingSize(): void
+    {
+        $r = fopen('php://temp', 'w+');
+        fwrite($r, 'data');
+        $stream = new Stream($r);
+        self::assertSame(4, $stream->getSize());
+
+        self::$isFWriteException = true;
+        self::$isStreamTimedOut = true;
+        self::$isStreamMetadataError = true;
+
+        try {
+            self::assertSame(0, $stream->write(''));
+            self::assertSame(4, $stream->getSize());
+        } finally {
+            $stream->close();
+        }
+    }
+
+    public function testStreamWritingEmptyStringStillRequiresWritableStream(): void
+    {
+        $r = fopen('php://input', 'r');
+        $stream = new Stream($r);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Cannot write to a non-writable stream');
+
+        try {
+            $stream->write('');
+        } finally {
+            $stream->close();
+        }
+    }
+
+    public function testStreamWritingPositiveBytesIgnoresStaleTimeoutMetadata(): void
+    {
+        $r = fopen('php://temp', 'w+');
+        $stream = new Stream($r);
+        self::$isStreamTimedOut = true;
+
+        try {
+            self::assertSame(3, $stream->write('foo'));
+        } finally {
+            $stream->close();
+        }
+    }
+
+    public function testStreamWritingFwriteExceptionWhenTimedOutThrowsTimeoutExceptionWithPrevious(): void
+    {
+        self::$isFWriteException = true;
+        self::$isStreamTimedOut = true;
+        $r = fopen('php://temp', 'w+');
+        $stream = new Stream($r);
+
+        try {
+            $stream->write('x');
+            self::fail('Expected timeout exception');
+        } catch (TimeoutException $e) {
+            self::assertSame('Unable to write to stream: timed out', $e->getMessage());
+            self::assertInstanceOf(\ErrorException::class, $e->getPrevious());
+            self::assertSame('Some write error', $e->getPrevious()->getMessage());
+        } finally {
+            $stream->close();
+        }
+    }
+
+    public function testStreamWritingFwriteExceptionWithoutTimeoutThrowsRuntimeExceptionWithPrevious(): void
+    {
+        self::$isFWriteException = true;
+        $r = fopen('php://temp', 'w+');
+        $stream = new Stream($r);
+
+        try {
+            $stream->write('x');
+            self::fail('Expected runtime exception');
+        } catch (\RuntimeException $e) {
+            self::assertNotInstanceOf(TimeoutException::class, $e);
+            self::assertSame('Unable to write to stream', $e->getMessage());
+            self::assertInstanceOf(\ErrorException::class, $e->getPrevious());
+            self::assertSame('Some write error', $e->getPrevious()->getMessage());
+        } finally {
+            $stream->close();
+        }
+    }
+
+    public function testStreamWritingFwriteFalseWhenMetadataProbeFailsPreservesGenericRuntimeException(): void
+    {
+        self::$isFWriteError = true;
+        $r = fopen('php://temp', 'w+');
+        $stream = new Stream($r);
+        self::$isStreamMetadataError = true;
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Unable to write to stream');
+
+        try {
+            $stream->write('x');
+        } finally {
+            $stream->close();
+        }
+    }
+
     /**
      * @requires extension zlib
      *
@@ -450,4 +631,50 @@ use GuzzleHttp\Tests\Psr7\StreamTest;
 function fread($handle, int $length)
 {
     return StreamTest::$isFReadError ? false : \fread($handle, $length);
+}
+
+/**
+ * @param resource $handle
+ *
+ * @return int|false
+ */
+function fwrite($handle, string $string, ?int $length = null)
+{
+    if (StreamTest::$isFWriteException) {
+        throw new \ErrorException('Some write error');
+    }
+
+    if (StreamTest::$isFWriteError) {
+        return false;
+    }
+
+    if (StreamTest::$isFWriteZero) {
+        return 0;
+    }
+
+    if ($length === null) {
+        return \fwrite($handle, $string);
+    }
+
+    return \fwrite($handle, $string, $length);
+}
+
+/**
+ * @param resource $stream
+ *
+ * @return array<string, mixed>
+ */
+function stream_get_meta_data($stream): array
+{
+    if (StreamTest::$isStreamMetadataError) {
+        throw new \RuntimeException('metadata failed');
+    }
+
+    $metadata = \stream_get_meta_data($stream);
+
+    if (StreamTest::$isStreamTimedOut) {
+        $metadata['timed_out'] = true;
+    }
+
+    return $metadata;
 }


### PR DESCRIPTION
This change makes direct `Stream::write()` calls participate in the same timeout model already used by stream reads and `Utils::copyToStream()`. Failed or no-progress non-empty writes now throw `GuzzleHttp\Psr7\Exception\TimeoutException` when PHP stream metadata reports `timed_out`, while successful partial writes and ordinary zero-byte writes without timeout metadata keep their existing return values. Empty writes remain a validated no-op and do not invalidate the cached size.

The tests use the existing namespaced-function shim pattern in `StreamTest` to cover `fwrite()` failures, zero-byte writes, stale timeout metadata, metadata probe failures, and previous-exception preservation deterministically. The changelog and 3.0 upgrade guide now mention direct `Stream::write()` timeout detection.