### PR TITLE
Reject non-string scalar stream bodies and query values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reject malformed HTTP request/response start-lines
 - Validate iterator chunks passed to `Utils::streamFor()`
 - Validate unsupported values passed to `Query::build()`
-- Reject non-finite float values in `Query::build()`, `Uri::withQueryValues()`, and `Utils::streamFor()`
+- Reject non-finite float values in `Query::build()` and `MultipartStream` contents
+- `Utils::streamFor()` now rejects non-string scalar bodies
+- `Uri::withQueryValues()` now rejects non-string values
 - Reject invalid `Utils::modifyRequest()` change values
 - Use PHP debug type names in type error messages
 - Changed `Utils::copyToStream()` to throw when destination streams cannot make progress

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -121,7 +121,7 @@ Recognized change values must use the documented types:
 - `uri`: `UriInterface`
 - `query`: `string`
 - `version`: `string`
-- `body`: `resource|string|int|float|bool|StreamInterface|callable|\Iterator|\Stringable`
+- `body`: `resource|string|StreamInterface|callable|\Iterator|\Stringable`
 - `set_headers`: `array<array-key, string|non-empty-array<array-key, string>>`
 - `remove_headers`: `array<array-key, string|int>`
 
@@ -330,6 +330,9 @@ Flat arrays are still supported for repeated query parameters:
 Query::build(['tag' => ['a', 'b']]);
 // tag=a&tag=b
 ```
+
+`Uri::withQueryValues()` is stricter than `Query::build()` and requires `string`
+or `null` values; cast numeric and boolean query values to string.
 
 #### PumpStream Source Callables
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -199,6 +199,12 @@ parameters:
 			path: src/UriResolver.php
 
 		-
+			message: '#^Call to function is_string\(\) with string will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: src/Utils.php
+
+		-
 			message: '#^Method GuzzleHttp\\Psr7\\Utils\:\:tryGetContents\(\) should return string but returns string\|false\.$#'
 			identifier: return.type
 			count: 1

--- a/src/MultipartStream.php
+++ b/src/MultipartStream.php
@@ -128,18 +128,10 @@ final class MultipartStream implements StreamInterface
         if (is_scalar($contents) && !is_string($contents)) {
             // Multipart field values are byte strings on the wire, so finite
             // numeric and boolean field values are cast to string here rather
-            // than tripping streamFor()'s non-string-scalar deprecation. Non-finite
-            // floats are deprecated and normalized here too, so the deprecation is
-            // reported against MultipartStream instead of transitively through
-            // streamFor().
+            // than rejected by streamFor(). Non-finite floats cannot be
+            // represented and are rejected.
             if (is_float($contents) && !is_finite($contents)) {
-                \trigger_deprecation(
-                    'guzzlehttp/psr7',
-                    '2.12',
-                    'Passing a non-finite float as multipart contents is deprecated; guzzlehttp/psr7 3.0 rejects non-finite floats.'
-                );
-
-                $contents = is_nan($contents) ? 'NAN' : ($contents > 0 ? 'INF' : '-INF');
+                throw new \InvalidArgumentException('Cannot create a stream from a non-finite float.');
             }
 
             $contents = (string) $contents;

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -371,7 +371,7 @@ class Uri implements UriInterface, \JsonSerializable
         $result = self::getFilteredQueryString($uri, array_keys($keyValueArray));
 
         foreach ($keyValueArray as $key => $value) {
-            self::assertFiniteQueryValue($value);
+            self::assertStringOrNullQueryValue($value);
             $result[] = self::generateQueryString((string) $key, $value !== null ? (string) $value : null);
         }
 
@@ -381,19 +381,13 @@ class Uri implements UriInterface, \JsonSerializable
     /**
      * @param mixed $value
      */
-    private static function assertFiniteQueryValue($value): void
+    private static function assertStringOrNullQueryValue($value): void
     {
-        if (!is_string($value)) {
-            \trigger_deprecation(
-                'guzzlehttp/psr7',
-                '2.12',
-                'Passing %s to Uri::withQueryValues() is deprecated; cast it to a string. guzzlehttp/psr7 3.0 will only accept string or null query values.',
-                \gettype($value)
-            );
-
-            if (is_float($value) && !is_finite($value)) {
-                throw new \InvalidArgumentException('Query string values must be finite; non-finite floats are not supported.');
-            }
+        if ($value !== null && !is_string($value)) {
+            throw new \InvalidArgumentException(\sprintf(
+                'Query string values must be a string or null, %s given.',
+                \get_debug_type($value)
+            ));
         }
     }
 

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -198,9 +198,9 @@ final class Utils
      * - remove_headers: (array) Remove the given headers. Values may be
      *   strings or integers.
      * - body: (mixed) Sets the given body. Present non-null values are converted
-     *   with self::streamFor(), including scalar values, resources, streams,
-     *   iterators, callable arrays, closures, invokable objects, and stringable
-     *   objects. String inputs remain literal bodies.
+     *   with self::streamFor(), including resources, streams, iterators, callable
+     *   arrays, closures, invokable objects, and stringable objects. String inputs
+     *   remain literal bodies.
      * - uri: (UriInterface) Set the URI.
      * - query: (string) Set the query string value of the URI.
      * - version: (string) Set the protocol version.
@@ -210,7 +210,7 @@ final class Utils
      *     method?: string,
      *     set_headers?: array<array-key, string|non-empty-array<array-key, string>>,
      *     remove_headers?: array<array-key, string|int>,
-     *     body?: resource|string|int|float|bool|StreamInterface|callable|\Iterator|\Stringable,
+     *     body?: resource|string|StreamInterface|callable|\Iterator|\Stringable,
      *     uri?: UriInterface,
      *     query?: string,
      *     version?: string
@@ -351,7 +351,7 @@ final class Utils
         }
 
         if (\array_key_exists('body', $changes) && $changes['body'] === null) {
-            self::assertValidModifyRequestChange('body', 'resource|string|int|float|bool|StreamInterface|callable|\Iterator|\Stringable', $changes['body']);
+            self::assertValidModifyRequestChange('body', 'resource|string|StreamInterface|callable|\Iterator|\Stringable', $changes['body']);
         }
 
         if (\array_key_exists('set_headers', $changes)) {
@@ -481,11 +481,8 @@ final class Utils
      *   inputs are always treated as string bodies, even when they name callable
      *   functions.
      *
-     * Passing a non-string scalar (`int`, `float`, or `bool`) is deprecated; cast
-     * it to a string instead. guzzlehttp/psr7 3.0 will reject non-string scalars.
-     *
-     * @param resource|string|int|float|bool|StreamInterface|callable|\Iterator|\Stringable|null $resource Entity body data
-     * @param array{size?: int, metadata?: array}                                                $options  Additional options
+     * @param resource|string|StreamInterface|callable|\Iterator|\Stringable|null $resource Entity body data
+     * @param array{size?: int, metadata?: array}                                 $options  Additional options
      *
      * @throws \InvalidArgumentException if the $resource arg is not valid.
      */
@@ -493,21 +490,15 @@ final class Utils
     {
         if (is_scalar($resource)) {
             if (!is_string($resource)) {
-                \trigger_deprecation(
-                    'guzzlehttp/psr7',
-                    '2.12',
-                    'Passing %s to Utils::streamFor() is deprecated; cast it to a string. guzzlehttp/psr7 3.0 will only accept string, resource, StreamInterface, Stringable, Iterator, callable, or null.',
-                    \gettype($resource)
-                );
-
-                if (is_float($resource) && !is_finite($resource)) {
-                    throw new \InvalidArgumentException('Cannot create a stream from a non-finite float.');
-                }
+                throw new \InvalidArgumentException(\sprintf(
+                    'Cannot create a stream from %s; pass a string, resource, StreamInterface, Stringable, Iterator, callable, or null.',
+                    \get_debug_type($resource)
+                ));
             }
 
             $stream = self::tryFopen('php://temp', 'r+');
             if ($resource !== '') {
-                fwrite($stream, (string) $resource);
+                fwrite($stream, $resource);
                 fseek($stream, 0);
             }
 

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -620,19 +620,6 @@ class UriTest extends TestCase
         self::assertSame('', $uri->getQuery());
     }
 
-    public function testScalarQueryValues(): void
-    {
-        $uri = new Uri();
-        $uri = Uri::withQueryValues($uri, [
-            2 => 2,
-            1 => true,
-            'false' => false,
-            'float' => 3.1,
-        ]);
-
-        self::assertSame('2=2&1=1&false=&float=3.1', $uri->getQuery());
-    }
-
     public function testWithQueryValues(): void
     {
         $uri = new Uri();
@@ -644,23 +631,34 @@ class UriTest extends TestCase
         self::assertSame('key1=value1&key2=value2', $uri->getQuery());
     }
 
+    public function testWithQueryValuesAcceptsNull(): void
+    {
+        $uri = Uri::withQueryValues(new Uri(), ['key1' => 'value1', 'key2' => null]);
+
+        self::assertSame('key1=value1&key2', $uri->getQuery());
+    }
+
     /**
-     * @dataProvider nonFiniteFloatProvider
+     * @dataProvider nonStringQueryValueProvider
+     *
+     * @param mixed $value
      */
-    public function testWithQueryValuesRejectsNonFiniteFloat(float $value): void
+    public function testWithQueryValuesRejectsNonStringValue($value): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Query string values must be finite; non-finite floats are not supported.');
+        $this->expectExceptionMessage('Query string values must be a string or null');
 
         Uri::withQueryValues(new Uri(), ['key' => $value]);
     }
 
-    public static function nonFiniteFloatProvider(): array
+    public static function nonStringQueryValueProvider(): array
     {
         return [
+            'int' => [2],
+            'bool' => [true],
+            'float' => [3.1],
             'NAN' => [\NAN],
             'INF' => [\INF],
-            '-INF' => [-\INF],
         ];
     }
 

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -803,18 +803,23 @@ class UtilsTest extends TestCase
     }
 
     /**
-     * @dataProvider nonFiniteFloats
+     * @dataProvider nonStringScalars
+     *
+     * @param mixed $value
      */
-    public function testStreamForRejectsNonFiniteFloat(float $value): void
+    public function testStreamForRejectsNonStringScalar($value): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Cannot create a stream from a non-finite float.');
+        $this->expectExceptionMessage('Cannot create a stream from');
 
         Psr7\Utils::streamFor($value);
     }
 
-    public static function nonFiniteFloats(): iterable
+    public static function nonStringScalars(): iterable
     {
+        yield 'int' => [1];
+        yield 'float' => [1.5];
+        yield 'bool' => [true];
         yield 'NAN' => [\NAN];
         yield 'INF' => [\INF];
         yield '-INF' => [-\INF];
@@ -1544,7 +1549,7 @@ class UtilsTest extends TestCase
             ],
             'body null' => [
                 ['body' => null],
-                'Utils::modifyRequest() change "body" must be resource|string|int|float|bool|StreamInterface|callable|\Iterator|\Stringable; null provided.',
+                'Utils::modifyRequest() change "body" must be resource|string|StreamInterface|callable|\Iterator|\Stringable; null provided.',
             ],
             'set_headers null' => [
                 ['set_headers' => null],


### PR DESCRIPTION
This converts the deprecations from #790 into rejections for guzzlehttp/psr7 3.0. Utils::streamFor() now throws an InvalidArgumentException when given an integer, float, or boolean body, Uri::withQueryValues() throws for non-string, non-null values, and Utils::modifyRequest() drops scalars from its body allowlist. MultipartStream still accepts numeric and boolean field values by casting them to strings, since multipart field values are byte strings on the wire, but it now rejects non-finite floats directly rather than relying on streamFor(). The @param tags, modifyRequest documentation, changelog, and upgrade guide are updated to match, and the affected exception tests are broadened to cover the wider set of rejected values.