### PR TITLE
Return bytes copied from copyToStream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed `Utils::copyToStream()` to throw when destination streams cannot make progress
 - Throw `TimeoutException` from `Stream` read/write and `Utils` copy/hash/readLine on stream timeouts
 - Re-throw `TimeoutException` from `InflateStream` when the decoded source stream times out
+- Return the number of bytes copied from `Utils::copyToStream()`
 - Translate `StreamWrapper` runtime failures to PHP stream failure values
 - Stop adding default `Content-Length` to `multipart/form-data` parts (RFC 7578 §4.8)
 - Escape multipart `Content-Disposition` parameters and reject unsafe boundaries and part headers

--- a/README.md
+++ b/README.md
@@ -490,6 +490,10 @@ Remove the items given by the keys, case insensitively from the data.
 Copy the contents of a stream into another stream until the given number
 of bytes have been read. Returns the number of bytes copied.
 
+The returned byte count is an `int`. On 32-bit PHP, an unbounded copy larger
+than `PHP_INT_MAX` bytes cannot be represented by that return type; 64-bit PHP
+is not affected.
+
 The destination must accept writes that make positive progress. Streams that
 return 0 as a backpressure or drop signal — a `BufferStream` past its high water
 mark, or a full `DroppingStream` — will cause this method to throw. For full

--- a/README.md
+++ b/README.md
@@ -485,10 +485,10 @@ Remove the items given by the keys, case insensitively from the data.
 
 ## `GuzzleHttp\Psr7\Utils::copyToStream`
 
-`public static function copyToStream(StreamInterface $source, StreamInterface $dest, int $maxLen = -1): void`
+`public static function copyToStream(StreamInterface $source, StreamInterface $dest, int $maxLen = -1): int`
 
 Copy the contents of a stream into another stream until the given number
-of bytes have been read.
+of bytes have been read. Returns the number of bytes copied.
 
 The destination must accept writes that make positive progress. Streams that
 return 0 as a backpressure or drop signal — a `BufferStream` past its high water

--- a/README.md
+++ b/README.md
@@ -487,12 +487,10 @@ Remove the items given by the keys, case insensitively from the data.
 
 `public static function copyToStream(StreamInterface $source, StreamInterface $dest, int $maxLen = -1): int`
 
-Copy the contents of a stream into another stream until the given number
-of bytes have been read. Returns the number of bytes copied.
-
-The returned byte count is an `int`. On 32-bit PHP, an unbounded copy larger
-than `PHP_INT_MAX` bytes cannot be represented by that return type; 64-bit PHP
-is not affected.
+Copy the contents of a stream into another stream until the given number of
+bytes have been read, returning the number of bytes copied as an `int`. On
+32-bit PHP, an unbounded copy larger than `PHP_INT_MAX` bytes cannot be
+represented by that return type. 64-bit PHP is not affected.
 
 The destination must accept writes that make positive progress. Streams that
 return 0 as a backpressure or drop signal — a `BufferStream` past its high water

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -372,10 +372,11 @@ resource, open it with a valid update mode such as `r+`, `w+`, or `a+` instead.
 
 `Utils::copyToStream()` now returns the number of bytes copied and throws a
 `RuntimeException` when the destination stream cannot make progress, for example
-a `BufferStream` at its high-water mark or a full `DroppingStream`. Callers that
-ignore the return value do not need to change anything. In 2.x, the copy stopped
-silently when the destination could not make progress. For a guaranteed full
-copy, use a normal writable stream such as a file or `php://temp` stream.
+a `BufferStream` at its high-water mark or a full `DroppingStream`. Its
+signature changed from `: void` to `: int`, but callers that ignore the return
+value do not need to change anything. In 2.x, the copy stopped silently when the
+destination could not make progress. For a guaranteed full copy, use a normal
+writable stream such as a file or `php://temp` stream.
 
 #### Stream Timeout Detection
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -370,6 +370,10 @@ resource, open it with a valid update mode such as `r+`, `w+`, or `a+` instead.
 
 #### Stream Copy Behavior
 
+`Utils::copyToStream()` now returns the number of bytes copied. Callers that
+ignore the return value are unaffected, but reflection, generated docs, and
+static-analysis consumers will observe an `int` return instead of `void`.
+
 `Utils::copyToStream()` now throws a `RuntimeException` when the destination
 stream cannot make progress, for example a `BufferStream` at its high-water mark
 or a full `DroppingStream`. In 2.x, the copy stopped silently in this case. For a

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -373,11 +373,9 @@ resource, open it with a valid update mode such as `r+`, `w+`, or `a+` instead.
 `Utils::copyToStream()` now returns the number of bytes copied and throws a
 `RuntimeException` when the destination stream cannot make progress, for example
 a `BufferStream` at its high-water mark or a full `DroppingStream`. Callers that
-ignore the return value are unaffected, but reflection, generated docs, and
-static-analysis consumers will observe an `int` return instead of `void`.
-In 2.x, the copy stopped silently when the destination could not make progress.
-For a guaranteed full copy, use a normal writable stream such as a file or
-`php://temp` stream.
+ignore the return value do not need to change anything. In 2.x, the copy stopped
+silently when the destination could not make progress. For a guaranteed full
+copy, use a normal writable stream such as a file or `php://temp` stream.
 
 #### Stream Timeout Detection
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -370,15 +370,14 @@ resource, open it with a valid update mode such as `r+`, `w+`, or `a+` instead.
 
 #### Stream Copy Behavior
 
-`Utils::copyToStream()` now returns the number of bytes copied. Callers that
+`Utils::copyToStream()` now returns the number of bytes copied and throws a
+`RuntimeException` when the destination stream cannot make progress, for example
+a `BufferStream` at its high-water mark or a full `DroppingStream`. Callers that
 ignore the return value are unaffected, but reflection, generated docs, and
 static-analysis consumers will observe an `int` return instead of `void`.
-
-`Utils::copyToStream()` now throws a `RuntimeException` when the destination
-stream cannot make progress, for example a `BufferStream` at its high-water mark
-or a full `DroppingStream`. In 2.x, the copy stopped silently in this case. For a
-guaranteed full copy, use a normal writable stream such as a file or `php://temp`
-stream.
+In 2.x, the copy stopped silently when the destination could not make progress.
+For a guaranteed full copy, use a normal writable stream such as a file or
+`php://temp` stream.
 
 #### Stream Timeout Detection
 

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -39,7 +39,7 @@ final class Utils
 
     /**
      * Copy the contents of a stream into another stream until the given number
-     * of bytes have been read.
+     * of bytes have been read, returning the number of bytes copied.
      *
      * The destination must accept writes that make positive progress. Streams
      * that return 0 as a backpressure or drop signal (a BufferStream at its high
@@ -52,9 +52,10 @@ final class Utils
      *
      * @throws \RuntimeException on error.
      */
-    public static function copyToStream(StreamInterface $source, StreamInterface $dest, int $maxLen = -1): void
+    public static function copyToStream(StreamInterface $source, StreamInterface $dest, int $maxLen = -1): int
     {
         $bufferSize = 8192;
+        $copied = 0;
 
         if ($maxLen === -1) {
             while (!$source->eof()) {
@@ -64,6 +65,7 @@ final class Utils
                 }
 
                 self::writeAll($dest, $buf);
+                $copied += strlen($buf);
             }
         } else {
             $remaining = $maxLen;
@@ -75,8 +77,11 @@ final class Utils
                 }
                 $remaining -= $len;
                 self::writeAll($dest, $buf);
+                $copied += $len;
             }
         }
+
+        return $copied;
     }
 
     private static function writeAll(StreamInterface $dest, string $buf): void

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -156,14 +156,38 @@ class UtilsTest extends TestCase
     {
         $s1 = Psr7\Utils::streamFor('foobaz');
         $s2 = Psr7\Utils::streamFor('');
-        Psr7\Utils::copyToStream($s1, $s2);
+        self::assertSame(6, Psr7\Utils::copyToStream($s1, $s2));
         self::assertSame('foobaz', (string) $s2);
         $s2 = Psr7\Utils::streamFor('');
         $s1->seek(0);
-        Psr7\Utils::copyToStream($s1, $s2, 3);
+        self::assertSame(3, Psr7\Utils::copyToStream($s1, $s2, 3));
         self::assertSame('foo', (string) $s2);
-        Psr7\Utils::copyToStream($s1, $s2, 3);
+        self::assertSame(3, Psr7\Utils::copyToStream($s1, $s2, 3));
         self::assertSame('foobaz', (string) $s2);
+    }
+
+    public function testCopyToStreamReturnsActualBytesWhenSourceShorterThanMaxLen(): void
+    {
+        $dest = Psr7\Utils::streamFor('');
+
+        self::assertSame(2, Psr7\Utils::copyToStream(Psr7\Utils::streamFor('ab'), $dest, 5));
+        self::assertSame('ab', (string) $dest);
+    }
+
+    public function testCopyToStreamWithZeroMaxLenCopiesNothing(): void
+    {
+        $dest = Psr7\Utils::streamFor('');
+
+        self::assertSame(0, Psr7\Utils::copyToStream(Psr7\Utils::streamFor('abc'), $dest, 0));
+        self::assertSame('', (string) $dest);
+    }
+
+    public function testCopyToStreamWithNegativeMaxLenOtherThanMinusOneCopiesNothing(): void
+    {
+        $dest = Psr7\Utils::streamFor('');
+
+        self::assertSame(0, Psr7\Utils::copyToStream(Psr7\Utils::streamFor('abc'), $dest, -2));
+        self::assertSame('', (string) $dest);
     }
 
     public function testCopyToStreamRetriesShortWrites(): void
@@ -180,7 +204,7 @@ class UtilsTest extends TestCase
             },
         ]);
 
-        Psr7\Utils::copyToStream($s1, $s2);
+        self::assertSame(6, Psr7\Utils::copyToStream($s1, $s2));
 
         self::assertSame('foobaz', (string) $sink);
         self::assertSame(6, $writes);
@@ -200,7 +224,7 @@ class UtilsTest extends TestCase
             },
         ]);
 
-        Psr7\Utils::copyToStream($s1, $s2, 3);
+        self::assertSame(3, Psr7\Utils::copyToStream($s1, $s2, 3));
 
         self::assertSame('foo', (string) $sink);
         self::assertSame(3, $writes);
@@ -315,7 +339,7 @@ class UtilsTest extends TestCase
         ]);
         $s2 = Psr7\Utils::streamFor('');
 
-        Psr7\Utils::copyToStream($s1, $s2, 3);
+        self::assertSame(3, Psr7\Utils::copyToStream($s1, $s2, 3));
 
         self::assertSame('foo', (string) $s2);
     }
@@ -399,7 +423,7 @@ class UtilsTest extends TestCase
             },
         ]);
         $s2 = Psr7\Utils::streamFor('');
-        Psr7\Utils::copyToStream($s1, $s2, 16394);
+        self::assertSame(16394, Psr7\Utils::copyToStream($s1, $s2, 16394));
         $s2->seek(0);
         self::assertSame(16394, strlen($s2->getContents()));
         self::assertSame(8192, $sizes[0]);
@@ -416,7 +440,7 @@ class UtilsTest extends TestCase
             },
         ]);
         $s2 = Psr7\Utils::streamFor('');
-        Psr7\Utils::copyToStream($s1, $s2, 10);
+        self::assertSame(0, Psr7\Utils::copyToStream($s1, $s2, 10));
         self::assertSame('', (string) $s2);
     }
 


### PR DESCRIPTION
Utils::copyToStream() already owns the timeout-aware read loop and the retrying write loop, so returning the successful byte count lets callers detect short copies without duplicating that logic. Existing callers can keep ignoring the result, and the docs describe the reflected signature change.