### PR TITLE
Allow null body summary truncation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reject empty strings returned by `PumpStream` source callables
 - Discard buffered bytes on `PumpStream` close and detach
 - Restore the original stream position after `Message::bodySummary()`
+- Allow `null` for the `Message::bodySummary()` truncation length to use the default
 - Validate `LimitStream` offset/limit and track non-seekable offset by bytes skipped
 - Make `FnStream` close and detach terminal, calling close callbacks at most once
 - Suppress exceptions from `FnStream` close callbacks during destructor cleanup

--- a/README.md
+++ b/README.md
@@ -365,14 +365,15 @@ echo GuzzleHttp\Psr7\Message::toString($request);
 
 ## `GuzzleHttp\Psr7\Message::bodySummary`
 
-`public static function bodySummary(MessageInterface $message, int $truncateAt = 120): string|null`
+`public static function bodySummary(MessageInterface $message, ?int $truncateAt = null): string|null`
 
 Get a short summary of the message body.
 
 Will return `null` if the response is not printable.
 
 Reads seekable bodies from the beginning and restores the original cursor
-position before returning.
+position before returning. Pass `null` for `$truncateAt` to use the default
+summary length.
 
 
 ## `GuzzleHttp\Psr7\Message::rewindBody`

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -396,7 +396,9 @@ reported as generic write failures or no-progress writes.
 `Message::bodySummary()` still summarizes seekable bodies from the beginning,
 even when the body was already partially read. It now restores the body cursor to
 the position it had before the summary was created. In 2.x, calling
-`bodySummary()` left seekable bodies rewound to the beginning.
+`bodySummary()` left seekable bodies rewound to the beginning. The optional
+`$truncateAt` argument now accepts `null` as an explicit request for the default
+summary length, matching the behavior of omitting the argument.
 
 Most applications do not need to change anything. Check your code only if you
 called `bodySummary()` and then read the same body while relying on

--- a/src/Message.php
+++ b/src/Message.php
@@ -11,6 +11,8 @@ use Psr\Http\Message\UriInterface;
 
 final class Message
 {
+    private const DEFAULT_BODY_SUMMARY_TRUNCATE_AT = 120;
+
     private function __construct()
     {
     }
@@ -71,10 +73,12 @@ final class Message
      * Will return `null` if the response is not printable.
      *
      * @param MessageInterface $message    The message to get the body summary
-     * @param int              $truncateAt The maximum allowed size of the summary
+     * @param int|null         $truncateAt The maximum allowed size of the summary
      */
-    public static function bodySummary(MessageInterface $message, int $truncateAt = 120): ?string
+    public static function bodySummary(MessageInterface $message, ?int $truncateAt = null): ?string
     {
+        $truncateAt ??= self::DEFAULT_BODY_SUMMARY_TRUNCATE_AT;
+
         $body = $message->getBody();
 
         if (!$body->isSeekable() || !$body->isReadable()) {

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -660,6 +660,16 @@ class MessageTest extends TestCase
         self::assertSame('Lorem ipsu (truncated...)', Psr7\Message::bodySummary($message, 10));
     }
 
+    public function testMessageBodySummaryAcceptsNullTruncationLength(): void
+    {
+        $message = new Psr7\Response(200, [], str_repeat('a', 121));
+
+        self::assertSame(
+            Psr7\Message::bodySummary($message, 120),
+            Psr7\Message::bodySummary($message, null)
+        );
+    }
+
     public function testMessageBodySummaryWithSpecialUTF8Characters(): void
     {
         $message = new Psr7\Response(200, [], '’é€௵ဪ‱');


### PR DESCRIPTION
This lets callers pass null as the Message::bodySummary truncation length when they want the default summary length. That makes forwarding optional truncation values less awkward because callers no longer need to know the default or omit the argument conditionally.