### PR TITLE
Tighten Header::splitList trim characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Made static utility classes non-instantiable
 - Validate bracketed IP-literal hosts consistently between parsing and `withHost()`, including userinfo forms
 - Normalize percent-encoded octets in the URI host to uppercase hex
+- Trim header list elements with only spaces, horizontal tabs, and line terminators in `Header::splitList()`
 
 ### Removed
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -556,6 +556,11 @@ The deprecated `Header::normalize()` method was removed. Use
 `Header::splitList()` to split HTTP headers that are defined as comma-separated
 lists.
 
+`Header::splitList()` now trims list elements with spaces, horizontal tabs,
+carriage returns, and line feeds. 2.x also trimmed null bytes and vertical
+tabs. Validated header values cannot contain those bytes, so this only affects
+strings passed to `Header::splitList()` directly.
+
 #### Non-instantiable Utility Classes
 
 Static utility and constant classes such as `Header`, `Message`, `MimeType`,

--- a/src/Header.php
+++ b/src/Header.php
@@ -126,7 +126,7 @@ final class Header
                 }
 
                 if (!$isQuoted && $value[$i] === ',') {
-                    $v = \trim($v);
+                    $v = \trim($v, " \t\n\r");
                     if ($v !== '') {
                         $result[] = $v;
                     }
@@ -151,7 +151,7 @@ final class Header
                 $v .= $value[$i];
             }
 
-            $v = \trim($v);
+            $v = \trim($v, " \t\n\r");
             if ($v !== '') {
                 $result[] = $v;
             }

--- a/src/Message.php
+++ b/src/Message.php
@@ -26,7 +26,7 @@ final class Message
     {
         if ($message instanceof RequestInterface) {
             $msg = trim($message->getMethod().' '
-                    .$message->getRequestTarget())
+                    .$message->getRequestTarget(), " \n\r\t\0\x0B")
                 .' HTTP/'.$message->getProtocolVersion();
             if (!$message->hasHeader('host')) {
                 $msg .= "\r\nHost: ".self::hostHeaderFromUri($message->getUri());

--- a/tests/HeaderTest.php
+++ b/tests/HeaderTest.php
@@ -194,6 +194,11 @@ class HeaderTest extends TestCase
                 "<https://example.gitlab.com>; rel=\"first\",\n<https://example.gitlab.com>; rel=\"next\",\n<https://example.gitlab.com>; rel=\"prev\",\n<https://example.gitlab.com>; rel=\"last\",",
                 ['<https://example.gitlab.com>; rel="first"', '<https://example.gitlab.com>; rel="next"', '<https://example.gitlab.com>; rel="prev"', '<https://example.gitlab.com>; rel="last"'],
             ],
+            // NUL and vertical tab are not header whitespace and must survive splitting
+            [
+                "foo\x0B, \x00bar",
+                ["foo\x0B", "\x00bar"],
+            ],
         ];
     }
 


### PR DESCRIPTION
This is the 3.0 counterpart of #812. `Message::toString` freezes the pre-8.6 trim character set so its behavior stays identical when PHP 8.6 adds form feed to the default, while `Header::splitList` takes a deliberate tightening appropriate for a major: list elements are now trimmed with spaces, horizontal tabs, and line terminators only, where 2.x also stripped null bytes and vertical tabs. Line terminators stay in the set because splitting multi-line header blobs with elements separated by `",\n"` is deliberate, test-pinned behavior from #476. Validated header values cannot contain the no-longer-trimmed bytes, so only direct `splitList` callers are affected; the upgrade guide and a new provider case cover the change.
