### PR TITLE
Cover uploaded file tree and multipart rejection paths

### DIFF
--- a/tests/MultipartStreamTest.php
+++ b/tests/MultipartStreamTest.php
@@ -483,6 +483,45 @@ class MultipartStreamTest extends TestCase
         self::assertSame($expected, (string) $b);
     }
 
+    /**
+     * @dataProvider nonFiniteFloatContentsProvider
+     */
+    public function testRejectsNonFiniteFloatContents(float $value): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot create a stream from a non-finite float.');
+
+        new MultipartStream([
+            [
+                'name' => 'field',
+                'contents' => $value,
+            ],
+        ]);
+    }
+
+    /**
+     * @dataProvider nonFiniteFloatContentsProvider
+     */
+    public function testRejectsNonFiniteFloatInArrayContents(float $value): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot create a stream from a non-finite float.');
+
+        new MultipartStream([
+            [
+                'name' => 'field',
+                'contents' => ['nested' => $value],
+            ],
+        ]);
+    }
+
+    public static function nonFiniteFloatContentsProvider(): iterable
+    {
+        yield 'NAN' => [\NAN];
+        yield 'INF' => [\INF];
+        yield '-INF' => [-\INF];
+    }
+
     public function testExpandsArrayContentsWithNumericStringKeys(): void
     {
         $b = new MultipartStream([

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -1996,6 +1996,59 @@ PHP
         self::assertSame($files, $request2->getUploadedFiles());
     }
 
+    /**
+     * @dataProvider validUploadedFilesProvider
+     */
+    public function testWithUploadedFilesAcceptsValidTrees(array $files): void
+    {
+        $request = new ServerRequest('GET', '/');
+
+        $new = $request->withUploadedFiles($files);
+
+        self::assertNotSame($request, $new);
+        self::assertSame([], $request->getUploadedFiles());
+        self::assertSame($files, $new->getUploadedFiles());
+    }
+
+    public static function validUploadedFilesProvider(): iterable
+    {
+        $file = new UploadedFile('test', 123, UPLOAD_ERR_OK);
+
+        yield 'empty tree' => [[]];
+        yield 'flat list' => [[$file, $file]];
+        yield 'nested named tree' => [['files' => ['a' => $file, 'b' => [$file, $file]]]];
+    }
+
+    /**
+     * @dataProvider invalidUploadedFilesProvider
+     */
+    public function testWithUploadedFilesRejectsInvalidTrees(array $files, string $expectedType): void
+    {
+        $original = ['file' => new UploadedFile('test', 123, UPLOAD_ERR_OK)];
+        $request = (new ServerRequest('GET', '/'))->withUploadedFiles($original);
+
+        try {
+            $request->withUploadedFiles($files);
+            self::fail('Uploaded file tree should have been rejected.');
+        } catch (\InvalidArgumentException $e) {
+            self::assertSame(
+                sprintf('Invalid uploaded file tree; expected UploadedFileInterface instances but %s provided.', $expectedType),
+                $e->getMessage()
+            );
+            self::assertSame($original, $request->getUploadedFiles());
+        }
+    }
+
+    public static function invalidUploadedFilesProvider(): iterable
+    {
+        yield 'string leaf' => [['file' => 'not-a-file'], 'string'];
+        yield 'integer leaf' => [['file' => 1], 'int'];
+        yield 'null leaf' => [['file' => null], 'null'];
+        yield 'object leaf' => [['file' => new \stdClass()], 'stdClass'];
+        yield 'deeply nested invalid leaf' => [['files' => ['nested' => ['deep' => 'not-a-file']]], 'string'];
+        yield 'valid then invalid' => [['a' => new UploadedFile('test', 123, UPLOAD_ERR_OK), 'b' => 'not-a-file'], 'string'];
+    }
+
     public function testServerParams(): void
     {
         $params = ['name' => 'value'];


### PR DESCRIPTION
This test-only change adds coverage for two rejection paths that were previously unexercised. `ServerRequest::withUploadedFiles()` gains provider-backed tests asserting that valid trees (empty, flat, and nested) are accepted, and that trees containing strings, integers, nulls, plain objects, or nested offenders are rejected with the exact `InvalidArgumentException` message. `MultipartStream` gains tests asserting that non-finite float contents (`NAN`, `INF`, `-INF`) are rejected with an `InvalidArgumentException`, both when passed directly and when nested inside array contents. No production code is changed, so there is no changelog entry.