### PR TITLE
Include non-default URI ports in modifyRequest Host headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reject duplicate `Host` headers and validate present values for all request-target forms
 - Synchronize the `Host` header in `Request::withUri()` when the URI changes or Host is empty
 - Include the URI port in `Host` headers synthesized by `Message::toString()`
+- Include non-default URI ports in `Host` headers set by `Utils::modifyRequest()` URI changes
 - Accept `OPTIONS *` and `CONNECT` authority-form request targets in `Message::parseRequest()`
 - Reject malformed HTTP request/response start-lines
 - Validate iterator chunks passed to `Utils::streamFor()`

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -125,6 +125,10 @@ Recognized change values must use the documented types:
 - `set_headers`: `array<array-key, string|non-empty-array<array-key, string>>`
 - `remove_headers`: `array<array-key, string|int>`
 
+When a `uri` change contains a host, the synthesized `Host` header now
+includes any non-default URI port, matching the `Request` constructor. 2.x
+omitted port zero and every port on schemes other than HTTP and HTTPS.
+
 #### Uploaded Files
 
 `ServerRequestInterface::withUploadedFiles()` now rejects invalid nested upload

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -251,10 +251,11 @@ final class Utils
 
                 $changes['set_headers']['Host'] = $host;
 
-                if ($port = $uri->getPort()) {
+                $port = $uri->getPort();
+                if ($port !== null) {
                     $standardPorts = ['http' => 80, 'https' => 443];
                     $scheme = $uri->getScheme();
-                    if (isset($standardPorts[$scheme]) && $port != $standardPorts[$scheme]) {
+                    if (!isset($standardPorts[$scheme]) || $port != $standardPorts[$scheme]) {
                         $changes['set_headers']['Host'] .= ':'.$port;
                     }
                 }

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -1009,6 +1009,26 @@ class UtilsTest extends TestCase
         self::assertSame('www.foo.com:8000', (string) $r2->getHeaderLine('host'));
     }
 
+    public function testCanModifyRequestWithUriAndZeroPort(): void
+    {
+        $r1 = new Psr7\Request('GET', 'http://foo.com');
+        $r2 = Psr7\Utils::modifyRequest($r1, [
+            'uri' => (new Psr7\Uri('http://www.foo.com'))->withPort(0),
+        ]);
+        self::assertSame('http://www.foo.com:0', (string) $r2->getUri());
+        self::assertSame('www.foo.com:0', (string) $r2->getHeaderLine('host'));
+    }
+
+    public function testCanModifyRequestWithUriAndNonHttpSchemePort(): void
+    {
+        $r1 = new Psr7\Request('GET', 'http://foo.com');
+        $r2 = Psr7\Utils::modifyRequest($r1, [
+            'uri' => new Psr7\Uri('ws://www.foo.com:8080'),
+        ]);
+        self::assertSame('ws://www.foo.com:8080', (string) $r2->getUri());
+        self::assertSame('www.foo.com:8080', (string) $r2->getHeaderLine('host'));
+    }
+
     public function testModifyRequestRejectsInvalidUriHostFromCustomUri(): void
     {
         $uri = $this->createMock(UriInterface::class);
@@ -1018,6 +1038,18 @@ class UtilsTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
 
         Psr7\Utils::modifyRequest(new Psr7\Request('GET', '/'), ['uri' => $uri]);
+    }
+
+    public function testModifyRequestOmitsDefaultPortFromCustomUri(): void
+    {
+        $uri = $this->createMock(UriInterface::class);
+        $uri->method('getHost')->willReturn('www.foo.com');
+        $uri->method('getPort')->willReturn(80);
+        $uri->method('getScheme')->willReturn('http');
+
+        $r2 = Psr7\Utils::modifyRequest(new Psr7\Request('GET', '/'), ['uri' => $uri]);
+
+        self::assertSame('www.foo.com', $r2->getHeaderLine('host'));
     }
 
     public function testCanModifyRequestWithFalseyUriHost(): void


### PR DESCRIPTION
`Utils::modifyRequest()` synthesizes the `Host` header when a `uri` change contains a host, but it only appended the port for truthy, non-standard HTTP(S) ports, so port zero and every port on other schemes were silently dropped, unlike the `Request` constructor and the function's own fallback synthesis branch. The header now includes any non-null URI port unless it equals the scheme's standard port, preserving the suppression of default ports reported by foreign `UriInterface` implementations. This lands on 3.0 only as a behavior change with a changelog entry and an UPGRADING note; the 2.12 counterpart #829 was closed on compatibility grounds. The only guzzle caller passing a `uri` change is `RedirectMiddleware`, where the sole delta is port-zero redirects now sending the same `Host` a direct request sends.
