### PR TITLE
Reject malformed URI string ports

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -195,7 +195,8 @@ $uri = new Uri('https://example.com:8080/path');
 ```
 
 `Uri::fromParts()` accepts integer and decimal digit string ports, but floats and
-other port values are no longer cast.
+other port values are no longer cast. URI strings now reject malformed authority
+ports before native parsing can truncate or reinterpret them.
 
 Common host forms such as `localhost`, single-label hosts, underscores, Unicode
 hosts, valid IPv6 literals, and normal host and port URI strings remain

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -99,6 +99,10 @@ class Uri implements UriInterface, \JsonSerializable
             return self::parsePathNoSchemeReference($url);
         }
 
+        if (self::hasMalformedPort($url)) {
+            return false;
+        }
+
         // Preserve bracketed IPv6 literals before encoding, including dotted IPv4 tails.
         $prefix = '';
         if (preg_match('%^([0-9A-Za-z+.-]+://\[[0-9:.a-fA-F]+\])(.*?)$%', $url, $matches)) {
@@ -127,6 +131,74 @@ class Uri implements UriInterface, \JsonSerializable
         }
 
         return array_map('urldecode', $result);
+    }
+
+    private static function hasMalformedPort(string $url): bool
+    {
+        $authority = null;
+
+        if (preg_match('%^[A-Za-z][A-Za-z0-9+.-]*://([^/?#]*)%', $url, $matches)) {
+            $authority = $matches[1];
+        } elseif (0 === strpos($url, '//')) {
+            $authority = substr($url, 2, strcspn($url, '/?#', 2));
+            if ($authority === false) {
+                return false;
+            }
+        }
+
+        if ($authority === null || $authority === '') {
+            return false;
+        }
+
+        $lastAt = strrpos($authority, '@');
+        if ($lastAt !== false) {
+            $authority = substr($authority, $lastAt + 1);
+            if ($authority === false) {
+                return false;
+            }
+        }
+
+        if ($authority === '') {
+            return false;
+        }
+
+        if ($authority[0] === '[') {
+            $closingBracket = strpos($authority, ']');
+            if ($closingBracket === false) {
+                return false;
+            }
+
+            $remainder = substr($authority, $closingBracket + 1);
+            if ($remainder === '') {
+                return false;
+            }
+
+            if ($remainder[0] !== ':') {
+                return false;
+            }
+
+            $port = substr($remainder, 1);
+        } else {
+            $colon = strrpos($authority, ':');
+            if ($colon === false) {
+                return false;
+            }
+
+            $port = substr($authority, $colon + 1);
+        }
+
+        if ($port === '') {
+            return false;
+        }
+
+        if (!ctype_digit($port)) {
+            return true;
+        }
+
+        $normalized = ltrim($port, '0');
+
+        return $normalized !== ''
+            && (strlen($normalized) > 5 || (int) $normalized > 0xFFFF);
     }
 
     private static function isPathNoSchemeReference(string $url): bool

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -681,6 +681,15 @@ class ServerRequestTest extends TestCase
             'x=1',
         ];
 
+        yield 'absolute-form ipv6 empty port target supplies authority before malformed SERVER_PORT' => [
+            ['REQUEST_URI' => 'http://[::1]:/admin', 'HTTP_HOST' => 'good.example', 'SERVER_PORT' => '+443'],
+            'http://[::1]/admin',
+            '[::1]',
+            null,
+            '/admin',
+            '',
+        ];
+
         yield 'absolute-form userinfo target is normalized before malformed SERVER_PORT' => [
             ['REQUEST_URI' => 'http://trusted.example@evil.example/admin', 'HTTP_HOST' => 'trusted.example', 'SERVER_PORT' => '+443'],
             'http://evil.example/admin',
@@ -968,6 +977,12 @@ class ServerRequestTest extends TestCase
             ['REQUEST_METHOD' => 'GET', 'REQUEST_URI' => 'http://[::1]:8080/admin?x=1', 'HTTP_HOST' => 'good.example', 'SERVER_PORT' => '+443'],
             'http://[::1]:8080/admin?x=1',
             'http://[::1]:8080/admin?x=1',
+        ];
+
+        yield 'absolute-form ipv6 empty port target is normalized before malformed SERVER_PORT' => [
+            ['REQUEST_METHOD' => 'GET', 'REQUEST_URI' => 'http://[::1]:/admin', 'HTTP_HOST' => 'good.example', 'SERVER_PORT' => '+443'],
+            'http://[::1]/admin',
+            'http://[::1]/admin',
         ];
 
         yield 'absolute-form userinfo target is stripped from request target before malformed SERVER_PORT' => [

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -309,6 +309,69 @@ class UriTest extends TestCase
         yield 'huge finite float' => [1.0e100];
     }
 
+    /**
+     * @dataProvider malformedParsedPorts
+     */
+    public function testParseUriRejectsMalformedPortsBeforeParseUrlCanTruncate(string $uri): void
+    {
+        $this->expectException(MalformedUriException::class);
+        $this->expectExceptionMessage('Unable to parse URI');
+
+        new Uri($uri);
+    }
+
+    public static function malformedParsedPorts(): iterable
+    {
+        yield 'decimal network-path port' => ['//example.com:1.9'];
+        yield 'exponent network-path port' => ['//example.com:1e2'];
+        yield 'trailing alpha network-path port' => ['//example.com:8080abc'];
+        yield 'leading plus network-path port' => ['//example.com:+8080'];
+        yield 'negative network-path port' => ['//example.com:-1'];
+        yield 'whitespace network-path port' => ["//example.com:80\t"];
+        yield 'absolute URI decimal port' => ['http://example.com:1.9/path'];
+        yield 'absolute URI exponent port' => ['http://example.com:1e2/path'];
+        yield 'IPv6 decimal port' => ['//[::1]:1.9'];
+        yield 'IPv6 exponent port' => ['//[::1]:1e2'];
+        yield 'IPv4-tail IPv6 decimal port' => ['//[::ffff:192.0.2.128]:1.9'];
+    }
+
+    /**
+     * @dataProvider emptyParsedPorts
+     */
+    public function testParseUriAcceptsEmptyPorts(string $uri, string $expected): void
+    {
+        $parsed = new Uri($uri);
+
+        self::assertNull($parsed->getPort());
+        self::assertSame($expected, (string) $parsed);
+    }
+
+    public static function emptyParsedPorts(): iterable
+    {
+        yield 'network-path empty port' => ['//example.com:', '//example.com'];
+        yield 'absolute URI empty port' => ['http://example.com:/path', 'http://example.com/path'];
+        yield 'IPv6 empty port' => ['http://[::1]:/path', 'http://[::1]/path'];
+        yield 'userinfo empty port' => ['http://user@example.com:/path', 'http://user@example.com/path'];
+        yield 'query empty port' => ['http://example.com:?x=1', 'http://example.com?x=1'];
+    }
+
+    /**
+     * @dataProvider validParsedPorts
+     */
+    public function testParseUriAcceptsValidPorts(string $uri, int $port): void
+    {
+        self::assertSame($port, (new Uri($uri))->getPort());
+    }
+
+    public static function validParsedPorts(): iterable
+    {
+        yield 'zero' => ['//example.com:0', 0];
+        yield 'zero padded zero' => ['//example.com:0000', 0];
+        yield 'max' => ['//example.com:65535', 65535];
+        yield 'leading zero non-zero' => ['//example.com:08080', 8080];
+        yield 'IPv6 max' => ['//[::1]:65535', 65535];
+    }
+
     public function testParseUriPortCannotBeNegative(): void
     {
         $this->expectException(\InvalidArgumentException::class);


### PR DESCRIPTION
This rejects malformed non-empty authority ports in URI strings before calling parse_url(). Native parsing can otherwise truncate values such as //example.com:1.9 or //example.com:1e2 before Uri validation sees them. The change preserves existing URI behavior for empty authority ports by allowing them to normalize to no port, and it preserves valid decimal ports, including zero, leading zeroes, and IPv6 authority ports.