### PR TITLE
Document copyToStream no-progress throw for 3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Validate unsupported values passed to `Query::build()`
 - Reject invalid `Utils::modifyRequest()` change values
 - Use PHP debug type names in type error messages
-- Changed `Utils::copyToStream()` to throw a `RuntimeException` when a destination stream cannot make progress, for example a `BufferStream` past its high-water mark or a full `DroppingStream`
+- Changed `Utils::copyToStream()` to throw when destination streams cannot make progress
 - Throw `TimeoutException` from `Stream` read/write and `Utils` copy/hash/readLine on stream timeouts
 - Re-throw `TimeoutException` from `InflateStream` when the decoded source stream times out
 - Translate `StreamWrapper` runtime failures to PHP stream failure values

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Validate unsupported values passed to `Query::build()`
 - Reject invalid `Utils::modifyRequest()` change values
 - Use PHP debug type names in type error messages
+- Changed `Utils::copyToStream()` to throw a `RuntimeException` when a destination stream cannot make progress, for example a `BufferStream` past its high-water mark or a full `DroppingStream`
 - Throw `TimeoutException` from `Stream` read/write and `Utils` copy/hash/readLine on stream timeouts
 - Re-throw `TimeoutException` from `InflateStream` when the decoded source stream times out
 - Translate `StreamWrapper` runtime failures to PHP stream failure values

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -368,6 +368,14 @@ Literal `rw` metadata is now treated as read-only, matching PHP real-file
 streams. If a custom stream wrapper previously exposed `rw` for a writable
 resource, open it with a valid update mode such as `r+`, `w+`, or `a+` instead.
 
+#### Stream Copy Behavior
+
+`Utils::copyToStream()` now throws a `RuntimeException` when the destination
+stream cannot make progress, for example a `BufferStream` at its high-water mark
+or a full `DroppingStream`. In 2.x, the copy stopped silently in this case. For a
+guaranteed full copy, use a normal writable stream such as a file or `php://temp`
+stream.
+
 #### Stream Timeout Detection
 
 Timed-out stream operations now throw


### PR DESCRIPTION
This documents the 3.0-only behavior where Utils::copyToStream() throws when a destination stream cannot make progress. The 2.11 correction kept only the short-write retry as a bug fix, so the no-progress throw belongs in the 3.0 changelog and upgrade guide instead. This is a documentation-only change.