### PR TITLE
Freeze trim characters ahead of PHP 8.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.12.4 - Unreleased
+
+### Changed
+
+- Pass explicit trim characters ahead of the PHP 8.6 trim default change
+
 ## 2.12.3 - 2026-06-23
 
 ### Security

--- a/src/Header.php
+++ b/src/Header.php
@@ -142,7 +142,7 @@ final class Header
                 }
 
                 if (!$isQuoted && $value[$i] === ',') {
-                    $v = \trim($v);
+                    $v = \trim($v, " \n\r\t\0\x0B");
                     if ($v !== '') {
                         $result[] = $v;
                     }
@@ -167,7 +167,7 @@ final class Header
                 $v .= $value[$i];
             }
 
-            $v = \trim($v);
+            $v = \trim($v, " \n\r\t\0\x0B");
             if ($v !== '') {
                 $result[] = $v;
             }

--- a/src/Message.php
+++ b/src/Message.php
@@ -19,7 +19,7 @@ final class Message
     {
         if ($message instanceof RequestInterface) {
             $msg = trim($message->getMethod().' '
-                    .$message->getRequestTarget())
+                    .$message->getRequestTarget(), " \n\r\t\0\x0B")
                 .' HTTP/'.$message->getProtocolVersion();
             if (!$message->hasHeader('host')) {
                 $msg .= "\r\nHost: ".$message->getUri()->getHost();

--- a/src/MultipartStream.php
+++ b/src/MultipartStream.php
@@ -78,7 +78,7 @@ final class MultipartStream implements StreamInterface
             $str .= "{$key}: {$value}\r\n";
         }
 
-        return "--{$this->boundary}\r\n".trim($str)."\r\n\r\n";
+        return "--{$this->boundary}\r\n".trim($str, " \n\r\t\0\x0B")."\r\n\r\n";
     }
 
     /**


### PR DESCRIPTION
PHP 8.6 adds the form feed character to the default `$characters` set of `trim`, `ltrim`, and `rtrim`, so calls relying on the default would change behavior there. This change passes the pre-8.6 set explicitly at the four call sites that relied on it, in `Header::splitList`, `Message::toString`, and the `MultipartStream` part-header serialization, keeping behavior identical on every PHP version. This is the 2.12 counterpart of guzzle/guzzle#3775.
