### PR TITLE
Deprecate non-finite float values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.12.0 - Upcoming
+
+### Deprecated
+
+- Deprecated non-finite float values that guzzlehttp/psr7 3.0 will reject
+
 ## 2.11.1 - 2026-06-12
 
 ### Fixed

--- a/src/Query.php
+++ b/src/Query.php
@@ -127,6 +127,12 @@ final class Query
     private static function normalizeNonFiniteFloat($value)
     {
         if (is_float($value) && !is_finite($value)) {
+            \trigger_deprecation(
+                'guzzlehttp/psr7',
+                '2.12',
+                'Passing a non-finite float to Query::build() is deprecated; guzzlehttp/psr7 3.0 rejects non-finite floats.'
+            );
+
             return is_nan($value) ? 'NAN' : ($value > 0 ? 'INF' : '-INF');
         }
 

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -386,6 +386,12 @@ class Uri implements UriInterface, \JsonSerializable
     private static function stringifyQueryValue($value): string
     {
         if (is_float($value) && !is_finite($value)) {
+            \trigger_deprecation(
+                'guzzlehttp/psr7',
+                '2.12',
+                'Passing a non-finite float to Uri::withQueryValues() is deprecated; guzzlehttp/psr7 3.0 rejects non-finite floats.'
+            );
+
             return is_nan($value) ? 'NAN' : ($value > 0 ? 'INF' : '-INF');
         }
 

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -473,6 +473,12 @@ final class Utils
             // Convert non-finite floats explicitly, as implicit coercion of
             // NAN emits a warning on PHP 8.5.
             if (is_float($resource) && !is_finite($resource)) {
+                \trigger_deprecation(
+                    'guzzlehttp/psr7',
+                    '2.12',
+                    'Passing a non-finite float to Utils::streamFor() is deprecated; guzzlehttp/psr7 3.0 rejects non-finite floats.'
+                );
+
                 $resource = is_nan($resource) ? 'NAN' : ($resource > 0 ? 'INF' : '-INF');
             }
 


### PR DESCRIPTION
Non-finite floats passed to `Query::build()`, `Uri::withQueryValues()`, or `Utils::streamFor()` now emit a deprecation, since guzzlehttp/psr7 3.0 rejects them. The values still convert to their usual string forms for now. Header values are unchanged because any non-string scalar there already emits a deprecation.