### PR TITLE
Reject native PHP serialization of streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Require `psr/http-message:^2.0` and add native parameter and return types
 - Require `psr/http-factory:^1.1`
+- Reject native PHP serialization of stream implementations
 - Preserve request method casing, except `ServerRequest::fromGlobals()` still uppercases
 - Reject empty arrays and non-string values as header values
 - Reject invalid uploaded file trees and invalid parsed body values

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -23,12 +23,6 @@ Guzzle PSR-7 3.0 requires `psr/http-message:^2.0` and
 `psr/http-message:^1.1 || ^2.0` and `psr/http-factory:^1.0`. If your dependency
 constraints pin `psr/http-message` to v1, update them before upgrading.
 
-#### Native PHP Serialization Of Streams
-
-Guzzle PSR-7 stream implementations no longer support native PHP `serialize()`
-or `unserialize()`. Persist stream contents explicitly and recreate streams with
-`Utils::streamFor()` when needed.
-
 Guzzle PSR-7 no longer depends on `ralouphie/getallheaders` and no longer
 provides a transitive global `getallheaders()` polyfill.
 `ServerRequest::fromGlobals()` continues to collect request headers internally.
@@ -545,6 +539,12 @@ lists.
 Static utility and constant classes such as `Header`, `Message`, `MimeType`,
 `Query`, `Rfc7230`, and `Utils` now have private constructors. Replace any
 accidental instantiation with static method calls or constant access.
+
+#### Native PHP Serialization of Streams
+
+Guzzle PSR-7 stream implementations no longer support native PHP `serialize()`
+or `unserialize()`. Persist stream contents explicitly and recreate streams with
+`Utils::streamFor()` when needed.
 
 1.x to 2.0
 ----------

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -23,6 +23,12 @@ Guzzle PSR-7 3.0 requires `psr/http-message:^2.0` and
 `psr/http-message:^1.1 || ^2.0` and `psr/http-factory:^1.0`. If your dependency
 constraints pin `psr/http-message` to v1, update them before upgrading.
 
+#### Native PHP Serialization Of Streams
+
+Guzzle PSR-7 stream implementations no longer support native PHP `serialize()`
+or `unserialize()`. Persist stream contents explicitly and recreate streams with
+`Utils::streamFor()` when needed.
+
 Guzzle PSR-7 no longer depends on `ralouphie/getallheaders` and no longer
 provides a transitive global `getallheaders()` polyfill.
 `ServerRequest::fromGlobals()` continues to collect request headers internally.

--- a/src/AppendStream.php
+++ b/src/AppendStream.php
@@ -13,6 +13,8 @@ use Psr\Http\Message\StreamInterface;
  */
 final class AppendStream implements StreamInterface
 {
+    use NonSerializableStreamTrait;
+
     /** @var StreamInterface[] Streams being decorated */
     private array $streams = [];
 

--- a/src/BufferStream.php
+++ b/src/BufferStream.php
@@ -16,6 +16,8 @@ use Psr\Http\Message\StreamInterface;
  */
 final class BufferStream implements StreamInterface
 {
+    use NonSerializableStreamTrait;
+
     private int $hwm;
 
     private string $buffer = '';

--- a/src/CachingStream.php
+++ b/src/CachingStream.php
@@ -13,6 +13,7 @@ use Psr\Http\Message\StreamInterface;
 final class CachingStream implements StreamInterface
 {
     use StreamDecoratorTrait;
+    use NonSerializableStreamTrait;
 
     /** @var StreamInterface Stream being wrapped */
     private StreamInterface $remoteStream;

--- a/src/DroppingStream.php
+++ b/src/DroppingStream.php
@@ -13,6 +13,7 @@ use Psr\Http\Message\StreamInterface;
 final class DroppingStream implements StreamInterface
 {
     use StreamDecoratorTrait;
+    use NonSerializableStreamTrait;
 
     private int $maxLength;
 

--- a/src/FnStream.php
+++ b/src/FnStream.php
@@ -15,6 +15,8 @@ use Psr\Http\Message\StreamInterface;
 #[\AllowDynamicProperties]
 final class FnStream implements StreamInterface
 {
+    use NonSerializableStreamTrait;
+
     private const SLOTS = [
         '__toString', 'close', 'detach', 'rewind',
         'getSize', 'tell', 'eof', 'isSeekable', 'seek', 'isWritable', 'write',
@@ -73,6 +75,17 @@ final class FnStream implements StreamInterface
      */
     public function __wakeup(): void
     {
+        $this->methods = [];
+        $this->detached = true;
+
+        throw new \LogicException('FnStream should never be unserialized');
+    }
+
+    public function __unserialize(array $data): void
+    {
+        $this->methods = [];
+        $this->detached = true;
+
         throw new \LogicException('FnStream should never be unserialized');
     }
 

--- a/src/InflateStream.php
+++ b/src/InflateStream.php
@@ -21,6 +21,7 @@ use Psr\Http\Message\StreamInterface;
 final class InflateStream implements StreamInterface
 {
     use StreamDecoratorTrait;
+    use NonSerializableStreamTrait;
 
     private StreamInterface $stream;
 

--- a/src/LazyOpenStream.php
+++ b/src/LazyOpenStream.php
@@ -13,6 +13,7 @@ use Psr\Http\Message\StreamInterface;
 final class LazyOpenStream implements StreamInterface
 {
     use StreamDecoratorTrait;
+    use NonSerializableStreamTrait;
 
     private string $filename;
 
@@ -32,6 +33,13 @@ final class LazyOpenStream implements StreamInterface
         // unsetting the property forces the first access to go through
         // __get().
         unset($this->stream);
+    }
+
+    public function __unserialize(array $data): void
+    {
+        $this->stream = new BufferStream();
+
+        throw new \LogicException('LazyOpenStream should never be unserialized');
     }
 
     /**

--- a/src/LimitStream.php
+++ b/src/LimitStream.php
@@ -12,6 +12,7 @@ use Psr\Http\Message\StreamInterface;
 final class LimitStream implements StreamInterface
 {
     use StreamDecoratorTrait;
+    use NonSerializableStreamTrait;
 
     /** @var int Offset to start reading from */
     private int $offset;

--- a/src/MultipartStream.php
+++ b/src/MultipartStream.php
@@ -13,6 +13,7 @@ use Psr\Http\Message\StreamInterface;
 final class MultipartStream implements StreamInterface
 {
     use StreamDecoratorTrait;
+    use NonSerializableStreamTrait;
 
     private string $boundary;
 

--- a/src/NoSeekStream.php
+++ b/src/NoSeekStream.php
@@ -12,6 +12,7 @@ use Psr\Http\Message\StreamInterface;
 final class NoSeekStream implements StreamInterface
 {
     use StreamDecoratorTrait;
+    use NonSerializableStreamTrait;
 
     private StreamInterface $stream;
 

--- a/src/NonSerializableStreamTrait.php
+++ b/src/NonSerializableStreamTrait.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GuzzleHttp\Psr7;
+
+/**
+ * @internal
+ */
+trait NonSerializableStreamTrait
+{
+    public function __serialize(): array
+    {
+        throw new \LogicException(static::class.' should never be serialized');
+    }
+
+    public function __unserialize(array $data): void
+    {
+        throw new \LogicException(static::class.' should never be unserialized');
+    }
+}

--- a/src/PumpStream.php
+++ b/src/PumpStream.php
@@ -22,6 +22,8 @@ use Psr\Http\Message\StreamInterface;
  */
 final class PumpStream implements StreamInterface
 {
+    use NonSerializableStreamTrait;
+
     /** @var callable|null */
     private $source;
 
@@ -52,6 +54,17 @@ final class PumpStream implements StreamInterface
         $this->size = Integers::assertOptionalNonNegativeSize($options['size'] ?? null, 'Stream size');
         $this->metadata = $options['metadata'] ?? [];
         $this->buffer = new BufferStream();
+    }
+
+    public function __unserialize(array $data): void
+    {
+        $this->source = null;
+        $this->size = null;
+        $this->tellPos = 0;
+        $this->metadata = [];
+        $this->buffer = new BufferStream();
+
+        throw new \LogicException('PumpStream should never be unserialized');
     }
 
     public function __toString(): string

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -12,6 +12,8 @@ use Psr\Http\Message\StreamInterface;
  */
 class Stream implements StreamInterface
 {
+    use NonSerializableStreamTrait;
+
     /** @var resource */
     private $stream;
     private ?int $size = null;

--- a/tests/FnStreamTest.php
+++ b/tests/FnStreamTest.php
@@ -355,11 +355,28 @@ class FnStreamTest extends TestCase
 
     public function testDoNotAllowUnserialization(): void
     {
-        $a = new FnStream([]);
-        $b = serialize($a);
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('FnStream should never be unserialized');
-        unserialize($b);
+        unserialize(self::serializedObject(FnStream::class));
+    }
+
+    public function testUnserializationCannotInvokeToStringCallbackFromDestructor(): void
+    {
+        FnStreamUnserializeMarker::$calls = 0;
+        $payload = self::serializedObjectWithProperties(FnStreamUnserializeStringCastOnDestruct::class, [
+            'stream' => self::serializedObjectWithProperties(FnStream::class, [
+                '_fn___toString' => serialize([FnStreamUnserializeMarker::class, 'mark']),
+            ]),
+        ]);
+
+        try {
+            unserialize($payload);
+            self::fail('Expected unserialization to fail.');
+        } catch (\LogicException $e) {
+            self::assertSame('FnStream should never be unserialized', $e->getMessage());
+        }
+
+        self::assertSame(0, FnStreamUnserializeMarker::$calls);
     }
 
     public function testThatConvertingStreamToStringWillThrowException(): void
@@ -428,6 +445,24 @@ class FnStreamTest extends TestCase
         }
 
         self::fail('Expected stream to be detached');
+    }
+
+    private static function serializedObject(string $class): string
+    {
+        return sprintf('O:%d:"%s":0:{}', strlen($class), $class);
+    }
+
+    /**
+     * @param array<string, string> $properties Serialized property values indexed by property name.
+     */
+    private static function serializedObjectWithProperties(string $class, array $properties): string
+    {
+        $body = '';
+        foreach ($properties as $name => $serializedValue) {
+            $body .= serialize($name).$serializedValue;
+        }
+
+        return sprintf('O:%d:"%s":%d:{%s}', strlen($class), $class, count($properties), $body);
     }
 
     /**
@@ -507,5 +542,31 @@ class FnStreamTest extends TestCase
                 return $key === null ? ['foo' => 'bar'] : 'bar';
             },
         ]);
+    }
+}
+
+final class FnStreamUnserializeStringCastOnDestruct
+{
+    /** @var mixed */
+    public $stream;
+
+    public function __destruct()
+    {
+        try {
+            (string) $this->stream;
+        } catch (\Throwable $e) {
+        }
+    }
+}
+
+final class FnStreamUnserializeMarker
+{
+    public static int $calls = 0;
+
+    public static function mark(): string
+    {
+        ++self::$calls;
+
+        return 'marked';
     }
 }

--- a/tests/PumpStreamTest.php
+++ b/tests/PumpStreamTest.php
@@ -323,4 +323,67 @@ class PumpStreamTest extends TestCase
 
         (string) $p;
     }
+
+    public function testUnserializationCannotInvokeSourceFromDestructor(): void
+    {
+        PumpStreamUnserializeMarker::$calls = 0;
+        $payload = self::serializedObjectWithProperties(PumpStreamUnserializeStringCastOnDestruct::class, [
+            'stream' => self::serializedObjectWithProperties(PumpStream::class, [
+                self::privateProperty(PumpStream::class, 'source') => serialize([PumpStreamUnserializeMarker::class, 'mark']),
+            ]),
+        ]);
+
+        try {
+            unserialize($payload);
+            self::fail('Expected unserialization to fail.');
+        } catch (\LogicException $e) {
+            self::assertSame('PumpStream should never be unserialized', $e->getMessage());
+        }
+
+        self::assertSame(0, PumpStreamUnserializeMarker::$calls);
+    }
+
+    private static function privateProperty(string $class, string $property): string
+    {
+        return "\0".$class."\0".$property;
+    }
+
+    /**
+     * @param array<string, string> $properties Serialized property values indexed by property name.
+     */
+    private static function serializedObjectWithProperties(string $class, array $properties): string
+    {
+        $body = '';
+        foreach ($properties as $name => $serializedValue) {
+            $body .= serialize($name).$serializedValue;
+        }
+
+        return sprintf('O:%d:"%s":%d:{%s}', strlen($class), $class, count($properties), $body);
+    }
+}
+
+final class PumpStreamUnserializeStringCastOnDestruct
+{
+    /** @var mixed */
+    public $stream;
+
+    public function __destruct()
+    {
+        try {
+            (string) $this->stream;
+        } catch (\Throwable $e) {
+        }
+    }
+}
+
+final class PumpStreamUnserializeMarker
+{
+    public static int $calls = 0;
+
+    public static function mark(): string
+    {
+        ++self::$calls;
+
+        return 'marked';
+    }
 }


### PR DESCRIPTION
This rejects native PHP serialization for concrete stream implementations and hardens the callable-backed stream types against failed unserialization state. It also documents the new behavior.