### PR TITLE
Refine Stream mode capability detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reject malformed uploaded file specifications missing `tmp_name`, `size`, or `error`
 - Rewind seekable stream-backed uploaded files before copying them in `UploadedFile::moveTo()`
 - Reject negative stream read lengths consistently across stream implementations
+- Recognize PHP stream update modes with text or binary flags before `+` when reporting `Stream::isReadable()` and `Stream::isWritable()`
 - Reject empty strings returned by `PumpStream` source callables to prevent no-progress read loops
 - Make `PumpStream::close()` and `PumpStream::detach()` discard internally buffered unread bytes
 - Restore the original body cursor after `Message::bodySummary()` reads seekable bodies

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -358,6 +358,16 @@ $stream = Utils::streamFor(new ArrayIterator([false, 'body']));
 $stream = Utils::streamFor(new ArrayIterator(['body']));
 ```
 
+#### Stream Mode Capabilities
+
+`Stream::isReadable()` and `Stream::isWritable()` now follow PHP stream mode
+semantics more closely. Update modes are detected by the presence of `+`,
+including valid modes such as `rt+`, `wt+`, `at+`, `xt+`, and `ct+`.
+
+Literal `rw` metadata is now treated as read-only, matching PHP real-file
+streams. If a custom stream wrapper previously exposed `rw` for a writable
+resource, open it with a valid update mode such as `r+`, `w+`, or `a+` instead.
+
 #### Stream Timeout Detection
 
 Timed-out stream operations now throw

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -12,13 +12,6 @@ use Psr\Http\Message\StreamInterface;
  */
 class Stream implements StreamInterface
 {
-    /**
-     * @see https://www.php.net/manual/en/function.fopen.php
-     * @see https://www.php.net/manual/en/function.gzopen.php
-     */
-    private const READABLE_MODES = '/r|a\+|ab\+|w\+|wb\+|x\+|xb\+|c\+|cb\+/';
-    private const WRITABLE_MODES = '/a|w|r\+|rb\+|rw|x|c/';
-
     /** @var resource */
     private $stream;
     private ?int $size = null;
@@ -57,8 +50,8 @@ class Stream implements StreamInterface
         $this->stream = $stream;
         $meta = stream_get_meta_data($this->stream);
         $this->seekable = $meta['seekable'];
-        $this->readable = (bool) preg_match(self::READABLE_MODES, $meta['mode']);
-        $this->writable = (bool) preg_match(self::WRITABLE_MODES, $meta['mode']);
+        $this->readable = self::isReadableMode($meta['mode']);
+        $this->writable = self::isWritableMode($meta['mode']);
         $this->uri = $meta['uri'] ?? null;
     }
 
@@ -301,6 +294,28 @@ class Stream implements StreamInterface
         $meta = stream_get_meta_data($this->stream);
 
         return $meta[$key] ?? null;
+    }
+
+    /**
+     * @see https://www.php.net/manual/en/function.fopen.php
+     * @see https://www.php.net/manual/en/function.gzopen.php
+     */
+    private static function isReadableMode(string $mode): bool
+    {
+        return strpos($mode, 'r') === 0 || strpos($mode, '+') !== false;
+    }
+
+    /**
+     * @see https://www.php.net/manual/en/function.fopen.php
+     * @see https://www.php.net/manual/en/function.gzopen.php
+     */
+    private static function isWritableMode(string $mode): bool
+    {
+        return strpos($mode, 'a') === 0
+            || strpos($mode, 'w') === 0
+            || strpos($mode, 'x') === 0
+            || strpos($mode, 'c') === 0
+            || strpos($mode, '+') !== false;
     }
 
     private function timedOut(): bool

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -504,6 +504,97 @@ class StreamTest extends TestCase
         return [
             ['mode' => 'rb9', 'readable' => true, 'writable' => false],
             ['mode' => 'wb2', 'readable' => false, 'writable' => true],
+            ['mode' => 'wb6f', 'readable' => false, 'writable' => true],
+            ['mode' => 'wb1h', 'readable' => false, 'writable' => true],
+            ['mode' => 'ab9', 'readable' => false, 'writable' => true],
+        ];
+    }
+
+    /**
+     * @dataProvider fileModeCapabilityProvider
+     */
+    public function testFileStreamModeCapabilities(string $mode, bool $readable, bool $writable): void
+    {
+        $path = tempnam(sys_get_temp_dir(), 'guzzle-psr7-mode-');
+        if ($path === false) {
+            self::fail('Unable to create temporary file');
+        }
+
+        try {
+            if ($mode[0] === 'x') {
+                if (!unlink($path)) {
+                    self::fail('Unable to remove temporary file before exclusive create test');
+                }
+            } else {
+                if (file_put_contents($path, 'data') === false) {
+                    self::fail('Unable to write temporary file');
+                }
+            }
+
+            $r = fopen($path, $mode);
+            if (!is_resource($r)) {
+                self::fail(sprintf('Unable to open temporary file using mode "%s"', $mode));
+            }
+
+            $stream = new Stream($r);
+
+            try {
+                self::assertSame($readable, $stream->isReadable());
+                self::assertSame($writable, $stream->isWritable());
+            } finally {
+                $stream->close();
+            }
+        } finally {
+            if (file_exists($path)) {
+                unlink($path);
+            }
+        }
+    }
+
+    public static function fileModeCapabilityProvider(): iterable
+    {
+        return [
+            'r' => ['mode' => 'r', 'readable' => true, 'writable' => false],
+            'rb' => ['mode' => 'rb', 'readable' => true, 'writable' => false],
+            'rt' => ['mode' => 'rt', 'readable' => true, 'writable' => false],
+            'rw' => ['mode' => 'rw', 'readable' => true, 'writable' => false],
+            'r+' => ['mode' => 'r+', 'readable' => true, 'writable' => true],
+            'rb+' => ['mode' => 'rb+', 'readable' => true, 'writable' => true],
+            'r+b' => ['mode' => 'r+b', 'readable' => true, 'writable' => true],
+            'rt+' => ['mode' => 'rt+', 'readable' => true, 'writable' => true],
+            'r+t' => ['mode' => 'r+t', 'readable' => true, 'writable' => true],
+            'w' => ['mode' => 'w', 'readable' => false, 'writable' => true],
+            'wb' => ['mode' => 'wb', 'readable' => false, 'writable' => true],
+            'wt' => ['mode' => 'wt', 'readable' => false, 'writable' => true],
+            'w+' => ['mode' => 'w+', 'readable' => true, 'writable' => true],
+            'wb+' => ['mode' => 'wb+', 'readable' => true, 'writable' => true],
+            'w+b' => ['mode' => 'w+b', 'readable' => true, 'writable' => true],
+            'wt+' => ['mode' => 'wt+', 'readable' => true, 'writable' => true],
+            'w+t' => ['mode' => 'w+t', 'readable' => true, 'writable' => true],
+            'a' => ['mode' => 'a', 'readable' => false, 'writable' => true],
+            'ab' => ['mode' => 'ab', 'readable' => false, 'writable' => true],
+            'at' => ['mode' => 'at', 'readable' => false, 'writable' => true],
+            'a+' => ['mode' => 'a+', 'readable' => true, 'writable' => true],
+            'ab+' => ['mode' => 'ab+', 'readable' => true, 'writable' => true],
+            'a+b' => ['mode' => 'a+b', 'readable' => true, 'writable' => true],
+            'at+' => ['mode' => 'at+', 'readable' => true, 'writable' => true],
+            'a+t' => ['mode' => 'a+t', 'readable' => true, 'writable' => true],
+            'x' => ['mode' => 'x', 'readable' => false, 'writable' => true],
+            'xb' => ['mode' => 'xb', 'readable' => false, 'writable' => true],
+            'xt' => ['mode' => 'xt', 'readable' => false, 'writable' => true],
+            'x+' => ['mode' => 'x+', 'readable' => true, 'writable' => true],
+            'xb+' => ['mode' => 'xb+', 'readable' => true, 'writable' => true],
+            'x+b' => ['mode' => 'x+b', 'readable' => true, 'writable' => true],
+            'xt+' => ['mode' => 'xt+', 'readable' => true, 'writable' => true],
+            'x+t' => ['mode' => 'x+t', 'readable' => true, 'writable' => true],
+            'c' => ['mode' => 'c', 'readable' => false, 'writable' => true],
+            'cb' => ['mode' => 'cb', 'readable' => false, 'writable' => true],
+            'ct' => ['mode' => 'ct', 'readable' => false, 'writable' => true],
+            'c+' => ['mode' => 'c+', 'readable' => true, 'writable' => true],
+            'cb+' => ['mode' => 'cb+', 'readable' => true, 'writable' => true],
+            'c+b' => ['mode' => 'c+b', 'readable' => true, 'writable' => true],
+            'ct+' => ['mode' => 'ct+', 'readable' => true, 'writable' => true],
+            'c+t' => ['mode' => 'c+t', 'readable' => true, 'writable' => true],
         ];
     }
 
@@ -571,7 +662,6 @@ class StreamTest extends TestCase
         return [
             ['w'],
             ['w+'],
-            ['rw'],
             ['r+'],
             ['x+'],
             ['c+'],


### PR DESCRIPTION
This replaces the mode-matching regular expressions with small predicates that follow PHP stream mode semantics, including update modes where the text or binary flag appears before the plus sign. It also adds direct coverage for real file metadata modes and gzip compression suffix modes so the readable and writable flags stay aligned with observed PHP stream metadata.