### PR TITLE
Harden bracketed IP-literal authority parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Preserve explicit custom `MultipartStream` boundary `'0'` instead of replacing it with a generated boundary
 - Made static utility classes non-instantiable
 - Validate bracketed IP-literal hosts consistently between parsing and `withHost()`, including userinfo forms
+- Percent-encode raw control bytes in userinfo before bracketed IP-literal hosts instead of parsing mutated values
+- Reject invalid UTF-8 and preserve percent-sequences in userinfo before bracketed IP-literal hosts
+- Reject raw DEL bytes in bracketed IP-literal hosts instead of parsing a mutated host
 - Normalize percent-encoded octets in the URI host to uppercase hex
 - Trim header list elements with only spaces, horizontal tabs, and line terminators in `Header::splitList()`
 - Report header parameter PCRE failures explicitly in `Header::parse()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Percent-encode raw control bytes in userinfo before bracketed IP-literal hosts instead of parsing mutated values
 - Reject invalid UTF-8 and preserve percent-sequences in userinfo before bracketed IP-literal hosts
 - Reject raw DEL bytes in bracketed IP-literal hosts instead of parsing a mutated host
+- Reject invalid bytes after a bracketed IP-literal host instead of reparsing a different host
 - Normalize percent-encoded octets in the URI host to uppercase hex
 - Trim header list elements with only spaces, horizontal tabs, and line terminators in `Header::splitList()`
 - Report header parameter PCRE failures explicitly in `Header::parse()`

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -210,8 +210,14 @@ Userinfo before a bracketed IP-literal host is now percent-encoded ahead of
 parsing, so raw control bytes yield encoded userinfo, such as `us%01er`,
 instead of a silently mutated value, and raw DEL bytes in bracketed hosts are
 rejected instead of parsed as a mutated host. Consistent with registered-name
-authorities, such userinfo containing invalid UTF-8 is now rejected, and
-percent-sequences such as `u%41` are preserved rather than decoded.
+authorities, such userinfo containing invalid UTF-8 is now rejected,
+percent-sequences such as `u%41` are preserved rather than decoded, and a
+literal `+` is preserved rather than decoded to a space.
+
+Only an optional numeric port and a path, query, or fragment may follow a
+bracketed IP-literal host. Trailing bytes that are neither, such as
+`http://[::1]:80@evil/` or `http://[::1]:80x/`, are now rejected instead of
+being reparsed into a different host.
 
 Parsing still URL-decodes hosts before validation. Bracketed hosts containing
 bytes that change under URL decoding, such as `+` or percent-encoded octets,

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -214,10 +214,10 @@ authorities, such userinfo containing invalid UTF-8 is now rejected,
 percent-sequences such as `u%41` are preserved rather than decoded, and a
 literal `+` is preserved rather than decoded to a space.
 
-Only an optional numeric port and a path, query, or fragment may follow a
-bracketed IP-literal host. Trailing bytes that are neither, such as
-`http://[::1]:80@evil/` or `http://[::1]:80x/`, are now rejected instead of
-being reparsed into a different host.
+Only an optional numeric port (which may be empty) and a path, query, or
+fragment may follow a bracketed IP-literal host. Trailing bytes that are
+neither, such as `http://[::1]:80@evil/` or `http://[::1]:80x/`, are now
+rejected instead of being reparsed into a different host.
 
 Parsing still URL-decodes hosts before validation. Bracketed hosts containing
 bytes that change under URL decoding, such as `+` or percent-encoded octets,

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -206,6 +206,13 @@ the intact host. Bracketed literals containing authority/path delimiters, such
 as `[a@b]` or `[v1.a/b]`, still reject after fallback parsing and may report the
 mangled parsed host.
 
+Userinfo before a bracketed IP-literal host is now percent-encoded ahead of
+parsing, so raw control bytes yield encoded userinfo, such as `us%01er`,
+instead of a silently mutated value, and raw DEL bytes in bracketed hosts are
+rejected instead of parsed as a mutated host. Consistent with registered-name
+authorities, such userinfo containing invalid UTF-8 is now rejected, and
+percent-sequences such as `u%41` are preserved rather than decoded.
+
 Parsing still URL-decodes hosts before validation. Bracketed hosts containing
 bytes that change under URL decoding, such as `+` or percent-encoded octets,
 therefore are not guaranteed to match `withHost()` acceptance. For example,

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -113,7 +113,11 @@ class Uri implements UriInterface, \JsonSerializable
             /** @var array{0:string, 1:string, 2:string, 3:string, 4:string, 5:string} $matches */
             $suffix = $matches[5];
 
-            if ($suffix !== '' && strpos(':/?#', $suffix[0]) === false) {
+            // After the bracketed host only an optional numeric port and/or a
+            // path, query, or fragment may follow. Anything else (for example
+            // `:80@evil` or `:80x`) would let parse_url() reinterpret a
+            // different host.
+            if (preg_match('%\A(?::[0-9]*)?(?:[/?#].*)?\z%s', $suffix) !== 1) {
                 return false;
             }
 

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -99,23 +99,44 @@ class Uri implements UriInterface, \JsonSerializable
         }
 
         // Preserve bracketed IP-literals (IPv6 or IPvFuture) in scheme, userinfo,
-        // and network-path authorities before encoding.
+        // and network-path authorities before encoding. Userinfo is encoded
+        // separately so raw bytes cannot reach parse_url(), which mutates
+        // control characters instead of failing.
         $prefix = '';
-        $ipv6Prefix = preg_match('%\A((?:[0-9A-Za-z+.-]+:)?//(?:[^/?#@]*@)?\[[^\]\x00-\x20/?#@]+\])(.*)\z%s', $url, $matches);
+        $ipv6Prefix = preg_match('%\A((?:[0-9A-Za-z+.-]+:)?//)(?:([^/?#@]*)(@))?(\[[^\]\x00-\x20\x7F/?#@]+\])(.*)\z%s', $url, $matches);
 
         if ($ipv6Prefix === false) {
             return false;
         }
 
         if ($ipv6Prefix === 1) {
-            /** @var array{0:string, 1:string, 2:string} $matches */
-            $suffix = $matches[2];
+            /** @var array{0:string, 1:string, 2:string, 3:string, 4:string, 5:string} $matches */
+            $suffix = $matches[5];
 
             if ($suffix !== '' && strpos(':/?#', $suffix[0]) === false) {
                 return false;
             }
 
             $prefix = $matches[1];
+
+            if ($matches[3] === '@') {
+                /** @var string|null */
+                $encodedUserInfo = preg_replace_callback(
+                    '%[^:/@?&=#]+%usD',
+                    static function (array $matches): string {
+                        return urlencode($matches[0]);
+                    },
+                    $matches[2]
+                );
+
+                if ($encodedUserInfo === null) {
+                    return false;
+                }
+
+                $prefix .= $encodedUserInfo.'@';
+            }
+
+            $prefix .= $matches[4];
             $url = $suffix;
         }
 

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -951,6 +951,48 @@ class UriTest extends TestCase
     }
 
     /**
+     * @dataProvider getBracketedIpLiteralUserinfoEncodingCases
+     */
+    public function testParseEncodesUserinfoBeforeBracketedIpLiteral(string $input, string $expectedUserInfo, string $expectedString): void
+    {
+        $uri = new Uri($input);
+
+        self::assertSame($expectedUserInfo, $uri->getUserInfo());
+        self::assertSame($expectedString, (string) $uri);
+    }
+
+    public static function getBracketedIpLiteralUserinfoEncodingCases(): iterable
+    {
+        yield 'NUL before IPv6' => ["http://u\x00@[::1]/", 'u%00', 'http://u%00@[::1]/'];
+        yield 'space before IPv6' => ['http://u s@[::1]/', 'u%20s', 'http://u%20s@[::1]/'];
+        yield 'DEL before IPvFuture' => ["http://u\x7F@[v1.a]/", 'u%7F', 'http://u%7F@[v1.a]/'];
+        yield 'control in network-path userinfo' => ["//u\x01@[::1]/", 'u%01', '//u%01@[::1]/'];
+        yield 'space in password part' => ['http://user:pa ss@[::1]/', 'user:pa%20ss', 'http://user:pa%20ss@[::1]/'];
+        yield 'percent-sequence preserved' => ['http://u%41@[::1]/', 'u%41', 'http://u%41@[::1]/'];
+    }
+
+    public function testParseRejectsInvalidUtf8UserinfoBeforeBracketedIpLiteral(): void
+    {
+        $this->expectException(MalformedUriException::class);
+
+        new Uri("http://us\xFFer@[::1]/");
+    }
+
+    public function testParseRejectsDelInBracketedIpLiteralHost(): void
+    {
+        $this->expectException(MalformedUriException::class);
+
+        new Uri("http://[v1.a\x7Fb]/");
+    }
+
+    public function testParseRejectsUnsupportedIpv6ZoneIdentifierHost(): void
+    {
+        $this->expectException(MalformedUriException::class);
+
+        new Uri('http://[fe80::1%25eth0]/');
+    }
+
+    /**
      * @dataProvider getBracketedHostsWithDelimiters
      */
     public function testParseRejectsBracketedHostsWithDelimiters(string $uri): void

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -969,6 +969,9 @@ class UriTest extends TestCase
         yield 'control in network-path userinfo' => ["//u\x01@[::1]/", 'u%01', '//u%01@[::1]/'];
         yield 'space in password part' => ['http://user:pa ss@[::1]/', 'user:pa%20ss', 'http://user:pa%20ss@[::1]/'];
         yield 'percent-sequence preserved' => ['http://u%41@[::1]/', 'u%41', 'http://u%41@[::1]/'];
+        yield 'double-encoded percent preserved' => ['http://%2561@[::1]/', '%2561', 'http://%2561@[::1]/'];
+        yield 'plus preserved before IPv6' => ['http://user+name@[::1]/', 'user+name', 'http://user+name@[::1]/'];
+        yield 'plus preserved in password part' => ['http://user:p+ass@[::1]/', 'user:p+ass', 'http://user:p+ass@[::1]/'];
     }
 
     public function testParseRejectsInvalidUtf8UserinfoBeforeBracketedIpLiteral(): void
@@ -990,6 +993,48 @@ class UriTest extends TestCase
         $this->expectException(MalformedUriException::class);
 
         new Uri('http://[fe80::1%25eth0]/');
+    }
+
+    /**
+     * @dataProvider getInvalidBracketedIpLiteralSuffixes
+     */
+    public function testParseRejectsInvalidBracketedIpLiteralSuffix(string $input): void
+    {
+        $this->expectException(MalformedUriException::class);
+
+        new Uri($input);
+    }
+
+    public static function getInvalidBracketedIpLiteralSuffixes(): iterable
+    {
+        yield 'userinfo after port' => ['http://[::1]:80@evil/'];
+        yield 'userinfo after port with leading userinfo' => ['http://user@[::1]:80@evil/'];
+        yield 'userinfo after port on network path' => ['//[::1]:80@evil/'];
+        yield 'userinfo after empty port' => ['http://[::1]:@evil/'];
+        yield 'non-numeric port' => ['http://[::1]:80x/'];
+        yield 'trailing bytes without delimiter' => ['http://[::1]foo/'];
+    }
+
+    /**
+     * @dataProvider getValidBracketedIpLiteralSuffixes
+     */
+    public function testParsePreservesHostForValidBracketedIpLiteralSuffix(string $input): void
+    {
+        self::assertSame('[::1]', (new Uri($input))->getHost());
+    }
+
+    public static function getValidBracketedIpLiteralSuffixes(): iterable
+    {
+        yield 'no suffix' => ['x://[::1]'];
+        yield 'port' => ['x://[::1]:80'];
+        yield 'empty port' => ['x://[::1]:'];
+        yield 'path' => ['x://[::1]/path'];
+        yield 'query' => ['x://[::1]?q'];
+        yield 'fragment' => ['x://[::1]#f'];
+        yield 'port and path' => ['x://[::1]:80/path'];
+        yield 'port and query' => ['x://[::1]:80?q'];
+        yield 'port and fragment' => ['x://[::1]:80#f'];
+        yield 'port and path containing at sign' => ['x://[::1]:80/@evil'];
     }
 
     /**


### PR DESCRIPTION
The bracketed IP-literal fast path in `Uri::parse()` passed raw userinfo and host bytes straight to `parse_url()`, which rewrites control characters to `_` before this package's component filtering runs. `http://us\x01er@[::1]/` therefore parsed with its userinfo silently mutated to `us_er`, and a raw DEL inside a bracketed host, as in `http://[v1.a\x7Fb]/`, was silently accepted with the host mutated to `[v1.a_b]`. The fast path now captures userinfo separately and percent-encodes it before `parse_url()`, exactly as the non-preserved suffix is already encoded, and excludes DEL from the bracketed host capture so such hosts are rejected as invalid.

As a result, userinfo containing invalid UTF-8 before a bracketed host is now rejected, and percent-sequences such as `u%41` and a literal `+` are preserved instead of being decoded, all matching registered-name authorities.

The same fast path only checked the first byte after the bracketed host, so a suffix such as `:80@evil` or `:80x` slipped through to `parse_url()`, which reinterpreted the authority and produced a different host (for example `http://[::1]:80@evil/` resolving its host to `evil`). The suffix is now validated to be an optional numeric port (which may be empty) followed by an optional path, query, or fragment, so these malformed authorities are rejected rather than reparsed.

New tests cover the userinfo encoding across scheme and network-path forms, `+` and percent-sequence preservation, invalid-UTF-8 userinfo rejection, DEL host rejection, the malformed and valid bracketed-host suffixes, and a constructor-level regression test for unsupported RFC 6874 zone identifiers.
