### PR TITLE
Deprecate non-string scalar stream bodies and query values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
-- Deprecated non-finite float values that guzzlehttp/psr7 3.0 will reject
+- Deprecated non-finite float values in `Query::build()` that guzzlehttp/psr7 3.0 rejects
+- Deprecated non-finite float multipart contents that guzzlehttp/psr7 3.0 rejects
+- Deprecated non-string scalar bodies in `Utils::streamFor()`; cast them to a string for 3.0
+- Deprecated non-string `Uri::withQueryValues()` values; cast them to a string for 3.0
 
 ## 2.11.1 - 2026-06-12
 

--- a/src/MultipartStream.php
+++ b/src/MultipartStream.php
@@ -26,8 +26,9 @@ final class MultipartStream implements StreamInterface
      * @param array       $elements Array of associative arrays, each containing a
      *                              required "name" key mapping to the form field,
      *                              name, a required "contents" key mapping to any
-     *                              non-array value accepted by Utils::streamFor(),
-     *                              or an array for nested expansion.
+     *                              non-array value accepted by Utils::streamFor()
+     *                              (non-string scalar field values are cast to
+     *                              string), or an array for nested expansion.
      *                              Optional keys include "headers" (associative
      *                              array of custom headers) and "filename" (string
      *                              to send as the filename in the part).
@@ -124,7 +125,27 @@ final class MultipartStream implements StreamInterface
             return;
         }
 
-        $element['contents'] = Utils::streamFor($element['contents']);
+        $contents = $element['contents'];
+        if (is_scalar($contents) && !is_string($contents)) {
+            // Multipart field values are byte strings on the wire, so finite
+            // numeric and boolean field values are cast to string here rather
+            // than tripping streamFor()'s non-string-scalar deprecation. Non-finite
+            // floats are deprecated and normalized here too, so the deprecation is
+            // reported against MultipartStream instead of transitively through
+            // streamFor().
+            if (is_float($contents) && !is_finite($contents)) {
+                \trigger_deprecation(
+                    'guzzlehttp/psr7',
+                    '2.12',
+                    'Passing a non-finite float as multipart contents is deprecated; guzzlehttp/psr7 3.0 rejects non-finite floats.'
+                );
+
+                $contents = is_nan($contents) ? 'NAN' : ($contents > 0 ? 'INF' : '-INF');
+            }
+
+            $contents = (string) $contents;
+        }
+        $element['contents'] = Utils::streamFor($contents);
 
         if (empty($element['filename'])) {
             $uri = $element['contents']->getMetadata('uri');

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -378,21 +378,26 @@ class Uri implements UriInterface, \JsonSerializable
     }
 
     /**
-     * Converts non-finite floats to the strings PHP coerces them to, as
-     * implicit coercion of NAN emits a warning on PHP 8.5.
+     * Stringifies a non-null query value, deprecating non-string values that
+     * guzzlehttp/psr7 3.0 will reject. Non-finite floats are normalized to the
+     * strings PHP coerces them to, as implicit coercion of NAN emits a warning
+     * on PHP 8.5.
      *
      * @param mixed $value
      */
     private static function stringifyQueryValue($value): string
     {
-        if (is_float($value) && !is_finite($value)) {
+        if (!is_string($value)) {
             \trigger_deprecation(
                 'guzzlehttp/psr7',
                 '2.12',
-                'Passing a non-finite float to Uri::withQueryValues() is deprecated; guzzlehttp/psr7 3.0 rejects non-finite floats.'
+                'Passing %s to Uri::withQueryValues() is deprecated; cast it to a string. guzzlehttp/psr7 3.0 will only accept string or null query values.',
+                \gettype($value)
             );
 
-            return is_nan($value) ? 'NAN' : ($value > 0 ? 'INF' : '-INF');
+            if (is_float($value) && !is_finite($value)) {
+                return is_nan($value) ? 'NAN' : ($value > 0 ? 'INF' : '-INF');
+            }
         }
 
         return (string) $value;

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -462,6 +462,9 @@ final class Utils
      *   in subsequent reads. String inputs are always treated as string bodies,
      *   even when they name callable functions.
      *
+     * Passing a non-string scalar (`int`, `float`, or `bool`) is deprecated; cast
+     * it to a string instead. guzzlehttp/psr7 3.0 will reject non-string scalars.
+     *
      * @param resource|string|int|float|bool|StreamInterface|callable|\Iterator|null $resource Entity body data
      * @param array{size?: int, metadata?: array}                                    $options  Additional options
      *
@@ -470,16 +473,20 @@ final class Utils
     public static function streamFor($resource = '', array $options = []): StreamInterface
     {
         if (is_scalar($resource)) {
-            // Convert non-finite floats explicitly, as implicit coercion of
-            // NAN emits a warning on PHP 8.5.
-            if (is_float($resource) && !is_finite($resource)) {
+            if (!is_string($resource)) {
                 \trigger_deprecation(
                     'guzzlehttp/psr7',
                     '2.12',
-                    'Passing a non-finite float to Utils::streamFor() is deprecated; guzzlehttp/psr7 3.0 rejects non-finite floats.'
+                    'Passing %s to Utils::streamFor() is deprecated; cast it to a string. guzzlehttp/psr7 3.0 will only accept string, resource, StreamInterface, Stringable, Iterator, callable, or null.',
+                    \gettype($resource)
                 );
 
-                $resource = is_nan($resource) ? 'NAN' : ($resource > 0 ? 'INF' : '-INF');
+                if (is_float($resource) && !is_finite($resource)) {
+                    // Normalized only to avoid PHP 8.5's (string) NAN warning
+                    // while deprecated; 3.0 rejects non-finite floats with every
+                    // other non-string scalar.
+                    $resource = is_nan($resource) ? 'NAN' : ($resource > 0 ? 'INF' : '-INF');
+                }
             }
 
             $stream = self::tryFopen('php://temp', 'r+');


### PR DESCRIPTION
Utils::streamFor() and Uri::withQueryValues() accept non-string scalars today even though their documented contracts do not, so this deprecates passing an int, float, or bool to either and asks callers to cast to a string before guzzlehttp/psr7 3.0 rejects them. MultipartStream now casts finite non-string scalar field values to strings itself before calling streamFor(), so numeric and boolean form fields keep working without a deprecation. The existing non-finite float normalization is retained while the value is still being stringified to avoid the PHP 8.5 coercion warning.