### PR TITLE
Throw RuntimeException for negative computed seek targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make `FnStream` close and detach terminal, calling close callbacks at most once
 - Suppress exceptions from `FnStream` close callbacks during destructor cleanup
 - Make `CachingStream::close()` idempotent, preserving remote cleanup after detach
+- Do not move the `CachingStream` cursor when a `SEEK_END` target on an unknown-size stream is rejected
 - Normalize multiple leading slashes in `Uri::getPath()` and origin-form request targets
 - Serialize authority-less `file` URIs with rootless paths without the `//` separator
 - Serialize authority-less `file` URIs with empty paths as `file:` instead of the unparseable `file://`

--- a/src/CachingStream.php
+++ b/src/CachingStream.php
@@ -75,9 +75,22 @@ final class CachingStream implements StreamInterface
         } elseif ($whence === SEEK_END) {
             $size = $this->remoteStream->getSize();
             if ($size === null) {
+                // Discovering the size reads the remote stream to EOF and
+                // moves the cursor, so restore the cursor if the computed
+                // target is rejected to keep a failed seek side-effect free.
+                $position = $this->tell();
                 $size = $this->cacheEntireStream();
+
+                try {
+                    $byte = Integers::addSigned($size, $offset);
+                } catch (\Throwable $e) {
+                    $this->stream->seek($position);
+
+                    throw $e;
+                }
+            } else {
+                $byte = Integers::addSigned($size, $offset);
             }
-            $byte = Integers::addSigned($size, $offset);
         } else {
             throw new \InvalidArgumentException('Invalid whence');
         }

--- a/src/Integers.php
+++ b/src/Integers.php
@@ -38,7 +38,9 @@ final class Integers
 
         $value = $base + $delta;
         if ($value < 0) {
-            throw new \InvalidArgumentException('Stream offset must be non-negative');
+            // A negative computed offset is a seek failure at runtime, so throw
+            // RuntimeException per PSR-7, unlike the precondition check above.
+            throw new \RuntimeException('Stream offset must be non-negative');
         }
 
         return $value;

--- a/tests/CachingStreamTest.php
+++ b/tests/CachingStreamTest.php
@@ -584,4 +584,26 @@ class CachingStreamTest extends TestCase
         $this->expectExceptionMessage('Stream offset must be non-negative');
         $this->body->seek(-100, SEEK_END);
     }
+
+    public function testRejectedSeekEndWithUnknownSizeDoesNotMoveCursor(): void
+    {
+        $baseStream = Psr7\Utils::streamFor('testing');
+        $decorated = Psr7\FnStream::decorate($baseStream, [
+            'getSize' => function () {
+                return null;
+            },
+        ]);
+        $cached = new CachingStream($decorated);
+        self::assertSame('te', $cached->read(2));
+
+        try {
+            $cached->seek(-100, SEEK_END);
+            self::fail('Expected seek to fail');
+        } catch (\RuntimeException $e) {
+            self::assertSame('Stream offset must be non-negative', $e->getMessage());
+        }
+
+        self::assertSame(2, $cached->tell());
+        self::assertSame('sting', $cached->read(5));
+    }
 }

--- a/tests/CachingStreamTest.php
+++ b/tests/CachingStreamTest.php
@@ -570,4 +570,18 @@ class CachingStreamTest extends TestCase
         $this->expectExceptionMessage('Invalid whence');
         $this->body->seek(10, -123456);
     }
+
+    public function testEnsuresSeekCurTargetIsNonNegative(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Stream offset must be non-negative');
+        $this->body->seek(-1, SEEK_CUR);
+    }
+
+    public function testEnsuresSeekEndTargetIsNonNegative(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Stream offset must be non-negative');
+        $this->body->seek(-100, SEEK_END);
+    }
 }

--- a/tests/IntegersTest.php
+++ b/tests/IntegersTest.php
@@ -56,7 +56,7 @@ class IntegersTest extends TestCase
 
     public function testAddSignedRejectsNegativeResult(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Stream offset must be non-negative');
 
         Integers::addSigned(0, -1);

--- a/tests/StreamWrapperTest.php
+++ b/tests/StreamWrapperTest.php
@@ -209,6 +209,13 @@ class StreamWrapperTest extends TestCase
         self::assertSame(-1, fseek($resource, 0));
     }
 
+    public function testSeekToNegativeTargetReturnsMinusOne(): void
+    {
+        $resource = StreamWrapper::getResource(new Psr7\CachingStream(Utils::streamFor('foo')));
+
+        self::assertSame(-1, fseek($resource, -100, SEEK_END));
+    }
+
     public function testEofFailureReturnsTrue(): void
     {
         $stream = $this->createMock(StreamInterface::class);

--- a/tests/StreamWrapperTest.php
+++ b/tests/StreamWrapperTest.php
@@ -216,6 +216,19 @@ class StreamWrapperTest extends TestCase
         self::assertSame(-1, fseek($resource, -100, SEEK_END));
     }
 
+    public function testSeekToNegativeTargetWithUnknownSizeDoesNotMoveCursor(): void
+    {
+        $stream = Psr7\FnStream::decorate(Utils::streamFor('foo'), [
+            'getSize' => function () {
+                return null;
+            },
+        ]);
+        $resource = StreamWrapper::getResource(new Psr7\CachingStream($stream));
+
+        self::assertSame(-1, fseek($resource, -100, SEEK_END));
+        self::assertSame('foo', fread($resource, 3));
+    }
+
     public function testEofFailureReturnsTrue(): void
     {
         $stream = $this->createMock(StreamInterface::class);


### PR DESCRIPTION
PSR-7's `StreamInterface::seek()` documents `RuntimeException` on failure, and that is what released 2.12 throws for every negative seek target. On the 3.0 branch, `CachingStream::seek()` computes `SEEK_CUR` and `SEEK_END` targets through the internal `Integers::addSigned()` helper, whose negative-result branch throws `InvalidArgumentException`, while a negative `SEEK_SET` offset still reaches the decorated stream and throws `RuntimeException`. The exception class therefore depends on the whence used, and two of the three whences violate the PSR-7 contract.

The wrong class also leaks through the stream wrapper: `StreamWrapper::stream_seek()` only translates `RuntimeException` into a failure return, so `fseek($resource, -100, SEEK_END)` on a wrapped `CachingStream` lets `InvalidArgumentException` escape `fseek()` instead of returning `-1` as documented in the 3.0 upgrade guide. This change makes the negative-result branch of `addSigned()` throw `RuntimeException`, restoring the 2.12 exception class; the negative-base branch keeps `InvalidArgumentException` because the base always comes from `tell()` or `getSize()`. Tests cover the helper, both whences on `CachingStream`, and the wrapper's `-1` return.

A rejected `SEEK_END` seek on a `CachingStream` whose remote size is unknown also used to leave the stream at EOF, because the size is discovered by caching the entire remote stream before the computed target is validated. The cursor is now restored when the target is rejected, so a failed seek no longer changes the position — directly, and through the wrapper where `fseek()` returns `-1`. The side effect predates the exception-class change (released 2.12 behaves the same way) but only became silent with it.
