### PR TITLE
Relativize equal-path targets without inheriting the fragment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Serialize authority-less `file` URIs with empty paths as `file:` instead of the unparseable `file://`
 - Remove dot segments above the root per RFC 3986, prefixing authority-less `//` paths with `/.`
 - Return a network-path reference from `UriResolver::relativize()` when an empty-path target requires one
+- Stop returning an empty reference from `UriResolver::relativize()` when it would inherit the base fragment
+- Stop throwing from `UriResolver::relativize()` when an equal-path target's last path segment contains a colon
 - Harden URI host validation (delimiters, backslashes, IPv6, embedded ports); require schemes to start with a letter
 - Redact all non-empty URI userinfo in `Utils::redactUserInfo()`
 - Rebuild server request URIs from `$_SERVER` by `REQUEST_METHOD`, using target authority before `SERVER_PORT`

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -355,6 +355,15 @@ empty relative reference would otherwise inherit. When the base URI has an
 empty path as well and nothing would be inherited, shorter references such
 as the empty reference, `#fragment` or `?query` are still returned.
 
+`relativize()` also no longer returns the empty reference when the target
+path equals the base path but the base has a fragment the target lacks, as
+the empty reference would reintroduce that fragment. A relative-path
+reference, or a query reference when the target has a query, is returned
+instead. When the relative-path reference would be a single path segment
+containing a colon, which would be mistaken for a scheme name, it is
+prefixed with `./` (for example `./a:b`); 2.x threw a `MalformedUriException`
+for such targets when the base had a query the target lacked.
+
 #### HTTP Start-line Parsing
 
 `Message::parseRequest()` and `Message::parseResponse()` now validate HTTP

--- a/src/UriResolver.php
+++ b/src/UriResolver.php
@@ -201,19 +201,25 @@ final class UriResolver
             return $emptyPathUri->withPath(self::getRelativePath($base, $target));
         }
 
-        if ($base->getQuery() === $target->getQuery()) {
+        if ($base->getQuery() === $target->getQuery() && ($target->getFragment() !== '' || $base->getFragment() === '')) {
             // Only the target fragment is left. And it must be returned even if base and target fragment are the same.
             return $emptyPathUri->withQuery('');
         }
 
-        // If the base URI has a query but the target has none, we cannot return an empty path reference as it would
-        // inherit the base query component when resolving.
+        // If the base URI has a query or fragment that the target lacks, we cannot return an empty path
+        // reference as it would inherit that base component when resolving.
         if ($target->getQuery() === '') {
             $segments = explode('/', Uri::rawPath($target));
             /** @var string $lastSegment */
             $lastSegment = end($segments);
 
-            return $emptyPathUri->withPath($lastSegment === '' ? './' : $lastSegment);
+            // A reference to an empty last segment must be prefixed with "./". The same applies
+            // to a segment with a colon character, which would be mistaken for a scheme name.
+            if ($lastSegment === '' || str_contains($lastSegment, ':')) {
+                $lastSegment = "./$lastSegment";
+            }
+
+            return $emptyPathUri->withPath($lastSegment);
         }
 
         return $emptyPathUri;

--- a/tests/UriResolverTest.php
+++ b/tests/UriResolverTest.php
@@ -396,6 +396,18 @@ class UriResolverTest extends TestCase
             // nothing is inherited when the target has its own fragment or a different query
             ['urn://h#bf',      'urn://h#f',    '#f'],
             ['urn://h#bf',      'urn://h?q',    '?q'],
+            // a base fragment is not inherited into an equal-path target; a non-empty
+            // reference is returned instead of the empty reference
+            ['http://h/p#old',  'http://h/p',   'p'],
+            ['http://h/#old',   'http://h/',    './'],
+            ['http://h/p#old',  'http://h/p#f', '#f'],
+            ['http://h/p?q#old', 'http://h/p?q', '?q'],
+            // a single-segment reference containing a colon would be mistaken for a scheme
+            // name and is prefixed with "./", like in references to different paths
+            ['http://h/a:b#old', 'http://h/a:b', './a:b'],
+            ['http://h/a:b?bq',  'http://h/a:b', './a:b'],
+            // a colon-free segment needs no "./" prefix
+            ['http://h/p?bq',   'http://h/p',   'p'],
             // an empty base path needs no network-path reference when nothing would be inherited
             ['urn://h',         'urn://h',      ''],
             ['urn://h',         'urn://h#f',    '#f'],


### PR DESCRIPTION
This completes the `UriResolver::relativize()` round-trip work from #819 for a corner it left open. When the target has the same path as the base but the base carries a fragment the target lacks, `relativize()` returned the empty reference, which resolves back to the base with that fragment reintroduced — a different URI. For example, `relativize(new Uri('http://h/p#old'), new Uri('http://h/p'))` returned `''`, which resolves to `http://h/p#old` rather than `http://h/p`. It now returns a non-empty reference that round-trips: a relative-path reference, or a query reference when the target carries a query.

The relative-path reference for such a target is its last path segment, prefixed with `./` when that segment is empty or contains a colon, since a bare colon-bearing first segment would be parsed as a scheme name. `relativize(new Uri('http://h/a:b#old'), new Uri('http://h/a:b'))` now returns `./a:b` instead of throwing `MalformedUriException`, mirroring the guard already in `getRelativePath()`; this also fixes the same pre-existing throw on the differing-query route. New provider rows and an `UPGRADING.md` note cover the query, fragment, and colon cases.
