### PR TITLE
Follow RFC 3986 when removing dot segments above the root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make `CachingStream::close()` idempotent, preserving remote cleanup after detach
 - Normalize multiple leading slashes in `Uri::getPath()` and origin-form request targets
 - Serialize authority-less `file` URIs with rootless paths without the `//` separator
+- Remove dot segments above the root per RFC 3986, prefixing authority-less `//` paths with `/.`
 - Harden URI host validation (delimiters, backslashes, IPv6, embedded ports); require schemes to start with a letter
 - Redact all non-empty URI userinfo in `Utils::redactUserInfo()`
 - Rebuild server request URIs from `$_SERVER` by `REQUEST_METHOD`, using target authority before `SERVER_PORT`

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -312,6 +312,15 @@ authority separator: `(string) new Uri('file:foo/bar')` returns `file:foo/bar`
 instead of `file://foo/bar`, which reparses with host `foo` and path `/bar`.
 Rooted paths such as `file:///myfile` keep their existing serialization.
 
+`UriResolver::removeDotSegments()` now applies RFC 3986 Section 5.2.4 to `..`
+segments above the root of an absolute path: excess `..` segments no longer
+consume the root, so a following empty segment is preserved. Resolving `/..//a`
+against `http://example.org/base` yields `http://example.org//a` where 2.x
+produced `http://example.org/a`. When the resulting URI has no authority,
+`UriResolver::resolve()` and `UriNormalizer::normalize()` serialize such a
+`//`-leading path with a `/.` prefix (`mailto:/.//a`), like the WHATWG URL
+Standard, instead of collapsing the slashes or throwing.
+
 #### HTTP Start-line Parsing
 
 `Message::parseRequest()` and `Message::parseResponse()` now validate HTTP

--- a/src/UriNormalizer.php
+++ b/src/UriNormalizer.php
@@ -145,18 +145,24 @@ final class UriNormalizer
             $uri = $uri->withPort(null);
         }
 
-        if ($flags & self::REMOVE_DOT_SEGMENTS && !Uri::isRelativePathReference($uri)) {
-            $uri = $uri->withPath(UriResolver::removeDotSegments(Uri::rawPath($uri)));
-        }
+        $removeDotSegments = ($flags & self::REMOVE_DOT_SEGMENTS) && !Uri::isRelativePathReference($uri);
 
-        if ($flags & self::REMOVE_DUPLICATE_SLASHES) {
-            $path = preg_replace('#//++#', '/', Uri::rawPath($uri));
+        if ($removeDotSegments || $flags & self::REMOVE_DUPLICATE_SLASHES) {
+            $path = Uri::rawPath($uri);
 
-            if ($path === null) {
-                throw new \RuntimeException('Unable to remove duplicate slashes from URI path: '.preg_last_error_msg());
+            if ($removeDotSegments) {
+                $path = UriResolver::removeDotSegments($path);
             }
 
-            $uri = $uri->withPath($path);
+            if ($flags & self::REMOVE_DUPLICATE_SLASHES) {
+                $path = preg_replace('#//++#', '/', $path);
+
+                if ($path === null) {
+                    throw new \RuntimeException('Unable to remove duplicate slashes from URI path: '.preg_last_error_msg());
+                }
+            }
+
+            $uri = $uri->withPath(UriResolver::guardedPath($uri, $path));
         }
 
         if ($flags & self::SORT_QUERY_PARAMETERS && $uri->getQuery() !== '') {

--- a/src/UriResolver.php
+++ b/src/UriResolver.php
@@ -18,6 +18,12 @@ final class UriResolver
     /**
      * Removes dot segments from a path and returns the new path.
      *
+     * Excess ".." segments above the root of an absolute path are dropped without
+     * consuming the root, so the result can begin with "//" (e.g. "/..//a" becomes
+     * "//a"). Such a path is not valid for a URI without an authority (RFC 3986
+     * Section 3.3); resolve() and UriNormalizer::normalize() serialize it with a
+     * "/." prefix in that case, like the WHATWG URL Standard.
+     *
      * @see https://datatracker.ietf.org/doc/html/rfc3986#section-5.2.4
      */
     public static function removeDotSegments(string $path): string
@@ -28,9 +34,15 @@ final class UriResolver
 
         $results = [];
         $segments = explode('/', $path);
+        // The first segment of an absolute path is the empty root marker producing the
+        // leading slash. RFC 3986 Section 5.2.4 (2C) drops ".." segments in excess of
+        // the path hierarchy without consuming the root, so it must never be popped.
+        $floor = $segments[0] === '' ? 1 : 0;
         foreach ($segments as $segment) {
             if ($segment === '..') {
-                array_pop($results);
+                if (count($results) > $floor) {
+                    array_pop($results);
+                }
             } elseif ($segment !== '.') {
                 $results[] = $segment;
             }
@@ -51,6 +63,28 @@ final class UriResolver
     }
 
     /**
+     * Returns the path, prefixed with "/." when it would otherwise start the URI's
+     * string form with an authority-like "//".
+     *
+     * A URI without an authority cannot hold a path beginning with "//" (RFC 3986
+     * Section 3.3), but removeDotSegments() can produce one. The "/." prefix
+     * serializes such a path unambiguously, the same way the WHATWG URL Standard
+     * does, and resolves back to the same path.
+     *
+     * @see https://url.spec.whatwg.org/#url-serializing
+     *
+     * @internal
+     */
+    public static function guardedPath(UriInterface $uri, string $path): string
+    {
+        if (str_starts_with($path, '//') && $uri->getAuthority() === '') {
+            return '/.'.$path;
+        }
+
+        return $path;
+    }
+
+    /**
      * Converts the relative URI into a new URI that is resolved against the base URI.
      *
      * @see https://datatracker.ietf.org/doc/html/rfc3986#section-5.2
@@ -63,7 +97,7 @@ final class UriResolver
         }
 
         if ($rel->getScheme() != '') {
-            return $rel->withPath(self::removeDotSegments(Uri::rawPath($rel)));
+            return $rel->withPath(self::guardedPath($rel, self::removeDotSegments(Uri::rawPath($rel))));
         }
 
         if ($rel->getAuthority() != '') {
@@ -100,7 +134,7 @@ final class UriResolver
         $targetPath = self::removeDotSegments($targetPath);
 
         return $base
-            ->withPath($targetPath)
+            ->withPath(self::guardedPath($base, $targetPath))
             ->withQuery($rel->getQuery())
             ->withFragment($rel->getFragment());
     }

--- a/src/UriResolver.php
+++ b/src/UriResolver.php
@@ -69,7 +69,9 @@ final class UriResolver
      * A URI without an authority cannot hold a path beginning with "//" (RFC 3986
      * Section 3.3), but removeDotSegments() can produce one. The "/." prefix
      * serializes such a path unambiguously, the same way the WHATWG URL Standard
-     * does, and resolves back to the same path.
+     * does, and resolves back to the same path. Hostless http and https Uri
+     * instances gain the default localhost host when the path is written, so the
+     * path cannot be mistaken for an authority and the prefix is not added.
      *
      * @see https://url.spec.whatwg.org/#url-serializing
      *
@@ -77,11 +79,15 @@ final class UriResolver
      */
     public static function guardedPath(UriInterface $uri, string $path): string
     {
-        if (str_starts_with($path, '//') && $uri->getAuthority() === '') {
-            return '/.'.$path;
+        if (!str_starts_with($path, '//') || $uri->getAuthority() !== '') {
+            return $path;
         }
 
-        return $path;
+        if ($uri instanceof Uri && ($uri->getScheme() === 'http' || $uri->getScheme() === 'https')) {
+            return $path;
+        }
+
+        return '/.'.$path;
     }
 
     /**

--- a/tests/UriNormalizerTest.php
+++ b/tests/UriNormalizerTest.php
@@ -149,6 +149,35 @@ class UriNormalizerTest extends TestCase
         self::assertSame('http://example.org//a/c/d.html', (string) $normalizedUri);
     }
 
+    public function testRemoveDotSegmentsAboveRootRetainsDuplicateSlashes(): void
+    {
+        $uri = new Uri('http://example.org/..//a/../..//b.html');
+        $normalizedUri = UriNormalizer::normalize($uri, UriNormalizer::REMOVE_DOT_SEGMENTS);
+
+        self::assertInstanceOf(UriInterface::class, $normalizedUri);
+        self::assertSame('http://example.org//b.html', (string) $normalizedUri);
+    }
+
+    public function testRemoveDotSegmentsGuardsPathOfAuthorityLessUri(): void
+    {
+        $uri = new Uri('urn:/..//x');
+        $normalizedUri = UriNormalizer::normalize($uri, UriNormalizer::REMOVE_DOT_SEGMENTS);
+
+        self::assertInstanceOf(UriInterface::class, $normalizedUri);
+        self::assertSame('urn:/.//x', (string) $normalizedUri);
+        // the "/." prefix is stable under repeated normalization
+        self::assertSame('urn:/.//x', (string) UriNormalizer::normalize($normalizedUri, UriNormalizer::REMOVE_DOT_SEGMENTS));
+    }
+
+    public function testRemoveDotSegmentsAndDuplicateSlashesOnAuthorityLessUri(): void
+    {
+        $uri = new Uri('urn:/..//x');
+        $normalizedUri = UriNormalizer::normalize($uri, UriNormalizer::REMOVE_DOT_SEGMENTS | UriNormalizer::REMOVE_DUPLICATE_SLASHES);
+
+        self::assertInstanceOf(UriInterface::class, $normalizedUri);
+        self::assertSame('urn:/x', (string) $normalizedUri);
+    }
+
     public function testPreservingNormalizationsRetainDuplicateSlashes(): void
     {
         $uri = new Uri('http://example.org//a%c2%b1b/./p%61th');
@@ -156,6 +185,15 @@ class UriNormalizerTest extends TestCase
 
         self::assertInstanceOf(UriInterface::class, $normalizedUri);
         self::assertSame('http://example.org//a%C2%B1b/path', (string) $normalizedUri);
+    }
+
+    public function testPreservingNormalizationsGuardPathOfAuthorityLessUri(): void
+    {
+        $uri = new Uri('urn:a/..///x');
+        $normalizedUri = UriNormalizer::normalize($uri);
+
+        self::assertInstanceOf(UriInterface::class, $normalizedUri);
+        self::assertSame('urn:/.//x', (string) $normalizedUri);
     }
 
     public function testNormalizePreservesRootlessFileUriFromExtendedInstances(): void
@@ -205,6 +243,9 @@ class UriNormalizerTest extends TestCase
             ['http://example.org/path?#', 'http://example.org/path', true],
             ['http://example.org:80', 'http://example.org/', true],
             ['http://example.org/../a/.././p%61th?%7a=%5e', 'http://example.org/path?z=%5E', true],
+            ['http://example.org/..//a', 'http://example.org//a', true],
+            ['http://example.org/..//a', 'http://example.org/a', false],
+            ['urn:/..//x', 'urn:/.//x', true],
             ['http://example.org/path#fr%61g%c2%b1', 'http://example.org/path#frag%C2%B1', true],
             ['https://example.org/', 'http://example.org/', false],
             ['https://example.org/', '//example.org/', false],

--- a/tests/UriNormalizerTest.php
+++ b/tests/UriNormalizerTest.php
@@ -169,6 +169,17 @@ class UriNormalizerTest extends TestCase
         self::assertSame('urn:/.//x', (string) UriNormalizer::normalize($normalizedUri, UriNormalizer::REMOVE_DOT_SEGMENTS));
     }
 
+    public function testRemoveDotSegmentsDoesNotGuardPathOfHostlessHttpUri(): void
+    {
+        $uri = new Uri('http:/a/..//b');
+        $normalizedUri = UriNormalizer::normalize($uri, UriNormalizer::REMOVE_DOT_SEGMENTS);
+
+        self::assertInstanceOf(UriInterface::class, $normalizedUri);
+        self::assertSame('http://localhost//b', (string) $normalizedUri);
+        // the default host makes the path unambiguous, keeping normalization idempotent
+        self::assertSame('http://localhost//b', (string) UriNormalizer::normalize($normalizedUri, UriNormalizer::REMOVE_DOT_SEGMENTS));
+    }
+
     public function testRemoveDotSegmentsAndDuplicateSlashesOnAuthorityLessUri(): void
     {
         $uri = new Uri('urn:/..//x');
@@ -246,6 +257,7 @@ class UriNormalizerTest extends TestCase
             ['http://example.org/..//a', 'http://example.org//a', true],
             ['http://example.org/..//a', 'http://example.org/a', false],
             ['urn:/..//x', 'urn:/.//x', true],
+            ['http:/a/..//b', 'http:/%61/..//b', true],
             ['http://example.org/path#fr%61g%c2%b1', 'http://example.org/path#frag%C2%B1', true],
             ['https://example.org/', 'http://example.org/', false],
             ['https://example.org/', '//example.org/', false],

--- a/tests/UriResolverTest.php
+++ b/tests/UriResolverTest.php
@@ -17,6 +17,14 @@ class UriResolverTest extends TestCase
     private const RFC3986_BASE = 'http://a/b/c/d;p?q';
 
     /**
+     * @dataProvider getRemoveDotSegmentsTestCases
+     */
+    public function testRemoveDotSegments(string $path, string $expectedPath): void
+    {
+        self::assertSame($expectedPath, UriResolver::removeDotSegments($path));
+    }
+
+    /**
      * @dataProvider getResolveTestCases
      */
     public function testResolveUri(string $base, string $rel, string $expectedTarget): void
@@ -162,6 +170,32 @@ class UriResolverTest extends TestCase
         self::assertSame((string) $targetUri, (string) UriResolver::resolve($baseUri, $relativeUri));
     }
 
+    public static function getRemoveDotSegmentsTestCases(): iterable
+    {
+        return [
+            ['', ''],
+            ['/', '/'],
+            // RFC 3986 Section 5.2.4 examples
+            ['/a/b/c/./../../g', '/a/g'],
+            ['mid/content=5/../6', 'mid/6'],
+            // ".." segments above the root of an absolute path are dropped without
+            // consuming the root, so a following empty segment is preserved
+            ['/..//a', '//a'],
+            ['/..//..//b', '//b'],
+            ['/a/../..//b', '//b'],
+            ['/..//', '//'],
+            ['/..', '/'],
+            ['/../..', '/'],
+            ['/a/..//b', '//b'],
+            ['//a', '//a'],
+            // rootless paths keep their historic behavior where excess ".." segments
+            // may consume the first segment entirely
+            ['a/../', ''],
+            ['..//..', ''],
+            ['a/..//a/b', '/a/b'],
+        ];
+    }
+
     public static function getResolveTestCases(): iterable
     {
         return [
@@ -268,6 +302,19 @@ class UriResolverTest extends TestCase
             ['http://a//b/c',    'x',             'http://a//b/x'],
             ['http://a/b/c',     'http://x//y/z', 'http://x//y/z'],
             ['http://a/b/c',     '//x//y/z',      'http://x//y/z'],
+            // ".." segments above the root do not consume the root, so a following
+            // empty segment is preserved (RFC 3986 Section 5.2.4)
+            [self::RFC3986_BASE, '/..//g',        'http://a//g'],
+            [self::RFC3986_BASE, '/..//..//g',    'http://a//g'],
+            ['http://a/b',       '..//g',         'http://a//g'],
+            ['http://a/b',       'http://x/..//y', 'http://x//y'],
+            ['http://a/b/c',     '//h/..//z',     'http://h//z'],
+            // paths starting with "//" on a URI without an authority are serialized
+            // with a "/." prefix like the WHATWG URL Standard
+            ['mailto:base',      '/..//e/x',      'mailto:/.//e/x'],
+            ['mailto:base',      'b/..///x',      'mailto:/.//x'],
+            ['urn:base/x',       'urn:a/..///x',  'urn:/.//x'],
+            ['/',                '/..//g',        '/.//g'],
             // base URI has less components than relative URI
             ['/',                '//a/b?q#h',     '//a/b?q#h'],
             ['/',                'urn:/',         'urn:/'],

--- a/tests/UriResolverTest.php
+++ b/tests/UriResolverTest.php
@@ -170,6 +170,13 @@ class UriResolverTest extends TestCase
         self::assertSame((string) $targetUri, (string) UriResolver::resolve($baseUri, $relativeUri));
     }
 
+    public function testResolveDoesNotGuardPathsOfHostlessHttpUris(): void
+    {
+        $targetUri = UriResolver::resolve(new Uri('http:/x'), new Uri('/..//b'));
+
+        self::assertSame('http://localhost//b', (string) $targetUri);
+    }
+
     public static function getRemoveDotSegmentsTestCases(): iterable
     {
         return [


### PR DESCRIPTION
`UriResolver::removeDotSegments()` implements RFC 3986 Section 5.2.4 with a segment stack whose unconditional `array_pop()` also consumes the empty segment marking an absolute path's root. An above-root `..` therefore swallowed a following empty segment: `removeDotSegments('/..//a')` returned `/a` where the RFC algorithm yields `//a`, resolution rewrote `http://example.org/..//a` into a URI identifying a different resource, and `UriNormalizer::isEquivalent()` reported two RFC-equivalent URIs as different under the default preserving normalizations. The stack now stops popping at the root marker, which matches the RFC output for every absolute path (verified exhaustively against a literal transcription of the specification) while leaving rootless paths untouched, since their deviation from the RFC's absolutizing outputs is deliberate and existing relativization round-trips depend on it.

A path produced this way can begin with `//`, which RFC 3986 Section 3.3 forbids on a URI without an authority and `Uri::withPath()` already rejects. Instead of throwing or corrupting the target, `UriResolver::resolve()` and `UriNormalizer::normalize()` now serialize such paths with a `/.` prefix, so resolving `/..//e/x` against `mailto:base` yields `mailto:/.//e/x`. This is the WHATWG URL Standard's serializer behavior, shipped by browsers and matched by curl; the prefix is stable under repeated resolution and normalization and cannot be misread as a protocol-relative URL. It also fixes existing crashes where `resolve()` and `normalize()` threw `MalformedUriException` for valid inputs like `b/..///x` against `mailto:base`.

This is a deliberate divergence from 2.x for above-root `..` followed by an empty segment, documented in `UPGRADING.md` alongside the raw-path resolution notes. It lands on 3.0 only: on 2.x the raw `getPath()` would expose `//`-leading paths that the 3.0 `getPath()` normalization guards, and the collapsing behavior there has shipped unchanged for years. With this change, `REMOVE_DUPLICATE_SLASHES` remains the sole normalization that collapses duplicate slashes, completing the 3.0 policy that dot-segment removal must not alter empty segments.
