### PR TITLE
Restore copyToStream throws annotation

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -45,6 +45,8 @@ final class Utils
      * @param StreamInterface $dest   Stream to write to
      * @param int             $maxLen Maximum number of bytes to read. Pass -1
      *                                to read the entire stream.
+     *
+     * @throws \RuntimeException on error.
      */
     public static function copyToStream(StreamInterface $source, StreamInterface $dest, int $maxLen = -1): void
     {


### PR DESCRIPTION
The short-write fix on 2.11 softened the no-progress destination-write case, but copyToStream can still throw RuntimeException from stream reads and writes. 2.10 and 3.0 both document that, as do the neighboring copy helpers.

This restores the @throws annotation on the 2.11 branch without changing behavior. 3.0 already has the annotation, so the merge-up should not need a source change.