### PR TITLE
Preserve multipart part header whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Translate `StreamWrapper` runtime failures to PHP stream failure values
 - Stop adding default `Content-Length` to `multipart/form-data` parts (RFC 7578 §4.8)
 - Escape multipart `Content-Disposition` parameters and reject unsafe boundaries and part headers
+- Preserve trailing whitespace in custom `MultipartStream` part header values
 - Made static utility classes non-instantiable
 
 ### Removed

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -486,6 +486,13 @@ Custom multipart part header names and values are also validated before
 serialization. Header names must be valid HTTP tokens, and header values must be
 strings without CR, LF, or other invalid control bytes.
 
+`MultipartStream` now preserves trailing spaces and tabs in custom multipart
+part header values when serializing the body. In 2.x, the final serialized part
+header line was trimmed as a side effect of removing the generated header
+terminator. Normal multipart parsers treat this optional whitespace as
+insignificant, but tests, signatures, or snapshots that compare raw multipart
+body bytes may need updated expectations.
+
 #### URI Userinfo Redaction
 
 `Utils::redactUserInfo()` now redacts all non-empty URI userinfo, including

--- a/src/MultipartStream.php
+++ b/src/MultipartStream.php
@@ -75,7 +75,7 @@ final class MultipartStream implements StreamInterface
             $str .= "{$key}: {$value}\r\n";
         }
 
-        return "--{$this->boundary}\r\n".trim($str)."\r\n\r\n";
+        return "--{$this->boundary}\r\n".rtrim($str, "\r\n")."\r\n\r\n";
     }
 
     /**

--- a/tests/MultipartStreamTest.php
+++ b/tests/MultipartStreamTest.php
@@ -923,6 +923,58 @@ class MultipartStreamTest extends TestCase
         self::assertSame($expected, (string) $b);
     }
 
+    public function testPreservesTrailingWhitespaceInFinalCustomPartHeader(): void
+    {
+        $b = new MultipartStream([
+            [
+                'name' => 'field',
+                'contents' => 'body',
+                'headers' => [
+                    'Content-Disposition' => 'form-data; name="field"',
+                    'X-Trailing' => "value \t",
+                ],
+            ],
+        ], 'boundary');
+
+        $expected = \implode('', [
+            "--boundary\r\n",
+            "Content-Disposition: form-data; name=\"field\"\r\n",
+            "X-Trailing: value \t\r\n",
+            "\r\n",
+            "body\r\n",
+            "--boundary--\r\n",
+        ]);
+
+        self::assertSame($expected, (string) $b);
+        self::assertSame(\strlen($expected), $b->getSize());
+    }
+
+    public function testPreservesAllWhitespaceFinalCustomPartHeaderValue(): void
+    {
+        $b = new MultipartStream([
+            [
+                'name' => 'field',
+                'contents' => 'body',
+                'headers' => [
+                    'Content-Disposition' => 'form-data; name="field"',
+                    'X-Blank' => " \t ",
+                ],
+            ],
+        ], 'boundary');
+
+        $expected = \implode('', [
+            "--boundary\r\n",
+            "Content-Disposition: form-data; name=\"field\"\r\n",
+            "X-Blank:  \t \r\n",
+            "\r\n",
+            "body\r\n",
+            "--boundary--\r\n",
+        ]);
+
+        self::assertSame($expected, (string) $b);
+        self::assertSame(\strlen($expected), $b->getSize());
+    }
+
     /**
      * @dataProvider unstringableCustomHeaderValueProvider
      */


### PR DESCRIPTION
This preserves trailing spaces and tabs in custom MultipartStream part header values by removing only the generated CRLF from the serialized header block. The change keeps multipart framing unchanged while avoiding the previous order-dependent trimming of the final custom part header. The upgrade guide now calls out the raw body byte difference for users with multipart snapshots or signatures.