### PR TITLE
Add regression tests for multi-slash URI paths

### DIFF
--- a/tests/UriNormalizerTest.php
+++ b/tests/UriNormalizerTest.php
@@ -140,6 +140,24 @@ class UriNormalizerTest extends TestCase
         self::assertSame('http://example.org/foo/bar/bam.html', (string) $normalizedUri);
     }
 
+    public function testRemoveDotSegmentsRetainsDuplicateSlashes(): void
+    {
+        $uri = new Uri('http://example.org//a/b/../c/./d.html');
+        $normalizedUri = UriNormalizer::normalize($uri, UriNormalizer::REMOVE_DOT_SEGMENTS);
+
+        self::assertInstanceOf(UriInterface::class, $normalizedUri);
+        self::assertSame('http://example.org//a/c/d.html', (string) $normalizedUri);
+    }
+
+    public function testPreservingNormalizationsRetainDuplicateSlashes(): void
+    {
+        $uri = new Uri('http://example.org//a%c2%b1b/./p%61th');
+        $normalizedUri = UriNormalizer::normalize($uri);
+
+        self::assertInstanceOf(UriInterface::class, $normalizedUri);
+        self::assertSame('http://example.org//a%C2%B1b/path', (string) $normalizedUri);
+    }
+
     public function testSortQueryParameters(): void
     {
         $uri = new Uri('?lang=en&article=fred');
@@ -183,5 +201,14 @@ class UriNormalizerTest extends TestCase
             ['file:/myfile', 'file:///myfile', true],
             ['file:///myfile', 'file://localhost/myfile', true],
         ];
+    }
+
+    public function testIsEquivalentWithRemoveDuplicateSlashes(): void
+    {
+        $uri1 = new Uri('http://example.org//foo');
+        $uri2 = new Uri('http://example.org/foo');
+
+        self::assertFalse(UriNormalizer::isEquivalent($uri1, $uri2));
+        self::assertTrue(UriNormalizer::isEquivalent($uri1, $uri2, UriNormalizer::PRESERVING_NORMALIZATIONS | UriNormalizer::REMOVE_DUPLICATE_SLASHES));
     }
 }

--- a/tests/UriResolverTest.php
+++ b/tests/UriResolverTest.php
@@ -152,6 +152,16 @@ class UriResolverTest extends TestCase
         self::assertSame((string) UriResolver::resolve($baseUri, $targetUri), (string) UriResolver::resolve($baseUri, $relativeUri));
     }
 
+    public function testRelativizeAndResolveWithMultiSlashBasePathRoundTrips(): void
+    {
+        $baseUri = new Uri('http://example.com//a/b');
+        $targetUri = new Uri('http://example.com//a/x');
+        $relativeUri = UriResolver::relativize($baseUri, $targetUri);
+
+        self::assertSame('x', (string) $relativeUri);
+        self::assertSame((string) $targetUri, (string) UriResolver::resolve($baseUri, $relativeUri));
+    }
+
     public static function getResolveTestCases(): iterable
     {
         return [
@@ -252,6 +262,12 @@ class UriResolverTest extends TestCase
             ['//example.com//two-slashes', './',  '//example.com//'],
             ['//example.com',    './/',           '//example.com//'],
             ['//example.com/',   './/',           '//example.com//'],
+            // multiple leading slashes in paths are preserved during resolution
+            ['http://a//b/c',    '#s',            'http://a//b/c#s'],
+            ['http://a//b/c',    '?q',            'http://a//b/c?q'],
+            ['http://a//b/c',    'x',             'http://a//b/x'],
+            ['http://a/b/c',     'http://x//y/z', 'http://x//y/z'],
+            ['http://a/b/c',     '//x//y/z',      'http://x//y/z'],
             // base URI has less components than relative URI
             ['/',                '//a/b?q#h',     '//a/b?q#h'],
             ['/',                'urn:/',         'urn:/'],

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -472,6 +472,13 @@ class UriTest extends TestCase
         self::assertFalse(Uri::isSameDocumentReference(new Uri('http://example.org'), $baseUri));
 
         self::assertFalse(Uri::isSameDocumentReference(new Uri('urn:/path'), new Uri('urn://example.com/path')));
+
+        $multiSlashBaseUri = new Uri('http://example.org//path?foo=bar');
+
+        self::assertTrue(Uri::isSameDocumentReference(new Uri('#fragment'), $multiSlashBaseUri));
+        self::assertTrue(Uri::isSameDocumentReference(new Uri('http://example.org//path?foo=bar#fragment'), $multiSlashBaseUri));
+        self::assertFalse(Uri::isSameDocumentReference(new Uri('http://example.org/path?foo=bar'), $multiSlashBaseUri));
+        self::assertFalse(Uri::isSameDocumentReference(new Uri('http://example.org//path?foo=bar'), $baseUri));
     }
 
     public function testAddAndRemoveQueryValues(): void


### PR DESCRIPTION
On 3.0, the `Uri::getPath()` leading-slash normalization leaked into `UriResolver`, `UriNormalizer`, and `Uri::isSameDocumentReference()`, silently rewriting multi-slash paths during resolution and normalization; #815 fixes that by reading raw paths. The 2.12 series already behaves correctly in every one of those scenarios, but nothing in its suite pins that behavior, so a future 2.x hardening in the same direction could regress it unnoticed.

This backports the multi-slash regression tests from #815 that exercise behavior the two series share, with no source changes: resolver cases for fragment-only, query-only, and relative-merge references against multi-slash base paths plus the scheme and authority branches, the relativize/resolve round-trip invariant, normalization under `REMOVE_DOT_SEGMENTS` and the default preserving flags, `isEquivalent()` distinguishing `//foo` from `/foo` unless `REMOVE_DUPLICATE_SLASHES` is opted into, and same-document comparison with multi-slash paths. The remainder of #815's tests cover the new `Uri::rawPath()` helper and the construction-path consistency it introduces, which have no 2.12 counterpart. Everything here passes against 2.12 as-is, so this PR does not depend on #815 and can merge in either order, while keeping future merge-ups diff-minimal.
