### PR TITLE
Resolve and normalize URIs using raw paths

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -303,6 +303,10 @@ $uri->getPath(); // /valid///path
 `Request::getRequestTarget()` applies the same normalization for URI-derived
 origin-form request targets.
 
+Reference resolution and normalization (`UriResolver`, `UriNormalizer`, and
+`Uri::isSameDocumentReference()`) operate on the raw path from the URI string
+form and are therefore unaffected by this normalization.
+
 #### HTTP Start-line Parsing
 
 `Message::parseRequest()` and `Message::parseResponse()` now validate HTTP

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -481,7 +481,7 @@ class Uri implements UriInterface, \JsonSerializable
     }
 
     /**
-     * Returns the path of a URI as used within its string form.
+     * Returns the path a URI's string form is composed from.
      *
      * getPath() collapses multiple leading slashes so that a path used in
      * isolation cannot be mistaken for a protocol-relative URL. Whole-URI
@@ -489,21 +489,27 @@ class Uri implements UriInterface, \JsonSerializable
      * Sections 5 and 6) are defined on the URI string form, where the path
      * stays verbatim, so they must read the path through this method instead.
      * For direct instances of this class the stored path is read directly as
-     * that is the exact path the string form is composed from; subclasses and
-     * other implementations may customize their string form, so their path is
-     * parsed from it.
+     * that is the exact path the string form is composed from; for subclasses
+     * and other implementations the path is split from the string form per
+     * RFC 3986 Appendix B, without validating or decoding any other component.
      *
-     * @throws MalformedUriException If the URI string form cannot be parsed.
+     * @throws \RuntimeException If the path cannot be split from the string form.
      *
      * @internal
      */
     public static function rawPath(UriInterface $uri): string
     {
-        if (get_class($uri) !== self::class) {
-            $uri = new self((string) $uri);
+        if (get_class($uri) === self::class) {
+            return $uri->path;
         }
 
-        return $uri->path;
+        $count = preg_match('%^(?:[^:/?#]+:)?(?://[^/?#]*)?([^?#]*)%', (string) $uri, $matches);
+
+        if ($count === false) {
+            throw new \RuntimeException('Unable to read the URI path: '.preg_last_error_msg());
+        }
+
+        return $matches[1] ?? '';
     }
 
     public function getQuery(): string

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -488,8 +488,10 @@ class Uri implements UriInterface, \JsonSerializable
      * operations like reference resolution and normalization (RFC 3986
      * Sections 5 and 6) are defined on the URI string form, where the path
      * stays verbatim, so they must read the path through this method instead.
-     * For instances of this class the stored path is read directly as that is
-     * the exact path the string form is composed from.
+     * For direct instances of this class the stored path is read directly as
+     * that is the exact path the string form is composed from; subclasses and
+     * other implementations may customize their string form, so their path is
+     * parsed from it.
      *
      * @throws MalformedUriException If the URI string form cannot be parsed.
      *
@@ -497,7 +499,7 @@ class Uri implements UriInterface, \JsonSerializable
      */
     public static function rawPath(UriInterface $uri): string
     {
-        if (!$uri instanceof self) {
+        if (get_class($uri) !== self::class) {
             $uri = new self((string) $uri);
         }
 

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -325,7 +325,7 @@ class Uri implements UriInterface, \JsonSerializable
 
             return ($uri->getScheme() === $base->getScheme())
                 && ($uri->getAuthority() === $base->getAuthority())
-                && ($uri->getPath() === $base->getPath())
+                && (self::rawPath($uri) === self::rawPath($base))
                 && ($uri->getQuery() === $base->getQuery());
         }
 
@@ -478,6 +478,30 @@ class Uri implements UriInterface, \JsonSerializable
         }
 
         return $this->path;
+    }
+
+    /**
+     * Returns the path of a URI as used within its string form.
+     *
+     * getPath() collapses multiple leading slashes so that a path used in
+     * isolation cannot be mistaken for a protocol-relative URL. Whole-URI
+     * operations like reference resolution and normalization (RFC 3986
+     * Sections 5 and 6) are defined on the URI string form, where the path
+     * stays verbatim, so they must read the path through this method instead.
+     * For instances of this class the stored path is read directly as that is
+     * the exact path the string form is composed from.
+     *
+     * @throws MalformedUriException If the URI string form cannot be parsed.
+     *
+     * @internal
+     */
+    public static function rawPath(UriInterface $uri): string
+    {
+        if (!$uri instanceof self) {
+            $uri = new self((string) $uri);
+        }
+
+        return $uri->path;
     }
 
     public function getQuery(): string

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -481,17 +481,18 @@ class Uri implements UriInterface, \JsonSerializable
     }
 
     /**
-     * Returns the path a URI's string form is composed from.
+     * Returns the path as it appears within a URI's string form.
      *
      * getPath() collapses multiple leading slashes so that a path used in
      * isolation cannot be mistaken for a protocol-relative URL. Whole-URI
      * operations like reference resolution and normalization (RFC 3986
      * Sections 5 and 6) are defined on the URI string form, where the path
      * stays verbatim, so they must read the path through this method instead.
-     * For direct instances of this class the stored path is read directly as
-     * that is the exact path the string form is composed from; for subclasses
-     * and other implementations the path is split from the string form per
-     * RFC 3986 Appendix B, without validating or decoding any other component.
+     * For direct instances of this class the path is derived from the stored
+     * components, including the leading slash the string form adds to a
+     * rootless path when an authority is present; for subclasses and other
+     * implementations the path is split from the string form per RFC 3986
+     * Appendix B, without validating or decoding any other component.
      *
      * @throws \RuntimeException If the path cannot be split from the string form.
      *
@@ -500,6 +501,12 @@ class Uri implements UriInterface, \JsonSerializable
     public static function rawPath(UriInterface $uri): string
     {
         if (get_class($uri) === self::class) {
+            if ($uri->path !== '' && !str_starts_with($uri->path, '/') && $uri->getAuthority() !== '') {
+                // composeComponents() prepends a slash to a rootless path when
+                // an authority is present, so the string form uses this path.
+                return '/'.$uri->path;
+            }
+
             return $uri->path;
         }
 

--- a/src/UriNormalizer.php
+++ b/src/UriNormalizer.php
@@ -146,11 +146,11 @@ final class UriNormalizer
         }
 
         if ($flags & self::REMOVE_DOT_SEGMENTS && !Uri::isRelativePathReference($uri)) {
-            $uri = $uri->withPath(UriResolver::removeDotSegments($uri->getPath()));
+            $uri = $uri->withPath(UriResolver::removeDotSegments(Uri::rawPath($uri)));
         }
 
         if ($flags & self::REMOVE_DUPLICATE_SLASHES) {
-            $path = preg_replace('#//++#', '/', $uri->getPath());
+            $path = preg_replace('#//++#', '/', Uri::rawPath($uri));
 
             if ($path === null) {
                 throw new \RuntimeException('Unable to remove duplicate slashes from URI path: '.preg_last_error_msg());
@@ -196,7 +196,7 @@ final class UriNormalizer
         };
 
         return $uri
-            ->withPath(self::normalizePercentEncodingInComponent($uri->getPath(), $regex, $callback))
+            ->withPath(self::normalizePercentEncodingInComponent(Uri::rawPath($uri), $regex, $callback))
             ->withQuery(self::normalizePercentEncodingInComponent($uri->getQuery(), $regex, $callback))
             ->withFragment(self::normalizePercentEncodingInComponent($uri->getFragment(), $regex, $callback));
     }
@@ -210,7 +210,7 @@ final class UriNormalizer
         };
 
         return $uri
-            ->withPath(self::normalizePercentEncodingInComponent($uri->getPath(), $regex, $callback))
+            ->withPath(self::normalizePercentEncodingInComponent(Uri::rawPath($uri), $regex, $callback))
             ->withQuery(self::normalizePercentEncodingInComponent($uri->getQuery(), $regex, $callback))
             ->withFragment(self::normalizePercentEncodingInComponent($uri->getFragment(), $regex, $callback));
     }

--- a/src/UriResolver.php
+++ b/src/UriResolver.php
@@ -63,40 +63,45 @@ final class UriResolver
         }
 
         if ($rel->getScheme() != '') {
-            return $rel->withPath(self::removeDotSegments($rel->getPath()));
+            return $rel->withPath(self::removeDotSegments(Uri::rawPath($rel)));
         }
 
         if ($rel->getAuthority() != '') {
             return $rel
                 ->withScheme($base->getScheme())
-                ->withPath(self::removeDotSegments($rel->getPath()));
+                ->withPath(self::removeDotSegments(Uri::rawPath($rel)));
         }
 
-        if ($rel->getPath() === '') {
-            $targetPath = $base->getPath();
-            $targetQuery = $rel->getQuery() != '' ? $rel->getQuery() : $base->getQuery();
+        $relPath = Uri::rawPath($rel);
+
+        if ($relPath === '') {
+            // the base path is used as-is per RFC 3986 Section 5.2.2, so it must not be
+            // rewritten through a getPath()/withPath() round-trip
+            return $base
+                ->withQuery($rel->getQuery() != '' ? $rel->getQuery() : $base->getQuery())
+                ->withFragment($rel->getFragment());
+        }
+
+        if (str_starts_with($relPath, '/')) {
+            $targetPath = $relPath;
         } else {
-            if (str_starts_with($rel->getPath(), '/')) {
-                $targetPath = $rel->getPath();
+            $basePath = Uri::rawPath($base);
+            if ($base->getAuthority() != '' && $basePath === '') {
+                $targetPath = '/'.$relPath;
             } else {
-                if ($base->getAuthority() != '' && $base->getPath() === '') {
-                    $targetPath = '/'.$rel->getPath();
+                $lastSlashPos = strrpos($basePath, '/');
+                if ($lastSlashPos === false) {
+                    $targetPath = $relPath;
                 } else {
-                    $lastSlashPos = strrpos($base->getPath(), '/');
-                    if ($lastSlashPos === false) {
-                        $targetPath = $rel->getPath();
-                    } else {
-                        $targetPath = substr($base->getPath(), 0, $lastSlashPos + 1).$rel->getPath();
-                    }
+                    $targetPath = substr($basePath, 0, $lastSlashPos + 1).$relPath;
                 }
             }
-            $targetPath = self::removeDotSegments($targetPath);
-            $targetQuery = $rel->getQuery();
         }
+        $targetPath = self::removeDotSegments($targetPath);
 
         return $base
             ->withPath($targetPath)
-            ->withQuery($targetQuery)
+            ->withQuery($rel->getQuery())
             ->withFragment($rel->getFragment());
     }
 
@@ -145,7 +150,7 @@ final class UriResolver
         // invalid.
         $emptyPathUri = $target->withScheme('')->withPath('')->withUserInfo('')->withPort(null)->withHost('');
 
-        if ($base->getPath() !== $target->getPath()) {
+        if (Uri::rawPath($base) !== Uri::rawPath($target)) {
             return $emptyPathUri->withPath(self::getRelativePath($base, $target));
         }
 
@@ -157,7 +162,7 @@ final class UriResolver
         // If the base URI has a query but the target has none, we cannot return an empty path reference as it would
         // inherit the base query component when resolving.
         if ($target->getQuery() === '') {
-            $segments = explode('/', $target->getPath());
+            $segments = explode('/', Uri::rawPath($target));
             /** @var string $lastSegment */
             $lastSegment = end($segments);
 
@@ -169,8 +174,8 @@ final class UriResolver
 
     private static function getRelativePath(UriInterface $base, UriInterface $target): string
     {
-        $sourceSegments = explode('/', $base->getPath());
-        $targetSegments = explode('/', $target->getPath());
+        $sourceSegments = explode('/', Uri::rawPath($base));
+        $targetSegments = explode('/', Uri::rawPath($target));
         array_pop($sourceSegments);
         $targetLastSegment = array_pop($targetSegments);
         foreach ($sourceSegments as $i => $segment) {
@@ -189,7 +194,7 @@ final class UriResolver
         if ($relativePath === '' || str_contains(explode('/', $relativePath, 2)[0], ':')) {
             $relativePath = "./$relativePath";
         } elseif (str_starts_with($relativePath, '/')) {
-            if ($base->getAuthority() != '' && $base->getPath() === '') {
+            if ($base->getAuthority() != '' && Uri::rawPath($base) === '') {
                 // In this case an extra slash is added by resolve() automatically. So we must not add one here.
                 $relativePath = ".$relativePath";
             } else {

--- a/tests/UriNormalizerTest.php
+++ b/tests/UriNormalizerTest.php
@@ -140,6 +140,24 @@ class UriNormalizerTest extends TestCase
         self::assertSame('http://example.org/foo/bar/bam.html', (string) $normalizedUri);
     }
 
+    public function testRemoveDotSegmentsRetainsDuplicateSlashes(): void
+    {
+        $uri = new Uri('http://example.org//a/b/../c/./d.html');
+        $normalizedUri = UriNormalizer::normalize($uri, UriNormalizer::REMOVE_DOT_SEGMENTS);
+
+        self::assertInstanceOf(UriInterface::class, $normalizedUri);
+        self::assertSame('http://example.org//a/c/d.html', (string) $normalizedUri);
+    }
+
+    public function testPreservingNormalizationsRetainDuplicateSlashes(): void
+    {
+        $uri = new Uri('http://example.org//a%c2%b1b/./p%61th');
+        $normalizedUri = UriNormalizer::normalize($uri);
+
+        self::assertInstanceOf(UriInterface::class, $normalizedUri);
+        self::assertSame('http://example.org//a%C2%B1b/path', (string) $normalizedUri);
+    }
+
     public function testSortQueryParameters(): void
     {
         $uri = new Uri('?lang=en&article=fred');
@@ -183,5 +201,14 @@ class UriNormalizerTest extends TestCase
             ['file:/myfile', 'file:///myfile', true],
             ['file:///myfile', 'file://localhost/myfile', true],
         ];
+    }
+
+    public function testIsEquivalentWithRemoveDuplicateSlashes(): void
+    {
+        $uri1 = new Uri('http://example.org//foo');
+        $uri2 = new Uri('http://example.org/foo');
+
+        self::assertFalse(UriNormalizer::isEquivalent($uri1, $uri2));
+        self::assertTrue(UriNormalizer::isEquivalent($uri1, $uri2, UriNormalizer::PRESERVING_NORMALIZATIONS | UriNormalizer::REMOVE_DUPLICATE_SLASHES));
     }
 }

--- a/tests/UriResolverTest.php
+++ b/tests/UriResolverTest.php
@@ -152,6 +152,16 @@ class UriResolverTest extends TestCase
         self::assertSame((string) UriResolver::resolve($baseUri, $targetUri), (string) UriResolver::resolve($baseUri, $relativeUri));
     }
 
+    public function testRelativizeAndResolveWithMultiSlashBasePathRoundTrips(): void
+    {
+        $baseUri = new Uri('http://example.com//a/b');
+        $targetUri = new Uri('http://example.com//a/x');
+        $relativeUri = UriResolver::relativize($baseUri, $targetUri);
+
+        self::assertSame('x', (string) $relativeUri);
+        self::assertSame((string) $targetUri, (string) UriResolver::resolve($baseUri, $relativeUri));
+    }
+
     public static function getResolveTestCases(): iterable
     {
         return [
@@ -249,9 +259,15 @@ class UriResolverTest extends TestCase
             // empty base path and relative-path reference
             ['//example.com',    'a',             '//example.com/a'],
             // path starting with two slashes
-            ['//example.com//two-slashes', './',  '//example.com/'],
-            ['//example.com',    './',            '//example.com/'],
-            ['//example.com/',   './',            '//example.com/'],
+            ['//example.com//two-slashes', './',  '//example.com//'],
+            ['//example.com',    './/',           '//example.com//'],
+            ['//example.com/',   './/',           '//example.com//'],
+            // multiple leading slashes in paths are preserved during resolution
+            ['http://a//b/c',    '#s',            'http://a//b/c#s'],
+            ['http://a//b/c',    '?q',            'http://a//b/c?q'],
+            ['http://a//b/c',    'x',             'http://a//b/x'],
+            ['http://a/b/c',     'http://x//y/z', 'http://x//y/z'],
+            ['http://a/b/c',     '//x//y/z',      'http://x//y/z'],
             // base URI has less components than relative URI
             ['/',                '//a/b?q#h',     '//a/b?q#h'],
             ['/',                'urn:/',         'urn:/'],

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -679,6 +679,10 @@ class UriTest extends TestCase
         self::assertTrue(Uri::isSameDocumentReference(new Uri('http://example.org//path?foo=bar#fragment'), $multiSlashBaseUri));
         self::assertFalse(Uri::isSameDocumentReference(new Uri('http://example.org/path?foo=bar'), $multiSlashBaseUri));
         self::assertFalse(Uri::isSameDocumentReference(new Uri('http://example.org//path?foo=bar'), $baseUri));
+
+        $rootlessBaseUri = (new Uri('http://example.org?foo=bar'))->withPath('path');
+
+        self::assertTrue(Uri::isSameDocumentReference(new Uri('http://example.org/path?foo=bar'), $rootlessBaseUri));
     }
 
     public function testRawPathIsDerivedFromUriStringForm(): void
@@ -700,6 +704,15 @@ class UriTest extends TestCase
         })->withScheme('http')->withHost('[v1.fe80::a+en1]')->withPath('/');
 
         self::assertSame('/', Uri::rawPath($plainSubclassUri));
+
+        // A rootless path gains a leading slash in the string form when an
+        // authority is present; identical string forms must yield identical
+        // paths regardless of how the instance was constructed.
+        $rootlessUri = (new Uri())->withHost('example.com')->withPath('foo');
+
+        self::assertSame('//example.com/foo', (string) $rootlessUri);
+        self::assertSame('/foo', Uri::rawPath($rootlessUri));
+        self::assertSame(Uri::rawPath(new Uri('//example.com/foo')), Uri::rawPath($rootlessUri));
     }
 
     public function testAddAndRemoveQueryValues(): void

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -681,6 +681,20 @@ class UriTest extends TestCase
         self::assertFalse(Uri::isSameDocumentReference(new Uri('http://example.org//path?foo=bar'), $baseUri));
     }
 
+    public function testRawPathIsDerivedFromUriStringForm(): void
+    {
+        self::assertSame('//stored/path', Uri::rawPath(new Uri('http://example.org//stored/path')));
+
+        $extendedUri = new class('http://example.org/stored/path') extends Uri {
+            public function __toString(): string
+            {
+                return 'http://example.org//custom/form';
+            }
+        };
+
+        self::assertSame('//custom/form', Uri::rawPath($extendedUri));
+    }
+
     public function testAddAndRemoveQueryValues(): void
     {
         $uri = new Uri();

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -693,6 +693,13 @@ class UriTest extends TestCase
         };
 
         self::assertSame('//custom/form', Uri::rawPath($extendedUri));
+
+        // The split must not validate unrelated components: this host is
+        // accepted by the withers but rejected by the parser.
+        $plainSubclassUri = (new class() extends Uri {
+        })->withScheme('http')->withHost('[v1.fe80::a+en1]')->withPath('/');
+
+        self::assertSame('/', Uri::rawPath($plainSubclassUri));
     }
 
     public function testAddAndRemoveQueryValues(): void

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -700,7 +700,7 @@ class UriTest extends TestCase
 
         // The split must not validate unrelated components: this host is
         // accepted by the withers but rejected by the parser.
-        $plainSubclassUri = (new class() extends Uri {
+        $plainSubclassUri = (new class extends Uri {
         })->withScheme('http')->withHost('[v1.fe80::a+en1]')->withPath('/');
 
         self::assertSame('/', Uri::rawPath($plainSubclassUri));

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -672,6 +672,13 @@ class UriTest extends TestCase
         self::assertFalse(Uri::isSameDocumentReference(new Uri('http://example.org'), $baseUri));
 
         self::assertFalse(Uri::isSameDocumentReference(new Uri('urn:/path'), new Uri('urn://example.com/path')));
+
+        $multiSlashBaseUri = new Uri('http://example.org//path?foo=bar');
+
+        self::assertTrue(Uri::isSameDocumentReference(new Uri('#fragment'), $multiSlashBaseUri));
+        self::assertTrue(Uri::isSameDocumentReference(new Uri('http://example.org//path?foo=bar#fragment'), $multiSlashBaseUri));
+        self::assertFalse(Uri::isSameDocumentReference(new Uri('http://example.org/path?foo=bar'), $multiSlashBaseUri));
+        self::assertFalse(Uri::isSameDocumentReference(new Uri('http://example.org//path?foo=bar'), $baseUri));
     }
 
     public function testAddAndRemoveQueryValues(): void


### PR DESCRIPTION
In 3.0, `Uri::getPath()` deliberately collapses multiple leading slashes so a path used in isolation cannot be mistaken for a protocol-relative URL. `UriResolver`, `UriNormalizer`, and `Uri::isSameDocumentReference()` read paths through `getPath()` and write them back with `withPath()`, so that hardening leaked into whole-URI operations: normalizing `http://example.org//foo` with the default `PRESERVING_NORMALIZATIONS` rewrote it to `http://example.org/foo` and `isEquivalent()` treated the two as equal even though `REMOVE_DUPLICATE_SLASHES` is deliberately opt-in, resolving a fragment-only reference rewrote the base path contrary to RFC 3986 Section 5.2.2, and the documented relativize/resolve round-trip invariant failed. All of these behaviors regressed relative to 2.x.

This adds an internal `Uri::rawPath()` helper that derives the path from the URI string form, in which PSR-7 preserves the path verbatim, and switches reference resolution, the path-touching normalization steps, and the same-document comparison to it. For `GuzzleHttp\Psr7\Uri` instances the path is derived from the stored components, including the leading slash the string form adds to a rootless path when an authority is present, so identical string forms yield identical paths regardless of how an instance was constructed. Resolving a reference with an empty path now returns the base without touching its path at all, per RFC 3986. The three resolver test rows adjusted when the `getPath()` normalization was introduced in #676 are restored to their 2.x expectations, and resolution, normalization, and equivalence now match 2.12 for all multi-slash paths.

For subclasses of `Uri` and third-party `UriInterface` implementations the raw path is split from `(string) $uri` using the RFC 3986 Appendix B grammar. The split is purely syntactic and never validates or decodes other components, so reading a path cannot fail on an unrelated component: reparsing through the `Uri` constructor would reject some values the withers accept, such as IPvFuture hosts containing `+`. Stringifying is the one operation PSR-7 already requires every implementation to support.
