### PR TITLE
Anchor validation patterns to the true end of input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Pass explicit trim characters ahead of the PHP 8.6 trim default change
 
+### Fixed
+
+- Anchor server port and response start-line patterns to the true end of input
+
 ## 2.12.3 - 2026-06-23
 
 ### Security

--- a/src/Message.php
+++ b/src/Message.php
@@ -349,7 +349,7 @@ final class Message
         // According to https://datatracker.ietf.org/doc/html/rfc7230#section-3.1.2
         // the space between status-code and reason-phrase is required. But
         // browsers accept responses without space and reason as well.
-        $responseStartLineMatch = preg_match('/^HTTP\/.* [0-9]{3}( .*|$)/', $data['start-line']);
+        $responseStartLineMatch = preg_match('/^HTTP\/.* [0-9]{3}( .*|$)/D', $data['start-line']);
 
         if ($responseStartLineMatch === false) {
             throw new \RuntimeException('Unable to parse response start line: '.preg_last_error_msg());

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -269,7 +269,7 @@ class ServerRequest extends Request implements ServerRequestInterface
         }
 
         $serverPort = self::getServerParam('SERVER_PORT');
-        if (!$hasPort && $serverPort !== null && preg_match('/^[+-]?\d+$/', $serverPort) === 1) {
+        if (!$hasPort && $serverPort !== null && preg_match('/^[+-]?\d+$/D', $serverPort) === 1) {
             $uri = $uri->withPort((int) $serverPort);
         }
 

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -402,6 +402,10 @@ class ServerRequestTest extends TestCase
                 'https://www.example.org/blog/article.php?id=10&user=foo',
                 array_merge($server, ['SERVER_PORT' => 'not-a-port']),
             ],
+            'SERVER_PORT with a trailing newline is ignored' => [
+                'https://www.example.org/blog/article.php?id=10&user=foo',
+                array_merge($server, ['SERVER_PORT' => "8324\n"]),
+            ],
             'Non-string SERVER_PORT is ignored' => [
                 'https://www.example.org/blog/article.php?id=10&user=foo',
                 array_merge($server, ['SERVER_PORT' => ['443']]),


### PR DESCRIPTION
Without the PCRE `D` modifier a trailing `$` anchor also matches immediately before a final newline, so `ServerRequest::fromGlobals` accepted a `SERVER_PORT` such as `"8080\n"` and the response start-line check in `Message::parseResponse` tolerated a trailing newline on a reason-less status line. The start line cannot actually carry a newline through the parser's own splitting, and 3.0's counterparts are already fully anchored with `D`, so this aligns 2.12 with them. The audit covered every `preg_*` pattern in the repository; all other `$`-anchored patterns already carry `D`, use `\z`, or are line-anchored by design. Stacked on #812 to share its changelog section, and the guzzle counterparts are guzzle/guzzle#3778 and guzzle/guzzle#3779.
