### PR TITLE
Document server value, stream close, and scalar body changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Redact all non-empty URI userinfo in `Utils::redactUserInfo()`
 - Rebuild server request URIs from `$_SERVER` by `REQUEST_METHOD`, using target authority before `SERVER_PORT`
 - Reject zero-port `HTTP_HOST` and malformed `SERVER_PORT` in `ServerRequest::getUriFromGlobals()`
+- Reject malformed `REQUEST_METHOD` and `SERVER_PROTOCOL` server values in `ServerRequest::fromGlobals()`
 - Reject zero-port `Host` and normalize leading-zero ports in `Message::parseRequest()`
 - Reject duplicate `Host` headers and validate present values for all request-target forms
 - Synchronize the `Host` header in `Request::withUri()` when the URI changes or Host is empty
@@ -61,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed `Utils::copyToStream()` to throw when destination streams cannot make progress
 - Throw `TimeoutException` from `Stream` read/write and `Utils` copy/hash/readLine on stream timeouts
 - Re-throw `TimeoutException` from `InflateStream` when the decoded source stream times out
+- Close the compressed source stream from `InflateStream::close()`
 - Return the number of bytes copied from `Utils::copyToStream()`
 - Throw `OverflowException` when stream byte counts or offsets exceed `PHP_INT_MAX`
 - Translate `StreamWrapper` runtime failures to PHP stream failure values

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -387,6 +387,13 @@ Message::parseRequest("GET /foo%20bar HTTP/1.1\r\nHost: example.com\r\n\r\n");
 new Response(200, [], null, '1.1');
 ```
 
+`ServerRequest::fromGlobals()` applies the same validation to the
+`REQUEST_METHOD` and `SERVER_PROTOCOL` server values. Malformed values that 2.x
+hydrated, such as the `SERVER_PROTOCOL` value `INCLUDED` that Apache sets for
+server-side include subrequests, now throw `InvalidArgumentException`. Sanitize
+`$_SERVER` before calling `fromGlobals()` if such environments must be
+tolerated.
+
 #### Query Builder Values
 
 `Query::build()` now rejects unsupported values instead of relying on PHP string
@@ -413,6 +420,19 @@ Query::build(['tag' => ['a', 'b']]);
 
 `Uri::withQueryValues()` is stricter than `Query::build()` and requires `string`
 or `null` values; cast numeric and boolean query values to string.
+
+#### Non-string Scalar Bodies
+
+`Utils::streamFor()` and message bodies no longer accept `int`, `float`, or
+`bool` values. Cast them to strings first.
+
+```php
+// 2.x, no longer accepted in 3.0
+$response = new Response(200, [], 404);
+
+// 3.0
+$response = new Response(200, [], '404');
+```
 
 #### PumpStream Source Callables
 
@@ -447,6 +467,29 @@ $stream = Utils::streamFor(new ArrayIterator([false, 'body']));
 // After: false and null are skipped chunks. End the iterator to signal EOF.
 $stream = Utils::streamFor(new ArrayIterator(['body']));
 ```
+
+#### Stream Behavior Changes
+
+All stream implementations now reject negative `read()` lengths with
+`RuntimeException`. In 2.x, some decorators passed negative lengths through,
+some returned sliced data, and some behavior varied by PHP version.
+
+`LimitStream` now rejects negative offsets and limits below `-1`. For
+non-seekable streams, offsets are tracked by the number of bytes actually
+skipped. Short reads are retried until the offset is reached, EOF is reached, or
+the decorated stream stops making progress.
+
+`StreamWrapper` now translates `RuntimeException` failures from the wrapped
+PSR-7 stream into PHP stream-wrapper failure values. When using a resource from
+`StreamWrapper::getResource()`, functions such as `fread()`, `fwrite()`,
+`fseek()`, `feof()`, and `fstat()` may now return normal PHP failure values
+instead of propagating the PSR-7 stream exception. Call the PSR-7 stream directly
+if you need exception-based failure handling.
+
+The `StreamWrapper::stream_read()` callback no longer declares a native return
+type so read failures can return `false`. The `StreamWrapper::stream_tell()`
+callback no longer declares a native return type so post-seek position lookup
+failures can make `fseek()` fail.
 
 #### Stream Mode Capabilities
 
@@ -514,6 +557,11 @@ suppresses exceptions thrown by destructor-triggered close callbacks. Call
 still closes the remote stream owned by the `CachingStream`, but it no longer
 closes the detached cache resource returned to the caller. Repeated `close()`
 calls are no-ops.
+
+`InflateStream::close()` now also closes the compressed source stream that was
+passed to its constructor. In 2.x, closing an `InflateStream` left the source
+stream open. Call `detach()` instead of `close()` if the compressed source
+stream must stay open; `close()` after `detach()` no longer closes the source.
 
 `PumpStream::close()` and `PumpStream::detach()` now discard internally buffered
 unread bytes. If a callable or iterator source returns more bytes than a read
@@ -816,31 +864,10 @@ of depending on package internals.
 its high-water mark. This keeps the method compatible with the `int` return type
 from `StreamInterface::write()`.
 
-All stream implementations now reject negative `read()` lengths with
-`RuntimeException`. In 2.x, some decorators passed negative lengths through,
-some returned sliced data, and some behavior varied by PHP version.
-
-`LimitStream` now rejects negative offsets and limits below `-1`. For
-non-seekable streams, offsets are tracked by the number of bytes actually
-skipped. Short reads are retried until the offset is reached, EOF is reached, or
-the decorated stream stops making progress.
-
-`StreamWrapper` now translates `RuntimeException` failures from the wrapped
-PSR-7 stream into PHP stream-wrapper failure values. When using a resource from
-`StreamWrapper::getResource()`, functions such as `fread()`, `fwrite()`,
-`fseek()`, `feof()`, and `fstat()` may now return normal PHP failure values
-instead of propagating the PSR-7 stream exception. Call the PSR-7 stream directly
-if you need exception-based failure handling.
-
-The `StreamWrapper::stream_read()` callback no longer declares a native return
-type so read failures can return `false`. The `StreamWrapper::stream_tell()`
-callback no longer declares a native return type so post-seek position lookup
-failures can make `fseek()` fail.
-
-Several stream `__toString()` implementations now allow exceptions thrown during
-stringification to be rethrown. Avoid relying on `(string) $stream` to hide read
-failures; call `getContents()` or `read()` and handle exceptions when failures
-are possible.
+Several stream `__toString()` implementations now catch `Throwable`. On PHP 7.4
+and newer, exceptions thrown during stringification are rethrown. Avoid relying
+on `(string) $stream` to hide read failures; call `getContents()` or `read()` and
+handle exceptions when failures are possible.
 
 #### PSR-17 Factories
 

--- a/docs/message-helpers.md
+++ b/docs/message-helpers.md
@@ -68,7 +68,7 @@ This method is useful for reducing the number of clones needed to mutate a messa
 - method: (string) Changes the HTTP method.
 - set_headers: (array) Sets the given headers. Values must be strings or arrays of strings.
 - remove_headers: (array) Remove the given headers. Values may be strings or integers.
-- body: (mixed) Sets the given body. Present non-null values are converted with `GuzzleHttp\Psr7\Utils::streamFor()`, including scalar values, resources, streams, iterators, callable arrays, closures, invokable objects, and stringable objects. String inputs remain literal bodies.
+- body: (mixed) Sets the given body. Present non-null values are converted with `GuzzleHttp\Psr7\Utils::streamFor()`, including resources, streams, iterators, callable arrays, closures, invokable objects, and stringable objects. String inputs remain literal bodies.
 - uri: (UriInterface) Set the URI.
 - query: (string) Set the query string value of the URI.
 - version: (string) Set the protocol version.

--- a/docs/message-helpers.md
+++ b/docs/message-helpers.md
@@ -69,7 +69,7 @@ This method is useful for reducing the number of clones needed to mutate a messa
 - set_headers: (array) Sets the given headers. Values must be strings or arrays of strings.
 - remove_headers: (array) Remove the given headers. Values may be strings or integers.
 - body: (mixed) Sets the given body. Present non-null values are converted with `GuzzleHttp\Psr7\Utils::streamFor()`, including resources, streams, iterators, callable arrays, closures, invokable objects, and stringable objects. String inputs remain literal bodies.
-- uri: (UriInterface) Set the URI.
+- uri: (UriInterface) Set the URI. When the URI contains a host, the Host header is updated from it, and combining this with an explicit Host entry in set_headers throws an InvalidArgumentException. Apply an intentional Host override separately with withHeader() afterwards.
 - query: (string) Set the query string value of the URI.
 - version: (string) Set the protocol version.
 

--- a/docs/stream-helpers.md
+++ b/docs/stream-helpers.md
@@ -40,7 +40,7 @@ Throws `GuzzleHttp\Psr7\Exception\TimeoutException` when PHP-style timeout metad
 
 ## `GuzzleHttp\Psr7\Utils::streamFor`
 
-`public static function streamFor(resource|string|null|int|float|bool|StreamInterface|callable|\Iterator|\Stringable $resource = '', array $options = []): StreamInterface`
+`public static function streamFor(resource|string|null|StreamInterface|callable|\Iterator|\Stringable $resource = '', array $options = []): StreamInterface`
 
 Create a new stream based on the input type.
 

--- a/docs/streams-and-decorators.md
+++ b/docs/streams-and-decorators.md
@@ -12,7 +12,7 @@ Streams expose their capabilities using `isReadable()`, `isWritable()`, and `isS
 
 Use `GuzzleHttp\Psr7\Utils::streamFor()` to create streams from common PHP values. It accepts strings, resources returned from `fopen()`, objects that implement `__toString()`, iterators, callable arrays, closures, invokable objects, and existing `Psr\Http\Message\StreamInterface` instances.
 
-Scalar values and `null` are stored in `php://temp` streams. PHP keeps `php://temp` data in memory until the stream exceeds 2 MB, then spills to a temporary file on disk.
+Strings and `null` are stored in `php://temp` streams. PHP keeps `php://temp` data in memory until the stream exceeds 2 MB, then spills to a temporary file on disk. Non-string scalars such as integers, floats, and booleans are rejected; cast them to strings first.
 
 Callable sources receive a suggested read length, may return fewer or more bytes, and end the stream by returning `false` or `null`. Strings remain literal body contents, even when they name a callable.
 
@@ -195,6 +195,8 @@ Uses PHP's zlib.inflate filter to inflate zlib (HTTP deflate, RFC1950) or gzippe
 
 This stream decorator converts the provided stream to a PHP stream resource,
 appends the zlib.inflate filter, and wraps the filtered resource as a stream.
+
+Closing an `InflateStream` also closes the compressed source stream it decorates; `detach()` leaves the source stream open.
 
 
 ## LazyOpenStream

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -201,7 +201,10 @@ final class Utils
      *   with self::streamFor(), including resources, streams, iterators, callable
      *   arrays, closures, invokable objects, and stringable objects. String inputs
      *   remain literal bodies.
-     * - uri: (UriInterface) Set the URI.
+     * - uri: (UriInterface) Set the URI. When the URI contains a host, the
+     *   Host header is updated from it, and combining this with an explicit
+     *   Host entry in set_headers throws an InvalidArgumentException. Apply
+     *   an intentional Host override separately with withHeader() afterwards.
      * - query: (string) Set the query string value of the URI.
      * - version: (string) Set the protocol version.
      *


### PR DESCRIPTION
This documentation-only change covers the remaining undocumented 3.0 behavioral deltas. `ServerRequest::fromGlobals()` now throws for malformed `REQUEST_METHOD` and `SERVER_PROTOCOL` server values, such as the `SERVER_PROTOCOL` value `INCLUDED` that Apache sets for server-side include subrequests, because constructor validation applies during hydration. `InflateStream::close()` now also closes the compressed source stream. Both gain CHANGELOG bullets and UPGRADING prose, with a matching sentence on the streams documentation page.

The four stream paragraphs previously added to the `1.x to 2.0` section of UPGRADING (negative `read()` lengths, `LimitStream` validation, `StreamWrapper` failure translation, and the `stream_read()`/`stream_tell()` return-type removals) describe 3.0 changes, so they move verbatim into a new `Stream Behavior Changes` subsection under `2.x to 3.0`, and the original `__toString()` paragraph is restored, leaving the 2.0 section byte-identical to the 2.12 branch.

A new `Non-string Scalar Bodies` UPGRADING subsection documents the already-changelogged rejection of `int`, `float`, and `bool` bodies, and the three affected documentation pages drop their stale 2.x coercion claims: the `streamFor()` signature loses `int|float|bool`, and the stream-creation and `modifyRequest()` prose now match the source docblocks.

A follow-up commit also documents, in both the `modifyRequest()` docblock and its documentation page, that a `uri` change containing a host updates the `Host` header and conflicts with an explicit `Host` entry in `set_headers`, which throws an `InvalidArgumentException`.