### PR TITLE
Treat host-less origin-form `//` targets as paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Anchor server port and response start-line patterns to the true end of input
+- Treat host-less origin-form request targets starting with `//` as paths in `Message::parseRequest()`
 
 ## 2.12.3 - 2026-06-23
 

--- a/src/Message.php
+++ b/src/Message.php
@@ -265,19 +265,24 @@ final class Message
         $host = self::getHostFromHeaders($headers);
 
         // If no host is found, then a full URI cannot be constructed.
+        // Collapse leading slashes so an origin-form target cannot be
+        // parsed as a network-path reference with its own authority.
         if ($host === null) {
-            // Collapse leading slashes so an origin-form target cannot be
-            // parsed as a network-path reference with its own authority.
-            if (0 === strpos($path, '//')) {
-                return '/'.ltrim($path, '/');
-            }
-
-            return $path;
+            return self::normalizePathForOriginForm($path);
         }
 
         $scheme = substr($host, -4) === ':443' ? 'https' : 'http';
 
         return $scheme.'://'.$host.'/'.ltrim($path, '/');
+    }
+
+    private static function normalizePathForOriginForm(string $path): string
+    {
+        if (0 === strpos($path, '//')) {
+            return '/'.ltrim($path, '/');
+        }
+
+        return $path;
     }
 
     /**

--- a/src/Message.php
+++ b/src/Message.php
@@ -266,6 +266,12 @@ final class Message
 
         // If no host is found, then a full URI cannot be constructed.
         if ($host === null) {
+            // Collapse leading slashes so an origin-form target cannot be
+            // parsed as a network-path reference with its own authority.
+            if (0 === strpos($path, '//')) {
+                return '/'.ltrim($path, '/');
+            }
+
             return $path;
         }
 

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -182,6 +182,7 @@ class MessageTest extends TestCase
         yield 'authority-like target with query' => ['//evil.example/x?q=1', '/evil.example/x?q=1'];
         yield 'double slash only' => ['//', '/'];
         yield 'triple slash' => ['///x', '/x'];
+        yield 'internal double slash preserved' => ['//evil.example//x', '/evil.example//x'];
     }
 
     public function testParseRequestCollapsesMultiSlashTargetWithHostHeader(): void
@@ -210,6 +211,15 @@ class MessageTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
 
         Psr7\Message::parseRequest("GET http://[::1/ HTTP/1.1\r\n\r\n");
+    }
+
+    public function testParseRequestKeepsAbsoluteFormTargetWithMultiSlashPath(): void
+    {
+        $request = Psr7\Message::parseRequest("GET https://up.example//admin HTTP/1.1\r\n\r\n");
+
+        self::assertSame('https://up.example//admin', $request->getRequestTarget());
+        self::assertSame('up.example', $request->getUri()->getHost());
+        self::assertSame('https://up.example//admin', (string) $request->getUri());
     }
 
     public function testParsesRequestMessagesWithCustomMethod(): void

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -163,6 +163,36 @@ class MessageTest extends TestCase
         self::assertSame('/abc', (string) $request->getUri());
     }
 
+    /**
+     * @dataProvider hostlessMultiSlashTargetProvider
+     */
+    public function testParseRequestTreatsHostlessMultiSlashTargetAsPath(string $target, string $expected): void
+    {
+        $request = Psr7\Message::parseRequest("GET {$target} HTTP/1.1\r\nFoo: bar\r\n\r\n");
+
+        self::assertSame($expected, (string) $request->getUri());
+        self::assertSame('', $request->getUri()->getHost());
+        self::assertFalse($request->hasHeader('Host'));
+        self::assertSame($expected, $request->getRequestTarget());
+    }
+
+    public static function hostlessMultiSlashTargetProvider(): iterable
+    {
+        yield 'authority-like target' => ['//evil.example/x', '/evil.example/x'];
+        yield 'authority-like target with query' => ['//evil.example/x?q=1', '/evil.example/x?q=1'];
+        yield 'double slash only' => ['//', '/'];
+        yield 'triple slash' => ['///x', '/x'];
+    }
+
+    public function testParseRequestCollapsesMultiSlashTargetWithHostHeader(): void
+    {
+        $request = Psr7\Message::parseRequest("GET //evil.example/x HTTP/1.1\r\nHost: good.example\r\n\r\n");
+
+        self::assertSame('http://good.example/evil.example/x', (string) $request->getUri());
+        self::assertSame('good.example', $request->getHeaderLine('Host'));
+        self::assertSame('/evil.example/x', $request->getRequestTarget());
+    }
+
     public function testParsesRequestMessagesWithFullUri(): void
     {
         $req = "GET https://www.google.com:443/search?q=foobar HTTP/1.1\r\nHost: www.google.com\r\n\r\n";


### PR DESCRIPTION
`Message::parseRequest()` falls back to the raw request target when no `Host` header is present, so `GET //evil.example/x HTTP/1.1` is parsed as a network-path reference: `evil.example` is promoted to the URI authority, a `Host: evil.example` header is synthesized from it, and the request target collapses to `/x`. A request that carries no `Host` header at all thus ends up with an attacker-controlled authority, while the same target sent with a `Host` header is already correctly treated as a plain path.

`Message::parseRequestUri()` now collapses the leading slashes in its host-less fallback so the target stays a path-only URI: the request above yields the URI `/evil.example/x`, an empty URI host, no synthesized `Host` header, and the request target `/evil.example/x`, matching how `//`-prefixed targets are already normalized when a `Host` header is present. Only host-less origin-form targets beginning with `//` change behavior; this includes bare `//` and `///x`, which previously failed with `MalformedUriException` and now parse as the paths `/` and `/x`. Every other input is byte-identical. The same fix lands on the 3.0 branch in the sibling pull request #822.
