### PR TITLE
Include non-default URI ports in modifyRequest Host headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Anchor server port and response start-line patterns to the true end of input
 - Treat host-less origin-form request targets starting with `//` as paths in `Message::parseRequest()`
+- Include non-default URI ports in `Host` headers set by `Utils::modifyRequest()` URI changes
 
 ## 2.12.3 - 2026-06-23
 

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -187,7 +187,10 @@ final class Utils
      *   with self::streamFor(), including scalar values, resources, streams,
      *   iterators, callable arrays, closures, invokable objects, and objects
      *   with __toString(). String inputs remain literal bodies.
-     * - uri: (UriInterface) Set the URI.
+     * - uri: (UriInterface) Set the URI. When the URI contains a host, the
+     *   Host header is updated from it, and combining this with an explicit
+     *   Host entry in set_headers throws an InvalidArgumentException. Apply
+     *   an intentional Host override separately with withHeader() afterwards.
      * - query: (string) Set the query string value of the URI.
      * - version: (string) Set the protocol version.
      *
@@ -222,10 +225,11 @@ final class Utils
 
                 $changes['set_headers']['Host'] = $host;
 
-                if ($port = $changes['uri']->getPort()) {
+                $port = $changes['uri']->getPort();
+                if ($port !== null) {
                     $standardPorts = ['http' => 80, 'https' => 443];
                     $scheme = $changes['uri']->getScheme();
-                    if (isset($standardPorts[$scheme]) && $port != $standardPorts[$scheme]) {
+                    if (!isset($standardPorts[$scheme]) || $port != $standardPorts[$scheme]) {
                         $changes['set_headers']['Host'] .= ':'.$port;
                     }
                 }

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -469,6 +469,26 @@ class UtilsTest extends TestCase
         self::assertSame('www.foo.com:8000', (string) $r2->getHeaderLine('host'));
     }
 
+    public function testCanModifyRequestWithUriAndZeroPort(): void
+    {
+        $r1 = new Psr7\Request('GET', 'http://foo.com');
+        $r2 = Psr7\Utils::modifyRequest($r1, [
+            'uri' => new Psr7\Uri('http://www.foo.com:0'),
+        ]);
+        self::assertSame('http://www.foo.com:0', (string) $r2->getUri());
+        self::assertSame('www.foo.com:0', (string) $r2->getHeaderLine('host'));
+    }
+
+    public function testCanModifyRequestWithUriAndNonHttpSchemePort(): void
+    {
+        $r1 = new Psr7\Request('GET', 'http://foo.com');
+        $r2 = Psr7\Utils::modifyRequest($r1, [
+            'uri' => new Psr7\Uri('ws://www.foo.com:8080'),
+        ]);
+        self::assertSame('ws://www.foo.com:8080', (string) $r2->getUri());
+        self::assertSame('www.foo.com:8080', (string) $r2->getHeaderLine('host'));
+    }
+
     public function testCanModifyRequestWithFalseyUriHost(): void
     {
         $r1 = new Psr7\Request('GET', 'http://foo.com');


### PR DESCRIPTION
`Utils::modifyRequest()` synthesizes the `Host` header when a `uri` change contains a host, but the port append was gated on a truthy port and an `isset()` check against the standard HTTP(S) ports. A URI with port zero therefore produced `Host: www.foo.com` and a non-HTTP(S) URI such as `ws://www.foo.com:8080` silently dropped its real port. Both diverge from the `Request` constructor's Host synchronization, which appends any non-null port, and from `modifyRequest()`'s own fallback synthesis branch. The condition now appends any non-null port unless it equals the standard port for the scheme, which preserves the suppression of default ports reported by foreign `UriInterface` implementations.

The only guzzle call site passing a `uri` change is `RedirectMiddleware`, where targets are restricted to HTTP(S) by the `protocols` option before reaching this code, so the only observable delta there is a redirect to a port-zero URL, which now sends the same `Host` a direct request to that URL already sends. The `modifyRequest()` docblock also now documents that a hosted `uri` change conflicts with an explicit `Host` entry in `set_headers`.