### PR TITLE
Serialize authority-less empty-path file URIs as `file:`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make `CachingStream::close()` idempotent, preserving remote cleanup after detach
 - Normalize multiple leading slashes in `Uri::getPath()` and origin-form request targets
 - Serialize authority-less `file` URIs with rootless paths without the `//` separator
+- Serialize authority-less `file` URIs with empty paths as `file:` instead of the unparseable `file://`
 - Remove dot segments above the root per RFC 3986, prefixing authority-less `//` paths with `/.`
 - Return a network-path reference from `UriResolver::relativize()` when an empty-path target requires one
 - Harden URI host validation (delimiters, backslashes, IPv6, embedded ports); require schemes to start with a letter

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -312,6 +312,12 @@ authority separator: `(string) new Uri('file:foo/bar')` returns `file:foo/bar`
 instead of `file://foo/bar`, which reparses with host `foo` and path `/bar`.
 Rooted paths such as `file:///myfile` keep their existing serialization.
 
+Authority-less `file` URIs with empty paths now serialize as `file:` instead of
+`file://`, which `new Uri()` itself rejects as unparseable. This affects
+degenerate URIs such as `new Uri('file:')` or
+`Uri::fromParts(['scheme' => 'file'])`; the serialization of every file URI
+with a non-empty path is unchanged.
+
 `UriResolver::removeDotSegments()` now applies RFC 3986 Section 5.2.4 to `..`
 segments above the root of an absolute path: excess `..` segments no longer
 consume the root, so a following empty segment is preserved. Resolving `/..//a`

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -199,8 +199,9 @@ class Uri implements UriInterface, \JsonSerializable
      * for the "file" scheme. This is because PHP stream functions like `file_get_contents` only work with
      * `file:///myfile` but not with `file:/myfile` although they are equivalent according to RFC 3986. But
      * `file:///` is the more common syntax for the file scheme anyway (Chrome for example redirects to
-     * that format). The separator is omitted when such a URI has a rootless non-empty path, as adding it
-     * would turn the first path segment into the authority of the composed URI.
+     * that format). The separator is omitted when such a URI has a rootless or empty path: adding it would
+     * turn the first path segment into the authority of the composed URI, or compose the string `file://`,
+     * which cannot be parsed back into a URI.
      *
      * @see https://datatracker.ietf.org/doc/html/rfc3986#section-5.3
      */
@@ -213,7 +214,7 @@ class Uri implements UriInterface, \JsonSerializable
             $uri .= $scheme.':';
         }
 
-        if ($authority != '' || ($scheme === 'file' && ($path == '' || str_starts_with($path, '/')))) {
+        if ($authority != '' || ($scheme === 'file' && str_starts_with($path, '/'))) {
             $uri .= '//'.$authority;
         }
 

--- a/tests/UriNormalizerTest.php
+++ b/tests/UriNormalizerTest.php
@@ -91,6 +91,15 @@ class UriNormalizerTest extends TestCase
         self::assertSame('file:///myfile', (string) $normalizedUri);
     }
 
+    public function testRemoveDefaultHostWithEmptyPath(): void
+    {
+        $uri = new Uri('file://localhost');
+        $normalizedUri = UriNormalizer::normalize($uri, UriNormalizer::REMOVE_DEFAULT_HOST);
+
+        self::assertInstanceOf(UriInterface::class, $normalizedUri);
+        self::assertSame('file:', (string) $normalizedUri);
+    }
+
     public function testRemoveDefaultPort(): void
     {
         $uri = $this->createMock(UriInterface::class);

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -1127,6 +1127,16 @@ class UriTest extends TestCase
         self::assertSame('file:', (string) (new Uri('file:///x'))->withPath(''));
     }
 
+    public function testFileUriWithoutAuthorityAndPathKeepsQueryAndFragment(): void
+    {
+        self::assertSame('file:?q', (string) new Uri('file:?q'));
+        self::assertSame('file:?q', (string) new Uri((string) new Uri('file:?q')));
+        self::assertSame('file:#f', (string) new Uri('file:#f'));
+        self::assertSame('file:#f', (string) new Uri((string) new Uri('file:#f')));
+        self::assertSame('file:?q#f', (string) new Uri('file:?q#f'));
+        self::assertSame('file:?q#f', (string) new Uri((string) new Uri('file:?q#f')));
+    }
+
     /**
      * @dataProvider composeComponentsProvider
      */
@@ -1149,6 +1159,9 @@ class UriTest extends TestCase
         yield 'file separator omitted for authority-less rootless path' => ['file', '', 'foo/bar', '', '', 'file:foo/bar'];
         yield 'file separator omitted for authority-less empty path' => ['file', '', '', '', '', 'file:'];
         yield 'file separator omitted for null authority and empty path' => ['file', null, '', null, null, 'file:'];
+        yield 'file separator omitted for authority-less empty path with query' => ['file', '', '', 'q', '', 'file:?q'];
+        yield 'file separator omitted for authority-less empty path with fragment' => ['file', '', '', '', 'f', 'file:#f'];
+        yield 'file separator omitted for authority-less empty path with query and fragment' => ['file', '', '', 'q', 'f', 'file:?q#f'];
     }
 
     public static function uriComponentsEncodingProvider(): iterable

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -1116,6 +1116,41 @@ class UriTest extends TestCase
         self::assertSame('file:////tmp', (string) new Uri('file:////tmp'));
     }
 
+    public function testFileUriWithoutAuthorityAndPathSerializesWithoutSeparator(): void
+    {
+        $uri = new Uri('file:');
+
+        self::assertSame('', $uri->getPath());
+        self::assertSame('file:', (string) $uri);
+        self::assertSame('file:', (string) new Uri((string) $uri));
+        self::assertSame('file:', (string) Uri::fromParts(['scheme' => 'file']));
+        self::assertSame('file:', (string) (new Uri('file:///x'))->withPath(''));
+    }
+
+    /**
+     * @dataProvider composeComponentsProvider
+     */
+    public function testComposeComponents(?string $scheme, ?string $authority, string $path, ?string $query, ?string $fragment, string $expected): void
+    {
+        self::assertSame($expected, Uri::composeComponents($scheme, $authority, $path, $query, $fragment));
+    }
+
+    /**
+     * @return iterable<string, array{0: ?string, 1: ?string, 2: string, 3: ?string, 4: ?string, 5: string}>
+     */
+    public static function composeComponentsProvider(): iterable
+    {
+        yield 'all components' => ['http', 'user:pass@example.com:8080', '/path', 'query', 'fragment', 'http://user:pass@example.com:8080/path?query#fragment'];
+        yield 'null components compose like empty strings' => [null, null, '', null, null, ''];
+        yield 'relative path only' => ['', '', 'foo', '', '', 'foo'];
+        yield 'rootless path is rooted under an authority' => ['http', 'example.com', 'foo', '', '', 'http://example.com/foo'];
+        yield 'file with authority' => ['file', 'localhost', '/myfile', '', '', 'file://localhost/myfile'];
+        yield 'file separator added for authority-less rooted path' => ['file', '', '/myfile', '', '', 'file:///myfile'];
+        yield 'file separator omitted for authority-less rootless path' => ['file', '', 'foo/bar', '', '', 'file:foo/bar'];
+        yield 'file separator omitted for authority-less empty path' => ['file', '', '', '', '', 'file:'];
+        yield 'file separator omitted for null authority and empty path' => ['file', null, '', null, null, 'file:'];
+    }
+
     public static function uriComponentsEncodingProvider(): iterable
     {
         $unreserved = 'a-zA-Z0-9.-_~!$&\'()*+,;=:@';


### PR DESCRIPTION
Following up on #817, `composeComponents()` still emits the `//` authority separator for authority-less `file` URIs with empty paths, composing `file://` — a string `new Uri()` itself rejects with `MalformedUriException`, so `(string) new Uri('file:')` produces output that cannot be parsed back at all. The separator is now omitted for empty paths too, so these degenerate URIs serialize as `file:` and round-trip to the same components; rooted forms such as `file:///myfile` are unchanged, and RFC 8089 permits neither `file:` nor `file://`, so no valid file URI changes.

This adds the direct `Uri::composeComponents()` coverage requested in review — a data provider across each branch of the file-scheme condition, null components, and authority/rootless combinations only reachable by calling the method directly — plus round-trip pins for empty-path `file:` URIs carrying a query or fragment, and for `UriNormalizer::REMOVE_DEFAULT_HOST` collapsing `file://localhost` to `file:` where it previously produced the unparseable `file://`.
