### PR TITLE
Validate URI parts ports before casting

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -194,6 +194,9 @@ Normal URI strings with ports are still supported:
 $uri = new Uri('https://example.com:8080/path');
 ```
 
+`Uri::fromParts()` accepts integer and decimal digit string ports, but floats and
+other port values are no longer cast.
+
 Common host forms such as `localhost`, single-label hosts, underscores, Unicode
 hosts, valid IPv6 literals, and normal host and port URI strings remain
 supported.

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -594,7 +594,7 @@ class Uri implements UriInterface, \JsonSerializable
             ? $this->filterHost($parts['host'])
             : '';
         $this->port = isset($parts['port'])
-            ? $this->filterPort((int) $parts['port'])
+            ? $this->filterPortPart($parts['port'])
             : null;
         $this->path = isset($parts['path'])
             ? $this->filterPath($parts['path'])
@@ -665,6 +665,75 @@ class Uri implements UriInterface, \JsonSerializable
         }
 
         return $port;
+    }
+
+    /**
+     * @param mixed $port
+     *
+     * @throws \InvalidArgumentException If the port is invalid.
+     */
+    private function filterPortPart($port): ?int
+    {
+        if (\is_int($port)) {
+            return $this->filterPort($port);
+        }
+
+        if (!\is_string($port) || $port === '' || !\ctype_digit($port)) {
+            throw new \InvalidArgumentException(sprintf(
+                'Invalid port: %s. Must be between 0 and 65535',
+                self::describeInvalidPort($port)
+            ));
+        }
+
+        $normalized = \ltrim($port, '0');
+        if ($normalized === '') {
+            return 0;
+        }
+
+        if (\strlen($normalized) > 5 || (int) $normalized > 0xFFFF) {
+            throw new \InvalidArgumentException(sprintf(
+                'Invalid port: %s. Must be between 0 and 65535',
+                $normalized
+            ));
+        }
+
+        return (int) $normalized;
+    }
+
+    /**
+     * @param mixed $port
+     */
+    private static function describeInvalidPort($port): string
+    {
+        if (\is_string($port)) {
+            return $port;
+        }
+
+        if (\is_int($port)) {
+            return (string) $port;
+        }
+
+        if (\is_bool($port)) {
+            return $port ? 'true' : 'false';
+        }
+
+        if ($port === null) {
+            return 'null';
+        }
+
+        if (\is_float($port)) {
+            if (\is_nan($port)) {
+                return 'NAN';
+            }
+
+            if (\is_infinite($port)) {
+                return $port > 0 ? 'INF' : '-INF';
+            }
+
+            return \sprintf('%.14G', $port);
+        }
+
+        return \get_debug_type($port);
     }
 
     /**

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -267,6 +267,48 @@ class UriTest extends TestCase
         (new Uri())->withPort(-1);
     }
 
+    public function testFromPartsAcceptsDecimalDigitStringPort(): void
+    {
+        $uri = Uri::fromParts([
+            'scheme' => 'http',
+            'host' => 'example.com',
+            'port' => '8080',
+        ]);
+
+        self::assertSame(8080, $uri->getPort());
+    }
+
+    /**
+     * @dataProvider invalidFromPartsPorts
+     *
+     * @param mixed $port
+     */
+    public function testFromPartsRejectsInvalidPortBeforeCasting($port): void
+    {
+        $this->expectException(MalformedUriException::class);
+        $this->expectExceptionMessage('Invalid port');
+
+        Uri::fromParts([
+            'scheme' => 'http',
+            'host' => 'example.com',
+            'port' => $port,
+        ]);
+    }
+
+    public static function invalidFromPartsPorts(): iterable
+    {
+        yield 'string with trailing text' => ['8080abc'];
+        yield 'decimal float' => [1.9];
+        yield 'true' => [true];
+        yield 'false' => [false];
+        yield 'empty string' => [''];
+        yield 'infinity' => [\INF];
+        yield 'negative infinity' => [-\INF];
+        yield 'not a number' => [\NAN];
+        yield 'int max float boundary' => [(float) \PHP_INT_MAX];
+        yield 'huge finite float' => [1.0e100];
+    }
+
     public function testParseUriPortCannotBeNegative(): void
     {
         $this->expectException(\InvalidArgumentException::class);


### PR DESCRIPTION
This validates ports passed to Uri::fromParts before converting them to integers. It keeps integer and numeric string ports supported while rejecting floats and other values before PHP can perform an unsafe out-of-range cast.