### PR TITLE
Cover negative seek targets in CachingStreamTest

### DIFF
--- a/tests/CachingStreamTest.php
+++ b/tests/CachingStreamTest.php
@@ -348,4 +348,16 @@ class CachingStreamTest extends TestCase
         $this->expectExceptionMessage('Invalid whence');
         $this->body->seek(10, -123456);
     }
+
+    public function testEnsuresSeekCurTargetIsNonNegative(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->body->seek(-1, SEEK_CUR);
+    }
+
+    public function testEnsuresSeekEndTargetIsNonNegative(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->body->seek(-100, SEEK_END);
+    }
 }


### PR DESCRIPTION
Negative computed `SEEK_CUR` and `SEEK_END` seek targets throw `RuntimeException` per the PSR-7 `StreamInterface::seek()` contract, and the 2.12 series has always behaved this way through the decorated stream. This adds two `CachingStreamTest` cases pinning that class for both whences, because the unreleased 3.0 branch regressed these two cases to `InvalidArgumentException` (fixed separately on 3.0). The test names intentionally match the 3.0 suite so the two lines stay aligned across the branches during merge-ups.
