### PR TITLE
Serialize rootless file URI paths without an authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Suppress exceptions from `FnStream` close callbacks during destructor cleanup
 - Make `CachingStream::close()` idempotent, preserving remote cleanup after detach
 - Normalize multiple leading slashes in `Uri::getPath()` and origin-form request targets
+- Serialize authority-less `file` URIs with rootless paths without the `//` separator
 - Harden URI host validation (delimiters, backslashes, IPv6, embedded ports); require schemes to start with a letter
 - Redact all non-empty URI userinfo in `Utils::redactUserInfo()`
 - Rebuild server request URIs from `$_SERVER` by `REQUEST_METHOD`, using target authority before `SERVER_PORT`

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -307,6 +307,11 @@ Reference resolution and normalization (`UriResolver`, `UriNormalizer`, and
 `Uri::isSameDocumentReference()`) operate on the raw path from the URI string
 form and are therefore unaffected by this normalization.
 
+Authority-less `file` URIs with rootless paths now serialize without the `//`
+authority separator: `(string) new Uri('file:foo/bar')` returns `file:foo/bar`
+instead of `file://foo/bar`, which reparses with host `foo` and path `/bar`.
+Rooted paths such as `file:///myfile` keep their existing serialization.
+
 #### HTTP Start-line Parsing
 
 `Message::parseRequest()` and `Message::parseResponse()` now validate HTTP

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -199,7 +199,8 @@ class Uri implements UriInterface, \JsonSerializable
      * for the "file" scheme. This is because PHP stream functions like `file_get_contents` only work with
      * `file:///myfile` but not with `file:/myfile` although they are equivalent according to RFC 3986. But
      * `file:///` is the more common syntax for the file scheme anyway (Chrome for example redirects to
-     * that format).
+     * that format). The separator is omitted when such a URI has a rootless non-empty path, as adding it
+     * would turn the first path segment into the authority of the composed URI.
      *
      * @see https://datatracker.ietf.org/doc/html/rfc3986#section-5.3
      */
@@ -212,7 +213,7 @@ class Uri implements UriInterface, \JsonSerializable
             $uri .= $scheme.':';
         }
 
-        if ($authority != '' || $scheme === 'file') {
+        if ($authority != '' || ($scheme === 'file' && ($path == '' || str_starts_with($path, '/')))) {
             $uri .= '//'.$authority;
         }
 

--- a/tests/UriNormalizerTest.php
+++ b/tests/UriNormalizerTest.php
@@ -158,6 +158,17 @@ class UriNormalizerTest extends TestCase
         self::assertSame('http://example.org//a%C2%B1b/path', (string) $normalizedUri);
     }
 
+    public function testNormalizePreservesRootlessFileUriFromExtendedInstances(): void
+    {
+        $uri = new class('file:foo/bar') extends Uri {
+        };
+
+        $normalizedUri = UriNormalizer::normalize($uri);
+
+        self::assertInstanceOf(UriInterface::class, $normalizedUri);
+        self::assertSame('file:foo/bar', (string) $normalizedUri);
+    }
+
     public function testSortQueryParameters(): void
     {
         $uri = new Uri('?lang=en&article=fred');
@@ -200,6 +211,8 @@ class UriNormalizerTest extends TestCase
             ['//example.org/', '//example.org/', true],
             ['file:/myfile', 'file:///myfile', true],
             ['file:///myfile', 'file://localhost/myfile', true],
+            ['file:foo', 'file:bar', false],
+            ['file:foo', 'file://foo', false],
         ];
     }
 

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -1105,6 +1105,17 @@ class UriTest extends TestCase
         self::assertSame('file:///tmp/filename.ext', (string) $uri);
     }
 
+    public function testFileUriWithoutAuthorityKeepsRootlessPath(): void
+    {
+        $uri = new Uri('file:foo/bar');
+
+        self::assertSame('foo/bar', $uri->getPath());
+        self::assertSame('file:foo/bar', (string) $uri);
+        self::assertSame('file:foo/bar', (string) new Uri((string) $uri));
+        self::assertSame('file:///foo', (string) new Uri('file:/foo'));
+        self::assertSame('file:////tmp', (string) new Uri('file:////tmp'));
+    }
+
     public static function uriComponentsEncodingProvider(): iterable
     {
         $unreserved = 'a-zA-Z0-9.-_~!$&\'()*+,;=:@';


### PR DESCRIPTION
`composeComponents()` adds the `//` authority separator for the `file` scheme even when the authority is empty, regardless of path shape. For an authority-less file URI with a rootless path this swallows the first path segment into the authority slot: `file:foo/bar` stringifies as `file://foo/bar`, which reparses as host `foo` and path `/bar`. The corruption makes `UriNormalizer::isEquivalent()` treat `file:foo` and `file://foo` as equivalent, rewrites such URIs held by `Uri` subclasses during normalization, and is the one family of states where `Uri::rawPath()` cannot agree with the string form.

The separator is now omitted when the authority is empty and the path is rootless, so these URIs serialize faithfully as `file:foo/bar` and round-trip. Absolute paths (`file:///foo`) and `//`-rooted paths (`file:////tmp`) keep their existing serialization, which was already faithful, and RFC 8089 does not permit rootless file paths, so no valid file URI changes. New tests pin the round-trip, the equivalence distinction, and normalization of subclass instances.
