### PR TITLE
Relativize same-authority empty-path targets as network paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Normalize multiple leading slashes in `Uri::getPath()` and origin-form request targets
 - Serialize authority-less `file` URIs with rootless paths without the `//` separator
 - Remove dot segments above the root per RFC 3986, prefixing authority-less `//` paths with `/.`
-- Return a network-path reference from `UriResolver::relativize()` for same-authority targets with an empty path
+- Return a network-path reference from `UriResolver::relativize()` when an empty-path target requires one
 - Harden URI host validation (delimiters, backslashes, IPv6, embedded ports); require schemes to start with a letter
 - Redact all non-empty URI userinfo in `Utils::redactUserInfo()`
 - Rebuild server request URIs from `$_SERVER` by `REQUEST_METHOD`, using target authority before `SERVER_PORT`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Normalize multiple leading slashes in `Uri::getPath()` and origin-form request targets
 - Serialize authority-less `file` URIs with rootless paths without the `//` separator
 - Remove dot segments above the root per RFC 3986, prefixing authority-less `//` paths with `/.`
+- Return a network-path reference from `UriResolver::relativize()` for same-authority targets with an empty path
 - Harden URI host validation (delimiters, backslashes, IPv6, embedded ports); require schemes to start with a letter
 - Redact all non-empty URI userinfo in `Utils::redactUserInfo()`
 - Rebuild server request URIs from `$_SERVER` by `REQUEST_METHOD`, using target authority before `SERVER_PORT`

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -321,6 +321,30 @@ produced `http://example.org/a`. When the resulting URI has no authority,
 `//`-leading path with a `/.` prefix (`mailto:/.//a`), like the WHATWG URL
 Standard, instead of collapsing the slashes or throwing.
 
+#### URI Reference Relativization
+
+`UriResolver::relativize()` now returns a network-path reference (for example
+`//example.com`) when the target URI has the same authority as the base URI
+but an empty path. No path reference can express such a target, as resolving
+one always produces a path of at least `/`. The returned reference now
+resolves back to the exact target string, restoring the documented round-trip
+guarantee.
+
+```php
+$base = new Uri('http://example.com/a');
+$target = new Uri('http://example.com');
+
+// 2.x
+(string) UriResolver::relativize($base, $target); // ../
+// which resolved back to http://example.com/
+
+// 3.0
+(string) UriResolver::relativize($base, $target); // //example.com
+```
+
+The same applies when the base URI has a query component that an empty
+relative reference would otherwise inherit.
+
 #### HTTP Start-line Parsing
 
 `Message::parseRequest()` and `Message::parseResponse()` now validate HTTP

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -325,10 +325,12 @@ Standard, instead of collapsing the slashes or throwing.
 
 `UriResolver::relativize()` now returns a network-path reference (for example
 `//example.com`) when the target URI has the same authority as the base URI
-but an empty path. No path reference can express such a target, as resolving
-one always produces a path of at least `/`. The returned reference now
-resolves back to the exact target string, restoring the documented round-trip
-guarantee.
+but an empty path that no other relative reference round-trips. No path
+reference can express such a target, as resolving one always produces a path
+of at least `/`, and an empty reference would keep the base path or inherit
+the base query or fragment. The returned reference resolves back to the
+exact target string, restoring the documented round-trip guarantee for these
+targets.
 
 ```php
 $base = new Uri('http://example.com/a');
@@ -342,8 +344,10 @@ $target = new Uri('http://example.com');
 (string) UriResolver::relativize($base, $target); // //example.com
 ```
 
-The same applies when the base URI has a query component that an empty
-relative reference would otherwise inherit.
+The same applies when the base URI has a query or fragment component that an
+empty relative reference would otherwise inherit. When the base URI has an
+empty path as well and nothing would be inherited, shorter references such
+as the empty reference, `#fragment` or `?query` are still returned.
 
 #### HTTP Start-line Parsing
 

--- a/docs/uri-helpers.md
+++ b/docs/uri-helpers.md
@@ -189,6 +189,7 @@ echo UriResolver::relativize($base, new Uri('http://example.com/a/b/c'));  // pr
 echo UriResolver::relativize($base, new Uri('http://example.com/a/x/y'));  // prints '../x/y'.
 echo UriResolver::relativize($base, new Uri('http://example.com/a/b/?q')); // prints '?q'.
 echo UriResolver::relativize($base, new Uri('http://example.org/a/b/'));   // prints '//example.org/a/b/'.
+echo UriResolver::relativize($base, new Uri('http://example.com'));         // prints '//example.com'.
 ```
 
 ## Normalization and Comparison

--- a/src/UriResolver.php
+++ b/src/UriResolver.php
@@ -188,9 +188,11 @@ final class UriResolver
 
         // A target with the same authority as the base but an empty path can only be expressed by a network-path
         // reference, as resolving a path reference always produces a path of at least "/" and an empty reference
-        // would keep the base path or inherit the base query (RFC 3986 Section 5.2.2).
+        // would keep the base path or inherit the base query or fragment (RFC 3986 Section 5.2.2).
         if ($target->getAuthority() !== '' && Uri::rawPath($target) === ''
-            && (Uri::rawPath($base) !== '' || ($base->getQuery() !== '' && $target->getQuery() === ''))
+            && (Uri::rawPath($base) !== ''
+                || ($base->getQuery() !== '' && $target->getQuery() === '')
+                || ($base->getFragment() !== '' && $target->getFragment() === '' && $base->getQuery() === $target->getQuery()))
         ) {
             return $target->withScheme('');
         }

--- a/src/UriResolver.php
+++ b/src/UriResolver.php
@@ -160,6 +160,7 @@ final class UriResolver
      *    echo UriResolver::relativize($base, new Uri('http://example.com/a/x/y'));  // prints '../x/y'.
      *    echo UriResolver::relativize($base, new Uri('http://example.com/a/b/?q')); // prints '?q'.
      *    echo UriResolver::relativize($base, new Uri('http://example.org/a/b/'));   // prints '//example.org/a/b/'.
+     *    echo UriResolver::relativize($base, new Uri('http://example.com'));         // prints '//example.com'.
      *
      * This method also accepts a target that is already relative and will try to relativize it further. Only a
      * relative-path reference will be returned as-is.
@@ -182,6 +183,15 @@ final class UriResolver
         }
 
         if ($target->getAuthority() !== '' && $base->getAuthority() !== $target->getAuthority()) {
+            return $target->withScheme('');
+        }
+
+        // A target with the same authority as the base but an empty path can only be expressed by a network-path
+        // reference, as resolving a path reference always produces a path of at least "/" and an empty reference
+        // would keep the base path or inherit the base query (RFC 3986 Section 5.2.2).
+        if ($target->getAuthority() !== '' && Uri::rawPath($target) === ''
+            && (Uri::rawPath($base) !== '' || ($base->getQuery() !== '' && $target->getQuery() === ''))
+        ) {
             return $target->withScheme('');
         }
 

--- a/src/UriResolver.php
+++ b/src/UriResolver.php
@@ -186,14 +186,9 @@ final class UriResolver
             return $target->withScheme('');
         }
 
-        // A target with the same authority as the base but an empty path can only be expressed by a network-path
-        // reference, as resolving a path reference always produces a path of at least "/" and an empty reference
-        // would keep the base path or inherit the base query or fragment (RFC 3986 Section 5.2.2).
-        if ($target->getAuthority() !== '' && Uri::rawPath($target) === ''
-            && (Uri::rawPath($base) !== ''
-                || ($base->getQuery() !== '' && $target->getQuery() === '')
-                || ($base->getFragment() !== '' && $target->getFragment() === '' && $base->getQuery() === $target->getQuery()))
-        ) {
+        // A same-authority target with an empty path can only be expressed by a
+        // network-path reference (RFC 3986 Section 5.2.2).
+        if (self::needsNetworkPathReference($base, $target)) {
             return $target->withScheme('');
         }
 
@@ -222,6 +217,25 @@ final class UriResolver
         }
 
         return $emptyPathUri;
+    }
+
+    /**
+     * Whether relativizing to $target requires a network-path reference.
+     *
+     * A same-authority target with an empty path is expressible by a shorter
+     * relative reference unless resolving one would inherit a base component
+     * the target lacks: the base path (kept by any empty-path reference), or
+     * the base query or fragment (inherited by the empty reference).
+     */
+    private static function needsNetworkPathReference(UriInterface $base, UriInterface $target): bool
+    {
+        if ($target->getAuthority() === '' || Uri::rawPath($target) !== '') {
+            return false;
+        }
+
+        return Uri::rawPath($base) !== ''
+            || ($base->getQuery() !== '' && $target->getQuery() === '')
+            || ($base->getFragment() !== '' && $target->getFragment() === '' && $base->getQuery() === $target->getQuery());
     }
 
     private static function getRelativePath(UriInterface $base, UriInterface $target): string

--- a/tests/UriResolverTest.php
+++ b/tests/UriResolverTest.php
@@ -311,6 +311,7 @@ class UriResolverTest extends TestCase
             ['urn://h/path',     '//h',           'urn://h'],
             ['urn://h/path',     '//h?q',         'urn://h?q'],
             ['http://h/',        '//h',           'http://h'],
+            ['urn://h#f',        '//h',           'urn://h'],
             // empty base path and relative-path reference
             ['//example.com',    'a',             '//example.com/a'],
             // path starting with two slashes
@@ -385,6 +386,13 @@ class UriResolverTest extends TestCase
             // same for an empty-path reference that would inherit the base query
             ['urn://h?bq',      'urn://h',      '//h'],
             ['urn://h?bq',      'urn://h?q',    '?q'],
+            // same for an empty-path reference that would inherit the base fragment
+            ['urn://h#bf',      'urn://h',      '//h'],
+            ['urn://h?q#bf',    'urn://h?q',    '//h?q'],
+            ['//h#bf',          '//h',          '//h'],
+            // nothing is inherited when the target has its own fragment or a different query
+            ['urn://h#bf',      'urn://h#f',    '#f'],
+            ['urn://h#bf',      'urn://h?q',    '?q'],
             // an empty base path needs no network-path reference when nothing would be inherited
             ['urn://h',         'urn://h',      ''],
             ['urn://h',         'urn://h#f',    '#f'],

--- a/tests/UriResolverTest.php
+++ b/tests/UriResolverTest.php
@@ -380,6 +380,9 @@ class UriResolverTest extends TestCase
             ['urn://h/path',    'urn://h#f',    '//h#f'],
             ['urn://h/path?bq', 'urn://h',      '//h'],
             ['http://h/a/b/c',  'http://h',     '//h'],
+            // the network-path reference keeps the port and userinfo of the target authority
+            ['http://h:8080/path', 'http://h:8080', '//h:8080'],
+            ['http://u:p@h/path',  'http://u:p@h',  '//u:p@h'],
             // "http://h" and "http://h/" are distinct strings and must round-trip exactly
             ['http://h/',       'http://h',     '//h'],
             ['urn://h/path',    'urn://h/',     './'],

--- a/tests/UriResolverTest.php
+++ b/tests/UriResolverTest.php
@@ -170,6 +170,16 @@ class UriResolverTest extends TestCase
         self::assertSame((string) $targetUri, (string) UriResolver::resolve($baseUri, $relativeUri));
     }
 
+    public function testRelativizeAndResolveWithSameAuthorityEmptyPathTargetRoundTrips(): void
+    {
+        $baseUri = new Uri('urn://example.com/a/b');
+        $targetUri = new Uri('urn://example.com');
+        $relativeUri = UriResolver::relativize($baseUri, $targetUri);
+
+        self::assertSame('//example.com', (string) $relativeUri);
+        self::assertSame((string) $targetUri, (string) UriResolver::resolve($baseUri, $relativeUri));
+    }
+
     public function testResolveDoesNotGuardPathsOfHostlessHttpUris(): void
     {
         $targetUri = UriResolver::resolve(new Uri('http:/x'), new Uri('/..//b'));
@@ -297,6 +307,10 @@ class UriResolverTest extends TestCase
             ['/',                '..',            '/'],
             ['urn:a/b',          '..//a/b',       'urn:/a/b'],
             // network path references
+            // same-authority target with an empty path
+            ['urn://h/path',     '//h',           'urn://h'],
+            ['urn://h/path',     '//h?q',         'urn://h?q'],
+            ['http://h/',        '//h',           'http://h'],
             // empty base path and relative-path reference
             ['//example.com',    'a',             '//example.com/a'],
             // path starting with two slashes
@@ -359,6 +373,24 @@ class UriResolverTest extends TestCase
             ['http://a/b/',     '/',            '../'],
             // absolute target URI without authority but base URI has one
             ['urn://a/b/',      'urn:/b/',      'urn:/b/'],
+            // a same-authority target with an empty path can only be a network-path reference,
+            // as any path reference would resolve to a path of at least "/"
+            ['urn://h/path',    'urn://h',      '//h'],
+            ['urn://h/path',    'urn://h#f',    '//h#f'],
+            ['urn://h/path?bq', 'urn://h',      '//h'],
+            ['http://h/a/b/c',  'http://h',     '//h'],
+            // "http://h" and "http://h/" are distinct strings and must round-trip exactly
+            ['http://h/',       'http://h',     '//h'],
+            ['urn://h/path',    'urn://h/',     './'],
+            // same for an empty-path reference that would inherit the base query
+            ['urn://h?bq',      'urn://h',      '//h'],
+            ['urn://h?bq',      'urn://h?q',    '?q'],
+            // an empty base path needs no network-path reference when nothing would be inherited
+            ['urn://h',         'urn://h',      ''],
+            ['urn://h',         'urn://h#f',    '#f'],
+            ['urn://h',         'urn://h?q',    '?q'],
+            // an empty-path target with a different authority uses a network-path reference as well
+            ['http://h/a/b',    'http://other', '//other'],
         ];
     }
 


### PR DESCRIPTION
`UriResolver::relativize()` documents a round-trip invariant: `(string) $target === (string) UriResolver::resolve($base, UriResolver::relativize($base, $target))`. It was violated whenever the target shared the base's authority but had an empty path. For example, `relativize(new Uri('urn://h/path'), new Uri('urn://h'))` returned `../`, which resolves to `urn://h/` — a different URI string, and outside of http(s) a genuinely different resource, since only those schemes define an empty path as equivalent to `/`. Query and fragment variants failed the same way, as did the empty-base-path corner `relativize(new Uri('urn://h?q'), new Uri('urn://h'))`, which returned `./`. A base fragment failed the same way: `relativize(new Uri('urn://h#f'), new Uri('urn://h'))` returned the empty reference, which resolves back to the base itself, fragment included.

No path reference can express such a target: per RFC 3986 section 5.2, resolving a reference that carries a path against an authority-bearing base always produces a target path of at least `/`, and an empty-path reference keeps the base path and inherits its query and fragment. A network-path reference such as `//h` is the only relative form that resolves back to the target, and `relativize()` already returns network-path references for cross-authority targets. The new branch fires only when the target has the base's authority and an empty raw path, and the base has a non-empty path, or a query or fragment that would be inherited; no existing test row changes output.

The new provider rows cover the query, fragment, base-query, and base-fragment corners, exact round-trips for the distinct strings `http://h` and `http://h/`, and pins for the unchanged same-document, query-only, fragment-only, and cross-authority forms, alongside a round-trip regression test. The docblock, `docs/uri-helpers.md`, `CHANGELOG.md`, and `UPGRADING.md` document the new output. Corners no relative reference can express, such as relativizing `urn:` against the authority-less rooted base `urn:/a/b`, are unchanged.
