### PR TITLE
Fix non-finite float coercion warnings on PHP 8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.11.1 - Upcoming
+
+### Fixed
+
+- Fixed non-finite float values emitting coercion warnings on PHP 8.5
+
 ## 2.11.0 - 2026-06-02
 
 ### Changed

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -393,7 +393,7 @@ parameters:
 		-
 			message: '#^Cannot cast mixed to string\.$#'
 			identifier: cast.string
-			count: 1
+			count: 2
 			path: src/Query.php
 
 		-
@@ -555,6 +555,12 @@ parameters:
 		-
 			message: '#^Cannot cast mixed to int\.$#'
 			identifier: cast.int
+			count: 1
+			path: src/Uri.php
+
+		-
+			message: '#^Cannot cast mixed to string\.$#'
+			identifier: cast.string
 			count: 1
 			path: src/Uri.php
 

--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -273,6 +273,12 @@ trait MessageTrait
                 ));
             }
 
+            // Convert non-finite floats explicitly, as implicit coercion of
+            // NAN emits a warning on PHP 8.5.
+            if (is_float($value) && !is_finite($value)) {
+                $value = is_nan($value) ? 'NAN' : ($value > 0 ? 'INF' : '-INF');
+            }
+
             $trimmed = trim((string) $value, " \t");
             $this->assertValue($trimmed);
 

--- a/src/Query.php
+++ b/src/Query.php
@@ -96,7 +96,7 @@ final class Query
             $k = $encoder((string) $k);
             if (!is_array($v)) {
                 $qs .= $k;
-                $v = is_bool($v) ? $castBool($v) : $v;
+                $v = is_bool($v) ? $castBool($v) : self::normalizeNonFiniteFloat($v);
                 if ($v !== null) {
                     $qs .= '='.$encoder((string) $v);
                 }
@@ -104,7 +104,7 @@ final class Query
             } else {
                 foreach ($v as $vv) {
                     $qs .= $k;
-                    $vv = is_bool($vv) ? $castBool($vv) : $vv;
+                    $vv = is_bool($vv) ? $castBool($vv) : self::normalizeNonFiniteFloat($vv);
                     if ($vv !== null) {
                         $qs .= '='.$encoder((string) $vv);
                     }
@@ -114,5 +114,22 @@ final class Query
         }
 
         return $qs ? (string) substr($qs, 0, -1) : '';
+    }
+
+    /**
+     * Converts non-finite floats to the strings PHP coerces them to, as
+     * implicit coercion of NAN emits a warning on PHP 8.5.
+     *
+     * @param mixed $value
+     *
+     * @return mixed
+     */
+    private static function normalizeNonFiniteFloat($value)
+    {
+        if (is_float($value) && !is_finite($value)) {
+            return is_nan($value) ? 'NAN' : ($value > 0 ? 'INF' : '-INF');
+        }
+
+        return $value;
     }
 }

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -371,10 +371,25 @@ class Uri implements UriInterface, \JsonSerializable
         $result = self::getFilteredQueryString($uri, array_keys($keyValueArray));
 
         foreach ($keyValueArray as $key => $value) {
-            $result[] = self::generateQueryString((string) $key, $value !== null ? (string) $value : null);
+            $result[] = self::generateQueryString((string) $key, $value !== null ? self::stringifyQueryValue($value) : null);
         }
 
         return $uri->withQuery(implode('&', $result));
+    }
+
+    /**
+     * Converts non-finite floats to the strings PHP coerces them to, as
+     * implicit coercion of NAN emits a warning on PHP 8.5.
+     *
+     * @param mixed $value
+     */
+    private static function stringifyQueryValue($value): string
+    {
+        if (is_float($value) && !is_finite($value)) {
+            return is_nan($value) ? 'NAN' : ($value > 0 ? 'INF' : '-INF');
+        }
+
+        return (string) $value;
     }
 
     /**

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -470,6 +470,12 @@ final class Utils
     public static function streamFor($resource = '', array $options = []): StreamInterface
     {
         if (is_scalar($resource)) {
+            // Convert non-finite floats explicitly, as implicit coercion of
+            // NAN emits a warning on PHP 8.5.
+            if (is_float($resource) && !is_finite($resource)) {
+                $resource = is_nan($resource) ? 'NAN' : ($resource > 0 ? 'INF' : '-INF');
+            }
+
             $stream = self::tryFopen('php://temp', 'r+');
             if ($resource !== '') {
                 fwrite($stream, (string) $resource);


### PR DESCRIPTION
PHP 8.5 emits a warning whenever a NAN float is implicitly coerced to a string. Query string building, `Uri::withQueryValues()`, `Utils::streamFor()`, and header value trimming all cast scalar values with a plain string cast, so they trigger this warning when given a non-finite float. This converts non-finite floats to their string forms explicitly before the cast, preserving the existing output on all PHP versions.