### PR TITLE
Report PCRE failures from Header::parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Validate bracketed IP-literal hosts consistently between parsing and `withHost()`, including userinfo forms
 - Normalize percent-encoded octets in the URI host to uppercase hex
 - Trim header list elements with only spaces, horizontal tabs, and line terminators in `Header::splitList()`
+- Report header parameter PCRE failures explicitly in `Header::parse()`
 
 ### Removed
 

--- a/src/Header.php
+++ b/src/Header.php
@@ -27,7 +27,13 @@ final class Header
             foreach (self::splitList($value) as $val) {
                 $part = [];
                 foreach (self::splitParameters($val) as $kvp) {
-                    if (preg_match_all('/<[^>]+>|[^=]+/', $kvp, $matches)) {
+                    $count = preg_match_all('/<[^>]+>|[^=]+/', $kvp, $matches);
+
+                    if ($count === false) {
+                        throw new \RuntimeException('Unable to parse header parameters: '.preg_last_error_msg());
+                    }
+
+                    if ($count !== 0) {
                         $m = $matches[0];
                         if (isset($m[1])) {
                             $part[trim($m[0], $trimmed)] = trim($m[1], $trimmed);

--- a/tests/HeaderTest.php
+++ b/tests/HeaderTest.php
@@ -119,6 +119,20 @@ class HeaderTest extends TestCase
         self::assertSame([$expected], Psr7\Header::parse(\implode('; ', $parameters)));
     }
 
+    public function testParseReportsPcreFailures(): void
+    {
+        $limit = \ini_set('pcre.backtrack_limit', '1');
+
+        try {
+            $this->expectException(\RuntimeException::class);
+            $this->expectExceptionMessage('Unable to parse header parameters: ');
+
+            Psr7\Header::parse('rel=front');
+        } finally {
+            \ini_set('pcre.backtrack_limit', $limit);
+        }
+    }
+
     public static function normalizeProvider(): array
     {
         return [


### PR DESCRIPTION
`Header::parse()` gated its per-parameter `preg_match_all()` call on truthiness, which conflates a PCRE engine failure (`false`, for example backtrack or recursion limit exhaustion) with a legitimate zero-match (`0`). When the engine failed, the parameter was silently dropped from the parsed result, so callers could not tell a truncated parse from a header that genuinely had no parameters. This was the last data-affecting `preg_*` call in the library without an explicit failure check.

The call now checks for `=== false` and throws `\RuntimeException` with `preg_last_error_msg()`, matching the fail-closed convention the HTTP message parsers in `Message.php` and the URI helpers already follow. A zero-match still skips the segment exactly as before, so behavior for all parseable input is unchanged. A regression test forces the failure deterministically by lowering `pcre.backtrack_limit` around the call.
