### PR TITLE
Treat host-less origin-form `//` targets as paths

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -293,14 +293,25 @@ final class Message
         $host = self::getHostFromHeaders($headers);
 
         // If no host is found, then a full URI cannot be constructed.
+        // Collapse leading slashes so an origin-form target cannot be
+        // parsed as a network-path reference with its own authority.
         if ($host === null) {
-            return $path;
+            return self::normalizePathForOriginForm($path);
         }
 
         [$authorityHost, $port] = self::parseHostHeaderAuthority($host);
         $scheme = $port === 443 ? 'https' : 'http';
 
         return $scheme.'://'.self::composeAuthority($authorityHost, $port).'/'.ltrim($path, '/');
+    }
+
+    private static function normalizePathForOriginForm(string $path): string
+    {
+        if (str_starts_with($path, '//')) {
+            return '/'.ltrim($path, '/');
+        }
+
+        return $path;
     }
 
     /**

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -297,6 +297,7 @@ class MessageTest extends TestCase
         yield 'authority-like target with query' => ['//evil.example/x?q=1', '/evil.example/x?q=1'];
         yield 'double slash only' => ['//', '/'];
         yield 'triple slash' => ['///x', '/x'];
+        yield 'internal double slash preserved' => ['//evil.example//x', '/evil.example//x'];
     }
 
     public function testParseRequestCollapsesMultiSlashTargetWithHostHeader(): void
@@ -346,6 +347,15 @@ class MessageTest extends TestCase
         self::assertSame('https://up.example/admin', $request->getRequestTarget());
         self::assertSame('up.example', $request->getHeaderLine('Host'));
         self::assertSame('https://up.example/admin', (string) $request->getUri());
+    }
+
+    public function testParseAbsoluteFormPreservesMultiSlashPath(): void
+    {
+        $request = Psr7\Message::parseRequest("GET https://up.example//admin HTTP/1.1\r\n\r\n");
+
+        self::assertSame('https://up.example//admin', $request->getRequestTarget());
+        self::assertSame('up.example', $request->getUri()->getHost());
+        self::assertSame('https://up.example//admin', (string) $request->getUri());
     }
 
     public function testParsesOptionsAsteriskFormRequestTarget(): void

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -230,6 +230,11 @@ class MessageTest extends TestCase
         Psr7\Message::parseRequestUri('/', ['Host' => ['one.example', 'two.example']]);
     }
 
+    public function testParseRequestUriCollapsesHostlessMultiSlashPath(): void
+    {
+        self::assertSame('/evil.example/x', Psr7\Message::parseRequestUri('//evil.example/x', []));
+    }
+
     /**
      * @dataProvider invalidHostHeaderProvider
      */
@@ -271,6 +276,36 @@ class MessageTest extends TestCase
         $request = Psr7\Message::parseRequest("GET /abc HTTP/1.1\r\nFoo: bar\r\n\r\n");
 
         self::assertSame('/abc', (string) $request->getUri());
+    }
+
+    /**
+     * @dataProvider hostlessMultiSlashTargetProvider
+     */
+    public function testParseRequestTreatsHostlessMultiSlashTargetAsPath(string $target, string $expected): void
+    {
+        $request = Psr7\Message::parseRequest("GET {$target} HTTP/1.1\r\nFoo: bar\r\n\r\n");
+
+        self::assertSame($expected, (string) $request->getUri());
+        self::assertSame('', $request->getUri()->getHost());
+        self::assertFalse($request->hasHeader('Host'));
+        self::assertSame($expected, $request->getRequestTarget());
+    }
+
+    public static function hostlessMultiSlashTargetProvider(): iterable
+    {
+        yield 'authority-like target' => ['//evil.example/x', '/evil.example/x'];
+        yield 'authority-like target with query' => ['//evil.example/x?q=1', '/evil.example/x?q=1'];
+        yield 'double slash only' => ['//', '/'];
+        yield 'triple slash' => ['///x', '/x'];
+    }
+
+    public function testParseRequestCollapsesMultiSlashTargetWithHostHeader(): void
+    {
+        $request = Psr7\Message::parseRequest("GET //evil.example/x HTTP/1.1\r\nHost: good.example\r\n\r\n");
+
+        self::assertSame('http://good.example/evil.example/x', (string) $request->getUri());
+        self::assertSame('good.example', $request->getHeaderLine('Host'));
+        self::assertSame('/evil.example/x', $request->getRequestTarget());
     }
 
     public function testParsesRequestMessagesWithFullUri(): void


### PR DESCRIPTION
`Message::parseRequest()` falls back to the raw request target when no `Host` header is present, so `GET //evil.example/x HTTP/1.1` is parsed as a network-path reference: `evil.example` is promoted to the URI authority, a `Host: evil.example` header is synthesized from it, and the request target collapses to `/x`. A request that carries no `Host` header at all thus ends up with an attacker-controlled authority, while the same target sent with a `Host` header is already correctly treated as a plain path.

`Message::parseRequestUri()` now collapses the leading slashes in its host-less fallback, through a private `normalizePathForOriginForm()` helper mirroring the one on `Request`, so the target stays a path-only URI: the request above yields the URI `/evil.example/x`, an empty URI host, no synthesized `Host` header, and the request target `/evil.example/x`. Only host-less origin-form targets beginning with `//` change behavior; bare `//` and `///x`, which previously failed with `MalformedUriException`, now parse as the paths `/` and `/x`, while interior duplicate slashes are preserved. Every other input is byte-identical. This is the 3.0 counterpart of the 2.12 pull request #820, which carries the shared changelog entry.
