### PR TITLE
Guard stream integer arithmetic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reject empty arrays and non-string values as header values
 - Reject invalid uploaded file trees and invalid parsed body values
 - Reject uploaded file specs missing `tmp_name`, `size`, or `error`
+- Reject invalid stream/upload sizes, buffer high-water marks, and dropping-stream limits
 - Rewind seekable uploaded-file streams before copying in `UploadedFile::moveTo()`
 - Reject negative `read()` lengths across all stream implementations
 - Detect the `+` flag anywhere in a mode for `Stream::isReadable()`/`isWritable()`
@@ -49,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Throw `TimeoutException` from `Stream` read/write and `Utils` copy/hash/readLine on stream timeouts
 - Re-throw `TimeoutException` from `InflateStream` when the decoded source stream times out
 - Return the number of bytes copied from `Utils::copyToStream()`
+- Throw `OverflowException` when stream byte counts or offsets exceed `PHP_INT_MAX`
 - Translate `StreamWrapper` runtime failures to PHP stream failure values
 - Stop adding default `Content-Length` to `multipart/form-data` parts (RFC 7578 §4.8)
 - Escape multipart `Content-Disposition` parameters and reject unsafe boundaries and part headers

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -132,9 +132,13 @@ trees. Every leaf must be an `UploadedFileInterface` instance.
 
 `ServerRequest::normalizeFiles()` and `ServerRequest::fromGlobals()` now reject
 malformed `$_FILES` specifications earlier. Single-file specifications must
-contain non-null `tmp_name`, `size`, and `error` values. Nested specifications
-must provide `tmp_name`, `size`, and `error` as arrays with matching keys. When
-nested `name` or `type` metadata is provided, it must also be an array.
+contain non-null `tmp_name`, `size`, and `error` values. Single-file and nested
+file `size` values must be non-negative PHP integers; numeric strings are no
+longer cast. If PHP supplies an upload size as a string because the byte count
+cannot fit in `PHP_INT_MAX`, it is rejected rather than truncated or cast.
+Nested specifications must provide `tmp_name`, `size`, and `error` as arrays
+with matching keys. When nested `name` or `type` metadata is provided, it must
+also be an array.
 
 If your tests or adapters build `$_FILES` arrays manually, populate the full
 shape or create `UploadedFile` instances directly.
@@ -144,7 +148,7 @@ shape or create `UploadedFile` instances directly.
 $files = ['file' => ['tmp_name' => '/tmp/php123', 'error' => '0']];
 
 // 3.0
-$files = ['file' => ['tmp_name' => '/tmp/php123', 'size' => '123', 'error' => '0']];
+$files = ['file' => ['tmp_name' => '/tmp/php123', 'size' => 123, 'error' => UPLOAD_ERR_OK]];
 ```
 
 For stream-backed uploads, `UploadedFile::moveTo()` now rewinds seekable streams
@@ -369,6 +373,11 @@ streams. If a custom stream wrapper previously exposed `rw` for a writable
 resource, open it with a valid update mode such as `r+`, `w+`, or `a+` instead.
 
 #### Stream Copy Behavior
+
+Stream sizes, offsets, high-water marks, and byte counts are now validated as
+non-negative PHP integers where applicable. Operations that would overflow
+`PHP_INT_MAX` throw `OverflowException` instead of silently wrapping or producing
+an invalid position or size.
 
 `Utils::copyToStream()` now returns the number of bytes copied and throws a
 `RuntimeException` when the destination stream cannot make progress, for example

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -157,12 +157,6 @@ parameters:
 			path: src/ServerRequest.php
 
 		-
-			message: '#^Offset ''size'' on array\{0\: int, 1\: int, 2\: int, 3\: int, 4\: int, 5\: int, 6\: int, 7\: int, \.\.\.\} in isset\(\) always exists and is not nullable\.$#'
-			identifier: isset.offset
-			count: 1
-			path: src/Stream.php
-
-		-
 			message: '#^Property GuzzleHttp\\Psr7\\Stream\:\:\$stream \(resource\) in isset\(\) is not nullable\.$#'
 			identifier: isset.property
 			count: 10

--- a/src/AppendStream.php
+++ b/src/AppendStream.php
@@ -120,7 +120,7 @@ final class AppendStream implements StreamInterface
             if ($s === null) {
                 return null;
             }
-            $size += $s;
+            $size = Integers::add($size, $s);
         }
 
         return $size;
@@ -209,7 +209,7 @@ final class AppendStream implements StreamInterface
             $remaining = $length - strlen($buffer);
         }
 
-        $this->pos += strlen($buffer);
+        $this->pos = Integers::add($this->pos, strlen($buffer));
 
         return $buffer;
     }

--- a/src/BufferStream.php
+++ b/src/BufferStream.php
@@ -29,7 +29,7 @@ final class BufferStream implements StreamInterface
      */
     public function __construct(int $hwm = 16384)
     {
-        $this->hwm = $hwm;
+        $this->hwm = Integers::assertNonNegativeInteger($hwm, 'High water mark');
     }
 
     public function __toString(): string

--- a/src/CachingStream.php
+++ b/src/CachingStream.php
@@ -70,13 +70,13 @@ final class CachingStream implements StreamInterface
         if ($whence === SEEK_SET) {
             $byte = $offset;
         } elseif ($whence === SEEK_CUR) {
-            $byte = $offset + $this->tell();
+            $byte = Integers::addSigned($this->tell(), $offset);
         } elseif ($whence === SEEK_END) {
             $size = $this->remoteStream->getSize();
             if ($size === null) {
                 $size = $this->cacheEntireStream();
             }
-            $byte = $size + $offset;
+            $byte = Integers::addSigned($size, $offset);
         } else {
             throw new \InvalidArgumentException('Invalid whence');
         }
@@ -122,7 +122,7 @@ final class CachingStream implements StreamInterface
             // position. This mimics the behavior of other PHP stream wrappers.
             $remoteData = StreamTimeout::read(
                 $this->remoteStream,
-                $remaining + $this->skipReadBytes,
+                Integers::add($remaining, $this->skipReadBytes),
                 'Unable to read from stream: timed out'
             );
 
@@ -149,9 +149,9 @@ final class CachingStream implements StreamInterface
         // to skip bytes from being read from the remote stream to emulate
         // other stream wrappers. Basically replacing bytes of data of a fixed
         // length.
-        $overflow = (strlen($string) + $this->tell()) - $this->remoteStream->tell();
+        $overflow = Integers::add(strlen($string), $this->tell()) - $this->remoteStream->tell();
         if ($overflow > 0) {
-            $this->skipReadBytes += $overflow;
+            $this->skipReadBytes = Integers::add($this->skipReadBytes, $overflow);
         }
 
         return $this->stream->write($string);

--- a/src/DroppingStream.php
+++ b/src/DroppingStream.php
@@ -25,7 +25,7 @@ final class DroppingStream implements StreamInterface
     public function __construct(StreamInterface $stream, int $maxLength)
     {
         $this->stream = $stream;
-        $this->maxLength = $maxLength;
+        $this->maxLength = Integers::assertNonNegativeInteger($maxLength, 'Maximum length');
     }
 
     public function write(string $string): int

--- a/src/HttpFactory.php
+++ b/src/HttpFactory.php
@@ -36,7 +36,13 @@ final class HttpFactory implements RequestFactoryInterface, ResponseFactoryInter
             $size = $stream->getSize();
         }
 
-        return new UploadedFile($stream, $size, $error, $clientFilename, $clientMediaType);
+        return new UploadedFile(
+            $stream,
+            Integers::assertOptionalNonNegativeSize($size, 'Uploaded file size'),
+            $error,
+            $clientFilename,
+            $clientMediaType
+        );
     }
 
     public function createStream(string $content = ''): StreamInterface

--- a/src/Integers.php
+++ b/src/Integers.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GuzzleHttp\Psr7;
+
+/**
+ * @internal
+ */
+final class Integers
+{
+    private function __construct()
+    {
+    }
+
+    public static function add(int $a, int $b): int
+    {
+        if ($a < 0 || $b < 0) {
+            throw new \InvalidArgumentException('Integer operands must be non-negative');
+        }
+
+        if ($b > \PHP_INT_MAX - $a) {
+            throw new \OverflowException('Stream byte count exceeds the maximum integer size supported on this platform');
+        }
+
+        return $a + $b;
+    }
+
+    public static function addSigned(int $base, int $delta): int
+    {
+        if ($base < 0) {
+            throw new \InvalidArgumentException('Stream offset must be non-negative');
+        }
+
+        if ($delta > 0 && $delta > \PHP_INT_MAX - $base) {
+            throw new \OverflowException('Stream offset exceeds the maximum integer size supported on this platform');
+        }
+
+        $value = $base + $delta;
+        if ($value < 0) {
+            throw new \InvalidArgumentException('Stream offset must be non-negative');
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    public static function assertEngineInteger($value, string $what): ?int
+    {
+        if ($value === false || $value === null) {
+            return null;
+        }
+
+        if (!\is_int($value) || $value < 0) {
+            throw new \OverflowException($what.' exceeds the maximum integer size supported on this platform');
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    public static function assertOptionalNonNegativeSize($value, string $name): ?int
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (!\is_int($value) || $value < 0) {
+            throw new \InvalidArgumentException($name.' must be a non-negative integer or null');
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    public static function assertNonNegativeInteger($value, string $name): int
+    {
+        if (!\is_int($value) || $value < 0) {
+            throw new \InvalidArgumentException($name.' must be a non-negative integer');
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    public static function assertLimitInteger($value, string $name): int
+    {
+        if (!\is_int($value) || $value < -1) {
+            throw new \InvalidArgumentException($name.' must be -1 or a non-negative integer');
+        }
+
+        return $value;
+    }
+}

--- a/src/LimitStream.php
+++ b/src/LimitStream.php
@@ -50,7 +50,7 @@ final class LimitStream implements StreamInterface
             return false;
         }
 
-        return $this->stream->tell() >= $this->offset + $this->limit;
+        return $this->stream->tell() >= Integers::add($this->offset, $this->limit);
     }
 
     /**
@@ -84,11 +84,12 @@ final class LimitStream implements StreamInterface
             ));
         }
 
-        $offset += $this->offset;
+        $offset = Integers::add($this->offset, $offset);
 
         if ($this->limit !== -1) {
-            if ($offset > $this->offset + $this->limit) {
-                $offset = $this->offset + $this->limit;
+            $upperBound = Integers::add($this->offset, $this->limit);
+            if ($offset > $upperBound) {
+                $offset = $upperBound;
             }
         }
 
@@ -112,9 +113,7 @@ final class LimitStream implements StreamInterface
      */
     public function setOffset(int $offset): void
     {
-        if ($offset < 0) {
-            throw new \InvalidArgumentException('Offset must be a non-negative integer');
-        }
+        $offset = Integers::assertNonNegativeInteger($offset, 'Offset');
 
         $current = $this->stream->tell();
 
@@ -155,7 +154,7 @@ final class LimitStream implements StreamInterface
                 throw new \RuntimeException("Could not seek to stream offset $offset");
             }
 
-            $current += strlen($result);
+            $current = Integers::add($current, strlen($result));
         }
 
         $this->offset = $offset;
@@ -170,11 +169,7 @@ final class LimitStream implements StreamInterface
      */
     public function setLimit(int $limit): void
     {
-        if ($limit < -1) {
-            throw new \InvalidArgumentException('Limit must be -1 or a non-negative integer');
-        }
-
-        $this->limit = $limit;
+        $this->limit = Integers::assertLimitInteger($limit, 'Limit');
     }
 
     public function read(int $length): string
@@ -189,7 +184,7 @@ final class LimitStream implements StreamInterface
 
         // Check if the current position is less than the total allowed
         // bytes + original offset
-        $remaining = ($this->offset + $this->limit) - $this->stream->tell();
+        $remaining = Integers::add($this->offset, $this->limit) - $this->stream->tell();
         if ($remaining > 0) {
             // Only return the amount of requested data, ensuring that the byte
             // limit is not exceeded

--- a/src/PumpStream.php
+++ b/src/PumpStream.php
@@ -49,7 +49,7 @@ final class PumpStream implements StreamInterface
     public function __construct(callable $source, array $options = [])
     {
         $this->source = $source;
-        $this->size = $options['size'] ?? null;
+        $this->size = Integers::assertOptionalNonNegativeSize($options['size'] ?? null, 'Stream size');
         $this->metadata = $options['metadata'] ?? [];
         $this->buffer = new BufferStream();
     }
@@ -131,7 +131,7 @@ final class PumpStream implements StreamInterface
         }
 
         $data = $this->buffer->read($length);
-        $this->tellPos += strlen($data);
+        $this->tellPos = Integers::add($this->tellPos, strlen($data));
 
         return $data;
     }

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -109,7 +109,7 @@ class ServerRequest extends Request implements ServerRequestInterface
 
         return new UploadedFile(
             $value['tmp_name'],
-            (int) $value['size'],
+            Integers::assertNonNegativeInteger($value['size'], 'Uploaded file size'),
             (int) $value['error'],
             $value['name'] ?? null,
             $value['type'] ?? null

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -42,9 +42,7 @@ class Stream implements StreamInterface
             throw new \InvalidArgumentException('Stream must be a resource');
         }
 
-        if (isset($options['size'])) {
-            $this->size = $options['size'];
-        }
+        $this->size = Integers::assertOptionalNonNegativeSize($options['size'] ?? null, 'Stream size');
 
         $this->customMetadata = $options['metadata'] ?? [];
         $this->stream = $stream;
@@ -125,13 +123,13 @@ class Stream implements StreamInterface
         }
 
         $stats = fstat($this->stream);
-        if (is_array($stats) && isset($stats['size'])) {
-            $this->size = $stats['size'];
-
-            return $this->size;
+        if ($stats === false) {
+            return null;
         }
 
-        return null;
+        $this->size = Integers::assertEngineInteger($stats['size'], 'Stream size');
+
+        return $this->size;
     }
 
     public function isReadable(): bool
@@ -165,12 +163,16 @@ class Stream implements StreamInterface
         }
 
         $result = ftell($this->stream);
-
         if ($result === false) {
             throw new \RuntimeException('Unable to determine stream position');
         }
 
-        return $result;
+        $position = Integers::assertEngineInteger($result, 'Stream position');
+        if ($position === null) {
+            throw new \RuntimeException('Unable to determine stream position');
+        }
+
+        return $position;
     }
 
     public function rewind(): void

--- a/src/UploadedFile.php
+++ b/src/UploadedFile.php
@@ -47,7 +47,7 @@ class UploadedFile implements UploadedFileInterface
         ?string $clientMediaType = null
     ) {
         $this->setError($errorStatus);
-        $this->size = $size;
+        $this->size = Integers::assertOptionalNonNegativeSize($size, 'Uploaded file size');
         $this->clientFilename = $clientFilename;
         $this->clientMediaType = $clientMediaType;
 

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -65,7 +65,7 @@ final class Utils
                 }
 
                 self::writeAll($dest, $buf);
-                $copied += strlen($buf);
+                $copied = Integers::add($copied, strlen($buf));
             }
         } else {
             $remaining = $maxLen;
@@ -77,7 +77,7 @@ final class Utils
                 }
                 $remaining -= $len;
                 self::writeAll($dest, $buf);
-                $copied += $len;
+                $copied = Integers::add($copied, $len);
             }
         }
 

--- a/tests/AppendStreamTest.php
+++ b/tests/AppendStreamTest.php
@@ -324,6 +324,26 @@ class AppendStreamTest extends TestCase
         self::assertNull($a->getSize());
     }
 
+    public function testGetSizeThrowsWhenCombinedSizeOverflows(): void
+    {
+        $first = $this->createMock(StreamInterface::class);
+        $first->method('isReadable')->willReturn(true);
+        $first->method('isSeekable')->willReturn(true);
+        $first->method('getSize')->willReturn(\PHP_INT_MAX);
+
+        $second = $this->createMock(StreamInterface::class);
+        $second->method('isReadable')->willReturn(true);
+        $second->method('isSeekable')->willReturn(true);
+        $second->method('getSize')->willReturn(1);
+
+        $stream = new AppendStream([$first, $second]);
+
+        $this->expectException(\OverflowException::class);
+        $this->expectExceptionMessage('Stream byte count exceeds the maximum integer size supported on this platform');
+
+        $stream->getSize();
+    }
+
     public function testThrowsExceptionsWhenCastingToString(): void
     {
         $s = $this->createMock(StreamInterface::class);

--- a/tests/BufferStreamTest.php
+++ b/tests/BufferStreamTest.php
@@ -20,6 +20,14 @@ class BufferStreamTest extends TestCase
         self::assertSame([], $b->getMetadata());
     }
 
+    public function testRejectsNegativeHighWaterMark(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('High water mark must be a non-negative integer');
+
+        new BufferStream(-1);
+    }
+
     public function testRemovesReadDataFromBuffer(): void
     {
         $b = new BufferStream();

--- a/tests/DroppingStreamTest.php
+++ b/tests/DroppingStreamTest.php
@@ -10,6 +10,14 @@ use PHPUnit\Framework\TestCase;
 
 class DroppingStreamTest extends TestCase
 {
+    public function testRejectsNegativeMaximumLength(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Maximum length must be a non-negative integer');
+
+        new DroppingStream(new BufferStream(), -1);
+    }
+
     public function testBeginsDroppingWhenSizeExceeded(): void
     {
         $stream = new BufferStream();

--- a/tests/HttpFactoryTest.php
+++ b/tests/HttpFactoryTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GuzzleHttp\Tests\Psr7;
+
+use GuzzleHttp\Psr7\FnStream;
+use GuzzleHttp\Psr7\HttpFactory;
+use PHPUnit\Framework\TestCase;
+
+class HttpFactoryTest extends TestCase
+{
+    public function testCreateUploadedFileRejectsInvalidInferredSize(): void
+    {
+        $factory = new HttpFactory();
+        $stream = new FnStream([
+            'getSize' => static function (): int {
+                return -1;
+            },
+        ]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Uploaded file size must be a non-negative integer or null');
+
+        $factory->createUploadedFile($stream);
+    }
+}

--- a/tests/IntegersTest.php
+++ b/tests/IntegersTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GuzzleHttp\Tests\Psr7;
+
+use GuzzleHttp\Psr7\Integers;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \GuzzleHttp\Psr7\Integers
+ */
+class IntegersTest extends TestCase
+{
+    public function testAddAllowsMaximumIntegerResult(): void
+    {
+        self::assertSame(\PHP_INT_MAX, Integers::add(\PHP_INT_MAX - 1, 1));
+    }
+
+    public function testAddRejectsOverflow(): void
+    {
+        $this->expectException(\OverflowException::class);
+        $this->expectExceptionMessage('Stream byte count exceeds the maximum integer size supported on this platform');
+
+        Integers::add(\PHP_INT_MAX, 1);
+    }
+
+    public function testAddRejectsNegativeOperands(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Integer operands must be non-negative');
+
+        Integers::add(-1, 0);
+    }
+
+    public function testAddSignedAllowsNegativeDeltaWithinBounds(): void
+    {
+        self::assertSame(3, Integers::addSigned(5, -2));
+    }
+
+    public function testAddSignedRejectsNegativeBase(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Stream offset must be non-negative');
+
+        Integers::addSigned(-1, 1);
+    }
+
+    public function testAddSignedRejectsPositiveOverflow(): void
+    {
+        $this->expectException(\OverflowException::class);
+        $this->expectExceptionMessage('Stream offset exceeds the maximum integer size supported on this platform');
+
+        Integers::addSigned(\PHP_INT_MAX, 1);
+    }
+
+    public function testAddSignedRejectsNegativeResult(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Stream offset must be non-negative');
+
+        Integers::addSigned(0, -1);
+    }
+
+    public function testAssertEngineIntegerAcceptsUnavailableValues(): void
+    {
+        self::assertNull(Integers::assertEngineInteger(false, 'Stream size'));
+        self::assertNull(Integers::assertEngineInteger(null, 'Stream size'));
+    }
+
+    public function testAssertEngineIntegerAcceptsNonNegativeInteger(): void
+    {
+        self::assertSame(10, Integers::assertEngineInteger(10, 'Stream size'));
+    }
+
+    /**
+     * @dataProvider invalidEngineIntegers
+     *
+     * @param mixed $value
+     */
+    public function testAssertEngineIntegerRejectsInvalidValues($value): void
+    {
+        $this->expectException(\OverflowException::class);
+        $this->expectExceptionMessage('Stream size exceeds the maximum integer size supported on this platform');
+
+        Integers::assertEngineInteger($value, 'Stream size');
+    }
+
+    public static function invalidEngineIntegers(): iterable
+    {
+        yield 'negative integer' => [-1];
+        yield 'string integer' => ['1'];
+        yield 'float' => [1.0];
+    }
+
+    public function testAssertOptionalNonNegativeSizeAcceptsNullAndIntegers(): void
+    {
+        self::assertNull(Integers::assertOptionalNonNegativeSize(null, 'Stream size'));
+        self::assertSame(0, Integers::assertOptionalNonNegativeSize(0, 'Stream size'));
+        self::assertSame(10, Integers::assertOptionalNonNegativeSize(10, 'Stream size'));
+    }
+
+    /**
+     * @dataProvider invalidNonNegativeIntegers
+     *
+     * @param mixed $value
+     */
+    public function testAssertOptionalNonNegativeSizeRejectsInvalidValues($value): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Stream size must be a non-negative integer or null');
+
+        Integers::assertOptionalNonNegativeSize($value, 'Stream size');
+    }
+
+    /**
+     * @dataProvider invalidNonNegativeIntegers
+     *
+     * @param mixed $value
+     */
+    public function testAssertNonNegativeIntegerRejectsInvalidValues($value): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('High water mark must be a non-negative integer');
+
+        Integers::assertNonNegativeInteger($value, 'High water mark');
+    }
+
+    public static function invalidNonNegativeIntegers(): iterable
+    {
+        yield 'negative integer' => [-1];
+        yield 'string integer' => ['1'];
+        yield 'float' => [1.0];
+        yield 'false' => [false];
+    }
+
+    public function testAssertLimitIntegerAcceptsMinusOneAndNonNegativeIntegers(): void
+    {
+        self::assertSame(-1, Integers::assertLimitInteger(-1, 'Limit'));
+        self::assertSame(0, Integers::assertLimitInteger(0, 'Limit'));
+        self::assertSame(10, Integers::assertLimitInteger(10, 'Limit'));
+    }
+
+    /**
+     * @dataProvider invalidLimits
+     *
+     * @param mixed $value
+     */
+    public function testAssertLimitIntegerRejectsInvalidValues($value): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Limit must be -1 or a non-negative integer');
+
+        Integers::assertLimitInteger($value, 'Limit');
+    }
+
+    public static function invalidLimits(): iterable
+    {
+        yield 'below minus one' => [-2];
+        yield 'string integer' => ['1'];
+        yield 'float' => [1.0];
+    }
+}

--- a/tests/LimitStreamTest.php
+++ b/tests/LimitStreamTest.php
@@ -239,6 +239,30 @@ class LimitStreamTest extends TestCase
         $this->body->read(-1);
     }
 
+    public function testReadThrowsWhenOffsetAndLimitOverflow(): void
+    {
+        $stream = new FnStream([
+            'tell' => static function (): int {
+                return 0;
+            },
+            'isSeekable' => static function (): bool {
+                return true;
+            },
+            'seek' => static function (int $offset, int $whence = SEEK_SET): void {
+            },
+            'eof' => static function (): bool {
+                return false;
+            },
+        ]);
+
+        $limited = new LimitStream($stream, 1, \PHP_INT_MAX);
+
+        $this->expectException(\OverflowException::class);
+        $this->expectExceptionMessage('Stream byte count exceeds the maximum integer size supported on this platform');
+
+        $limited->read(1);
+    }
+
     public function testClaimsConsumedWhenReadLimitIsReached(): void
     {
         self::assertFalse($this->body->eof());

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -784,6 +784,27 @@ class MessageTest extends TestCase
         Psr7\Message::bodySummary($message);
     }
 
+    public function testMessageBodySummaryPropagatesOverflow(): void
+    {
+        $body = new FnStream([
+            'isSeekable' => static function (): bool {
+                return true;
+            },
+            'isReadable' => static function (): bool {
+                return true;
+            },
+            'getSize' => static function (): int {
+                throw new \OverflowException('size overflow');
+            },
+        ]);
+        $message = new Psr7\Response(200, [], $body);
+
+        $this->expectException(\OverflowException::class);
+        $this->expectExceptionMessage('size overflow');
+
+        Psr7\Message::bodySummary($message);
+    }
+
     public function testGetResponseBodySummaryOfNonReadableStream(): void
     {
         $message = new Psr7\Response(500, [], new ReadSeekOnlyStream());

--- a/tests/PumpStreamTest.php
+++ b/tests/PumpStreamTest.php
@@ -39,6 +39,26 @@ class PumpStreamTest extends TestCase
         self::assertSame(100, $p->getSize());
     }
 
+    /**
+     * @dataProvider invalidSizes
+     *
+     * @param mixed $size
+     */
+    public function testRejectsInvalidSizeOption($size): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Stream size must be a non-negative integer or null');
+
+        new PumpStream(static function (): void {
+        }, ['size' => $size]);
+    }
+
+    public static function invalidSizes(): iterable
+    {
+        yield 'negative integer' => [-1];
+        yield 'string integer' => ['100'];
+    }
+
     public function testCanReadFromCallable(): void
     {
         $p = Psr7\Utils::streamFor(function ($size) {

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -23,8 +23,8 @@ class ServerRequestTest extends TestCase
                         'name' => 'MyFile.txt',
                         'type' => 'text/plain',
                         'tmp_name' => '/tmp/php/php1h4j1o',
-                        'error' => '0',
-                        'size' => '123',
+                        'error' => UPLOAD_ERR_OK,
+                        'size' => 123,
                     ],
                 ],
                 [
@@ -41,8 +41,8 @@ class ServerRequestTest extends TestCase
                 [
                     'file' => [
                         'tmp_name' => '/tmp/php/php1h4j1o',
-                        'error' => '0',
-                        'size' => '123',
+                        'error' => UPLOAD_ERR_OK,
+                        'size' => 123,
                     ],
                 ],
                 [
@@ -59,8 +59,8 @@ class ServerRequestTest extends TestCase
                         'name' => '',
                         'type' => '',
                         'tmp_name' => '',
-                        'error' => '4',
-                        'size' => '0',
+                        'error' => UPLOAD_ERR_NO_FILE,
+                        'size' => 0,
                     ],
                 ],
                 [
@@ -137,15 +137,15 @@ class ServerRequestTest extends TestCase
                         'name' => 'MyFile.txt',
                         'type' => 'text/plain',
                         'tmp_name' => '/tmp/php/php1h4j1o',
-                        'error' => '0',
-                        'size' => '123',
+                        'error' => UPLOAD_ERR_OK,
+                        'size' => 123,
                     ],
                     'image_file' => [
                         'name' => '',
                         'type' => '',
                         'tmp_name' => '',
-                        'error' => '4',
-                        'size' => '0',
+                        'error' => UPLOAD_ERR_NO_FILE,
+                        'size' => 0,
                     ],
                 ],
                 [
@@ -181,12 +181,12 @@ class ServerRequestTest extends TestCase
                             1 => '/tmp/php/php1h4j1o',
                         ],
                         'error' => [
-                            0 => '0',
-                            1 => '0',
+                            0 => UPLOAD_ERR_OK,
+                            1 => UPLOAD_ERR_OK,
                         ],
                         'size' => [
-                            0 => '123',
-                            1 => '7349',
+                            0 => 123,
+                            1 => 7349,
                         ],
                     ],
                     'nested' => [
@@ -212,17 +212,17 @@ class ServerRequestTest extends TestCase
                             ],
                         ],
                         'error' => [
-                            'other' => '0',
+                            'other' => UPLOAD_ERR_OK,
                             'test' => [
-                                0 => '0',
-                                1 => '4',
+                                0 => UPLOAD_ERR_OK,
+                                1 => UPLOAD_ERR_NO_FILE,
                             ],
                         ],
                         'size' => [
-                            'other' => '421',
+                            'other' => 421,
                             'test' => [
-                                0 => '32',
-                                1 => '0',
+                                0 => 32,
+                                1 => 0,
                             ],
                         ],
                     ],
@@ -278,10 +278,10 @@ class ServerRequestTest extends TestCase
                             0 => '/tmp/php/hp9hskjhf',
                         ],
                         'error' => [
-                            0 => '0',
+                            0 => UPLOAD_ERR_OK,
                         ],
                         'size' => [
-                            0 => '123',
+                            0 => 123,
                         ],
                     ],
                 ],
@@ -327,32 +327,47 @@ class ServerRequestTest extends TestCase
         ];
 
         yield 'single file missing size' => [
-            ['file' => ['tmp_name' => '/tmp/php123', 'error' => '0']],
+            ['file' => ['tmp_name' => '/tmp/php123', 'error' => UPLOAD_ERR_OK]],
             'Invalid file specification',
         ];
 
         yield 'single file missing error' => [
-            ['file' => ['tmp_name' => '/tmp/php123', 'size' => '123']],
+            ['file' => ['tmp_name' => '/tmp/php123', 'size' => 123]],
             'Invalid file specification',
         ];
 
+        yield 'single file string size' => [
+            ['file' => ['tmp_name' => '/tmp/php123', 'size' => '123', 'error' => UPLOAD_ERR_OK]],
+            'Uploaded file size must be a non-negative integer',
+        ];
+
+        yield 'single file negative size' => [
+            ['file' => ['tmp_name' => '/tmp/php123', 'size' => -1, 'error' => UPLOAD_ERR_OK]],
+            'Uploaded file size must be a non-negative integer',
+        ];
+
         yield 'nested file missing size array' => [
-            ['file' => ['tmp_name' => [0 => '/tmp/php123'], 'error' => [0 => '0']]],
+            ['file' => ['tmp_name' => [0 => '/tmp/php123'], 'error' => [0 => UPLOAD_ERR_OK]]],
             'Invalid file specification',
         ];
 
         yield 'nested file missing error array' => [
-            ['file' => ['tmp_name' => [0 => '/tmp/php123'], 'size' => [0 => '123']]],
+            ['file' => ['tmp_name' => [0 => '/tmp/php123'], 'size' => [0 => 123]]],
             'Invalid file specification',
         ];
 
+        yield 'nested file string size' => [
+            ['file' => ['tmp_name' => [0 => '/tmp/php123'], 'size' => [0 => '123'], 'error' => [0 => UPLOAD_ERR_OK]]],
+            'Uploaded file size must be a non-negative integer',
+        ];
+
         yield 'nested file scalar size' => [
-            ['file' => ['tmp_name' => [0 => '/tmp/php123'], 'size' => '123', 'error' => [0 => '0']]],
+            ['file' => ['tmp_name' => [0 => '/tmp/php123'], 'size' => 123, 'error' => [0 => UPLOAD_ERR_OK]]],
             'Invalid nested file specification',
         ];
 
         yield 'nested file scalar error' => [
-            ['file' => ['tmp_name' => [0 => '/tmp/php123'], 'size' => [0 => '123'], 'error' => '0']],
+            ['file' => ['tmp_name' => [0 => '/tmp/php123'], 'size' => [0 => 123], 'error' => UPLOAD_ERR_OK]],
             'Invalid nested file specification',
         ];
 
@@ -360,8 +375,8 @@ class ServerRequestTest extends TestCase
             [
                 'file' => [
                     'tmp_name' => [0 => '/tmp/a', 1 => '/tmp/b'],
-                    'size' => [0 => '123'],
-                    'error' => [0 => '0', 1 => '0'],
+                    'size' => [0 => 123],
+                    'error' => [0 => UPLOAD_ERR_OK, 1 => UPLOAD_ERR_OK],
                 ],
             ],
             'matching keys',
@@ -371,8 +386,8 @@ class ServerRequestTest extends TestCase
             [
                 'file' => [
                     'tmp_name' => [0 => '/tmp/a', 1 => '/tmp/b'],
-                    'size' => [0 => '123', 1 => '456'],
-                    'error' => [0 => '0'],
+                    'size' => [0 => 123, 1 => 456],
+                    'error' => [0 => UPLOAD_ERR_OK],
                 ],
             ],
             'matching keys',
@@ -382,8 +397,8 @@ class ServerRequestTest extends TestCase
             [
                 'file' => [
                     'tmp_name' => [0 => '/tmp/a'],
-                    'size' => [0 => '123'],
-                    'error' => [0 => '0'],
+                    'size' => [0 => 123],
+                    'error' => [0 => UPLOAD_ERR_OK],
                     'name' => 'a.txt',
                 ],
             ],

--- a/tests/UploadedFileTest.php
+++ b/tests/UploadedFileTest.php
@@ -75,6 +75,14 @@ class UploadedFileTest extends TestCase
         self::assertSame($stream, $uploadStream);
     }
 
+    public function testRejectsNegativeSize(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Uploaded file size must be a non-negative integer or null');
+
+        new UploadedFile('not ok', -1, UPLOAD_ERR_NO_FILE);
+    }
+
     public function testGetStreamReturnsStreamForFile(): void
     {
         $this->cleanup[] = $stream = tempnam(sys_get_temp_dir(), 'stream_file');

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -782,6 +782,26 @@ class UtilsTest extends TestCase
         self::assertSame(10, $s->getSize());
     }
 
+    /**
+     * @dataProvider invalidStreamSizes
+     *
+     * @param mixed $size
+     */
+    public function testStreamForRejectsInvalidSizeOption($size): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Stream size must be a non-negative integer or null');
+
+        Psr7\Utils::streamFor('', ['size' => $size]);
+    }
+
+    public static function invalidStreamSizes(): iterable
+    {
+        yield 'negative integer' => [-1];
+        yield 'string integer' => ['10'];
+        yield 'float' => [10.0];
+    }
+
     public function testCanCreateIteratorBasedStream(): void
     {
         $a = new \ArrayIterator(['foo', 'bar', '123']);


### PR DESCRIPTION
This adds an internal integer guard for stream byte counts, sizes, and offsets, then uses it where stream decorators and upload helpers perform arithmetic or accept configured sizes. Operations that would exceed PHP's maximum integer now fail explicitly instead of wrapping or producing invalid positions, and negative or non-integer size-like values are rejected consistently. It also keeps message body summaries from hiding overflow failures, updates the 3.0 upgrade notes and changelog to describe the stricter behavior, and adds focused coverage for the helper and the public stream and upload paths that exercise it.