### PR TITLE
Validate uploaded file error values

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -133,12 +133,12 @@ trees. Every leaf must be an `UploadedFileInterface` instance.
 `ServerRequest::normalizeFiles()` and `ServerRequest::fromGlobals()` now reject
 malformed `$_FILES` specifications earlier. Single-file specifications must
 contain non-null `tmp_name`, `size`, and `error` values. Single-file and nested
-file `size` values must be non-negative PHP integers; numeric strings are no
-longer cast. If PHP supplies an upload size as a string because the byte count
-cannot fit in `PHP_INT_MAX`, it is rejected rather than truncated or cast.
-Nested specifications must provide `tmp_name`, `size`, and `error` as arrays
-with matching keys. When nested `name` or `type` metadata is provided, it must
-also be an array.
+file `size` values and `error` values must be non-negative PHP integers;
+numeric strings are no longer cast. If PHP supplies an upload size as a string
+because the byte count cannot fit in `PHP_INT_MAX`, it is rejected rather than
+truncated or cast. Nested specifications must provide `tmp_name`, `size`, and
+`error` as arrays with matching keys. When nested `name` or `type` metadata is
+provided, it must also be an array.
 
 If your tests or adapters build `$_FILES` arrays manually, populate the full
 shape or create `UploadedFile` instances directly.

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -110,7 +110,7 @@ class ServerRequest extends Request implements ServerRequestInterface
         return new UploadedFile(
             $value['tmp_name'],
             Integers::assertNonNegativeInteger($value['size'], 'Uploaded file size'),
-            (int) $value['error'],
+            Integers::assertNonNegativeInteger($value['error'], 'Uploaded file error'),
             $value['name'] ?? null,
             $value['type'] ?? null
         );

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -336,6 +336,16 @@ class ServerRequestTest extends TestCase
             'Invalid file specification',
         ];
 
+        yield 'single file string error' => [
+            ['file' => ['tmp_name' => '/tmp/php123', 'size' => 123, 'error' => '0']],
+            'Uploaded file error must be a non-negative integer',
+        ];
+
+        yield 'single file float error' => [
+            ['file' => ['tmp_name' => '/tmp/php123', 'size' => 123, 'error' => (float) \PHP_INT_MAX]],
+            'Uploaded file error must be a non-negative integer',
+        ];
+
         yield 'single file string size' => [
             ['file' => ['tmp_name' => '/tmp/php123', 'size' => '123', 'error' => UPLOAD_ERR_OK]],
             'Uploaded file size must be a non-negative integer',


### PR DESCRIPTION
This validates uploaded file error values before constructing uploaded files from $_FILES-style specifications. It avoids casting manually supplied numeric strings or out-of-range floats and keeps upload normalization aligned with the stricter size validation in 3.0.