### PR TITLE
Preserve InflateStream read timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reject invalid `Utils::modifyRequest()` change values
 - Use PHP debug type names in type error messages
 - Throw `TimeoutException` from `Stream` read/write and `Utils` copy/hash/readLine on stream timeouts
+- Re-throw `TimeoutException` from `InflateStream` when the decoded source stream times out
 - Translate `StreamWrapper` runtime failures to PHP stream failure values
 - Stop adding default `Content-Length` to `multipart/form-data` parts (RFC 7578 §4.8)
 - Escape multipart `Content-Disposition` parameters and reject unsafe boundaries and part headers

--- a/src/InflateStream.php
+++ b/src/InflateStream.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GuzzleHttp\Psr7;
 
+use GuzzleHttp\Psr7\Exception\TimeoutException;
 use Psr\Http\Message\StreamInterface;
 
 /**
@@ -23,8 +24,11 @@ final class InflateStream implements StreamInterface
 
     private StreamInterface $stream;
 
+    private ?StreamInterface $source;
+
     public function __construct(StreamInterface $stream)
     {
+        $this->source = $stream;
         $resource = StreamWrapper::getResource($stream);
         // Specify window=15+32, so zlib will use header detection to both gzip (with header) and zlib data
         // See https://www.zlib.net/manual.html#Advanced definition of inflateInit2
@@ -32,5 +36,43 @@ final class InflateStream implements StreamInterface
         // Default window size is 15.
         stream_filter_append($resource, 'zlib.inflate', STREAM_FILTER_READ, ['window' => 15 + 32]);
         $this->stream = $stream->isSeekable() ? new Stream($resource) : new NoSeekStream(new Stream($resource));
+    }
+
+    public function read(int $length): string
+    {
+        if ($length <= 0 || $this->source === null) {
+            return $this->stream->read($length);
+        }
+
+        try {
+            $data = $this->stream->read($length);
+        } catch (TimeoutException $e) {
+            throw $e;
+        } catch (\RuntimeException $e) {
+            if (StreamTimeout::isReadTimedOut($this->source)) {
+                throw new TimeoutException('Unable to read from stream: timed out', 0, $e);
+            }
+
+            throw $e;
+        }
+
+        if ($data === '' && StreamTimeout::isReadTimedOut($this->source)) {
+            throw new TimeoutException('Unable to read from stream: timed out');
+        }
+
+        return $data;
+    }
+
+    public function close(): void
+    {
+        $this->source = null;
+        $this->stream->close();
+    }
+
+    public function detach()
+    {
+        $this->source = null;
+
+        return $this->stream->detach();
     }
 }

--- a/src/InflateStream.php
+++ b/src/InflateStream.php
@@ -65,8 +65,30 @@ final class InflateStream implements StreamInterface
 
     public function close(): void
     {
+        $source = $this->source;
         $this->source = null;
-        $this->stream->close();
+
+        $exception = null;
+
+        try {
+            $this->stream->close();
+        } catch (\Throwable $e) {
+            $exception = $e;
+        }
+
+        if ($source !== null) {
+            try {
+                $source->close();
+            } catch (\Throwable $e) {
+                if ($exception === null) {
+                    $exception = $e;
+                }
+            }
+        }
+
+        if ($exception !== null) {
+            throw $exception;
+        }
     }
 
     public function detach()

--- a/tests/InflateStreamTest.php
+++ b/tests/InflateStreamTest.php
@@ -122,6 +122,78 @@ class InflateStreamTest extends TestCase
         self::assertSame('', $stream->read(1024));
     }
 
+    public function testCloseClosesSourceStream(): void
+    {
+        $resource = Psr7\Utils::tryFopen('php://temp', 'r+');
+        fwrite($resource, gzencode('test'));
+        rewind($resource);
+
+        $stream = new InflateStream(Psr7\Utils::streamFor($resource));
+
+        $stream->close();
+
+        self::assertFalse(is_resource($resource));
+    }
+
+    public function testCloseClosesSourceStreamOnlyOnce(): void
+    {
+        $closed = 0;
+
+        $source = new Psr7\FnStream([
+            'isReadable' => static fn (): bool => true,
+            'isWritable' => static fn (): bool => false,
+            'isSeekable' => static fn (): bool => false,
+            'eof' => static fn (): bool => true,
+            'read' => static fn (int $length): string => '',
+            'close' => static function () use (&$closed): void {
+                ++$closed;
+            },
+        ]);
+
+        $stream = new InflateStream($source);
+
+        $stream->close();
+        $stream->close();
+
+        self::assertSame(1, $closed);
+    }
+
+    public function testDetachDoesNotCloseOrDetachSourceStream(): void
+    {
+        $closed = 0;
+        $detached = 0;
+        $source = new Psr7\FnStream([
+            'isReadable' => static fn (): bool => true,
+            'isWritable' => static fn (): bool => false,
+            'isSeekable' => static fn (): bool => false,
+            'eof' => static fn (): bool => true,
+            'read' => static fn (int $length): string => '',
+            'close' => static function () use (&$closed): void {
+                ++$closed;
+            },
+            'detach' => static function () use (&$detached) {
+                ++$detached;
+
+                return null;
+            },
+        ]);
+
+        $stream = new InflateStream($source);
+        $resource = $stream->detach();
+
+        try {
+            self::assertIsResource($resource);
+            self::assertSame(0, $closed);
+            self::assertSame(0, $detached);
+        } finally {
+            if (is_resource($resource)) {
+                fclose($resource);
+            }
+
+            $source->close();
+        }
+    }
+
     public function testReadSurfacesPartialGzipSourceReadTimeout(): void
     {
         $compressed = gzencode(str_repeat('A', 100000));

--- a/tests/InflateStreamTest.php
+++ b/tests/InflateStreamTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace GuzzleHttp\Tests\Psr7;
 
 use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Exception\TimeoutException;
 use GuzzleHttp\Psr7\InflateStream;
 use GuzzleHttp\Psr7\NoSeekStream;
 use PHPUnit\Framework\TestCase;
@@ -88,6 +89,73 @@ class InflateStreamTest extends TestCase
         $this->expectExceptionMessage('Length parameter cannot be negative');
 
         $stream->read(-1);
+    }
+
+    public function testReadSurfacesSourceReadTimeout(): void
+    {
+        $source = new Psr7\FnStream([
+            'isReadable' => static fn (): bool => true,
+            'isWritable' => static fn (): bool => false,
+            'isSeekable' => static fn (): bool => false,
+            'eof' => static fn (): bool => false,
+            'read' => static function (int $length): string {
+                throw new TimeoutException('Unable to read from stream: timed out');
+            },
+            'getMetadata' => static function (?string $key = null) {
+                return $key === 'timed_out' ? true : null;
+            },
+        ]);
+
+        $stream = new InflateStream($source);
+
+        $this->expectException(TimeoutException::class);
+        $this->expectExceptionMessage('Unable to read from stream: timed out');
+
+        $stream->read(1024);
+    }
+
+    public function testReadReturnsEmptyStringOnCleanEofWithoutTimeout(): void
+    {
+        $stream = new InflateStream(Psr7\Utils::streamFor(gzencode('test')));
+
+        self::assertSame('test', (string) $stream);
+        self::assertSame('', $stream->read(1024));
+    }
+
+    public function testReadSurfacesPartialGzipSourceReadTimeout(): void
+    {
+        $compressed = gzencode(str_repeat('A', 100000));
+        $offset = 0;
+        $timedOut = false;
+
+        $source = new Psr7\FnStream([
+            'isReadable' => static fn (): bool => true,
+            'isWritable' => static fn (): bool => false,
+            'isSeekable' => static fn (): bool => false,
+            'eof' => static fn (): bool => false,
+            'read' => static function (int $length) use ($compressed, &$offset, &$timedOut): string {
+                if ($offset >= 64) {
+                    $timedOut = true;
+
+                    throw new TimeoutException('Unable to read from stream: timed out');
+                }
+
+                $chunk = substr($compressed, $offset, min($length, 64 - $offset));
+                $offset += strlen($chunk);
+
+                return $chunk;
+            },
+            'getMetadata' => static function (?string $key = null) use (&$timedOut) {
+                return $key === 'timed_out' ? $timedOut : null;
+            },
+        ]);
+
+        $stream = new InflateStream($source);
+
+        $this->expectException(TimeoutException::class);
+        $this->expectExceptionMessage('Unable to read from stream: timed out');
+
+        Psr7\Utils::copyToString($stream);
     }
 
     private function getGzipStringWithFilename(string $original_string): string


### PR DESCRIPTION
InflateStream reads compressed bodies through the guzzle stream wrapper and PHP zlib.inflate filter. When the wrapped source stream times out, the wrapper converts the PSR-7 TimeoutException into a PHP stream failure value, so the filtered read can lose the timeout signal and surface a generic read failure or an empty read.

This keeps a reference to the original source stream and has InflateStream::read() check the source timed_out metadata when the filtered read fails or returns an empty string. If the source is still timed out, it raises a PSR-7 TimeoutException; clean EOF continues to return an empty string. InflateStream::close() now closes both the filtered wrapper stream and the original source stream, while detach() still transfers the filtered resource without closing or detaching the source.

The regression coverage exercises the wrapper failure path, a partial gzip body that times out while draining, clean EOF, and the close/detach lifecycle behavior.