### PR TITLE
Fix copyToStream short writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Changed `Utils::copyToStream()` to retry short destination writes and throw when destination streams cannot make progress
 - Changed `Utils::modifyRequest()` to reject conflicting URI and `Host` header changes in the same call
 - Changed `Header::parse()` to split semicolon-separated parameters without repeated regular expression lookaheads
 - Changed `UriComparator::isCrossOrigin()` so only HTTP and HTTPS missing ports receive implicit default ports
@@ -26,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `Utils::copyToStream()` to retry short destination writes instead of dropping the unwritten remainder
 - Fixed `Header::parse()` splitting of semicolon-separated parameters with escaped quotes
 
 ## 2.10.4 - 2026-05-29

--- a/README.md
+++ b/README.md
@@ -469,6 +469,11 @@ Remove the items given by the keys, case insensitively from the data.
 Copy the contents of a stream into another stream until the given number
 of bytes have been read.
 
+The copy stops if the destination `write()` returns 0, for example a
+`BufferStream` at its high water mark or a full `DroppingStream`. For a
+guaranteed full copy, use a normal writable stream such as a file or
+`php://temp` stream.
+
 
 ## `GuzzleHttp\Psr7\Utils::copyToString`
 

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -36,12 +36,15 @@ final class Utils
      * Copy the contents of a stream into another stream until the given number
      * of bytes have been read.
      *
+     * The copy stops if the destination write returns 0, for example a
+     * BufferStream at its high water mark or a full DroppingStream. For a
+     * guaranteed full copy use a normal writable stream such as a file or
+     * php://temp stream.
+     *
      * @param StreamInterface $source Stream to read from
      * @param StreamInterface $dest   Stream to write to
      * @param int             $maxLen Maximum number of bytes to read. Pass -1
      *                                to read the entire stream.
-     *
-     * @throws \RuntimeException on error.
      */
     public static function copyToStream(StreamInterface $source, StreamInterface $dest, int $maxLen = -1): void
     {
@@ -54,7 +57,9 @@ final class Utils
                     break;
                 }
 
-                self::writeAll($dest, $buf);
+                if (!self::writeAll($dest, $buf)) {
+                    break;
+                }
             }
         } else {
             $remaining = $maxLen;
@@ -65,12 +70,19 @@ final class Utils
                     break;
                 }
                 $remaining -= $len;
-                self::writeAll($dest, $buf);
+                if (!self::writeAll($dest, $buf)) {
+                    break;
+                }
             }
         }
     }
 
-    private static function writeAll(StreamInterface $dest, string $buf): void
+    /**
+     * Writes the full buffer to the destination, retrying short writes.
+     *
+     * Returns false when the destination write returns 0 or less.
+     */
+    private static function writeAll(StreamInterface $dest, string $buf): bool
     {
         $written = 0;
         $len = strlen($buf);
@@ -78,11 +90,13 @@ final class Utils
         while ($written < $len) {
             $result = $dest->write(substr($buf, $written));
             if ($result <= 0) {
-                throw new \RuntimeException('Unable to write to stream');
+                return false;
             }
 
             $written += $result;
         }
+
+        return true;
     }
 
     /**

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -89,36 +89,53 @@ class UtilsTest extends TestCase
         self::assertSame(3, $writes);
     }
 
-    public function testCopyToStreamThrowsWhenWriteFails(): void
+    public function testCopyToStreamStopsWhenDestinationMakesNoProgress(): void
     {
         $s1 = Psr7\Utils::streamFor('foobaz');
-        $s2 = Psr7\Utils::streamFor('');
-        $s2 = FnStream::decorate($s2, [
+        $sink = Psr7\Utils::streamFor('');
+        $s2 = FnStream::decorate($sink, [
             'write' => function () {
                 return 0;
             },
         ]);
-
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Unable to write to stream');
 
         Psr7\Utils::copyToStream($s1, $s2);
+
+        self::assertSame('', (string) $sink);
     }
 
-    public function testCopyToStreamThrowsWhenWriteFailsWithMaxLen(): void
+    public function testCopyToStreamStopsWhenDestinationMakesNoProgressWithMaxLen(): void
     {
         $s1 = Psr7\Utils::streamFor('foobaz');
-        $s2 = Psr7\Utils::streamFor('');
-        $s2 = FnStream::decorate($s2, [
+        $sink = Psr7\Utils::streamFor('');
+        $s2 = FnStream::decorate($sink, [
             'write' => function () {
                 return 0;
             },
         ]);
 
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Unable to write to stream');
-
         Psr7\Utils::copyToStream($s1, $s2, 10);
+
+        self::assertSame('', (string) $sink);
+    }
+
+    public function testCopyToStreamStopsWithoutThrowingWhenDestinationBufferStreamReachesHighWaterMark(): void
+    {
+        $dest = new Psr7\BufferStream(3);
+
+        Psr7\Utils::copyToStream(Psr7\Utils::streamFor('foobaz'), $dest);
+
+        self::assertSame('foobaz', (string) $dest);
+    }
+
+    public function testCopyToStreamStopsWithoutThrowingWhenDestinationDroppingStreamIsFull(): void
+    {
+        $underlying = new Psr7\BufferStream();
+        $dest = new Psr7\DroppingStream($underlying, 3);
+
+        Psr7\Utils::copyToStream(Psr7\Utils::streamFor('foobaz'), $dest);
+
+        self::assertSame('foo', (string) $underlying);
     }
 
     public function testCopyToStreamReadsInChunksInsteadOfAllInMemory(): void


### PR DESCRIPTION
This fixes Utils::copyToStream() so short destination writes are retried instead of dropping the unwritten remainder. It keeps the existing behavior for destinations that return 0 by stopping the copy without throwing, which preserves compatibility with BufferStream high water marks and full DroppingStream instances. The docs and changelog now describe the current behavior without referencing future versions.