### PR TITLE
Report the full class name in serialization refusal messages

### DIFF
--- a/src/FnStream.php
+++ b/src/FnStream.php
@@ -78,7 +78,7 @@ final class FnStream implements StreamInterface
         $this->methods = [];
         $this->detached = true;
 
-        throw new \LogicException('FnStream should never be unserialized');
+        throw new \LogicException(static::class.' should never be unserialized');
     }
 
     public function __unserialize(array $data): void
@@ -86,7 +86,7 @@ final class FnStream implements StreamInterface
         $this->methods = [];
         $this->detached = true;
 
-        throw new \LogicException('FnStream should never be unserialized');
+        throw new \LogicException(static::class.' should never be unserialized');
     }
 
     /**

--- a/src/LazyOpenStream.php
+++ b/src/LazyOpenStream.php
@@ -39,7 +39,7 @@ final class LazyOpenStream implements StreamInterface
     {
         $this->stream = new BufferStream();
 
-        throw new \LogicException('LazyOpenStream should never be unserialized');
+        throw new \LogicException(static::class.' should never be unserialized');
     }
 
     /**

--- a/src/PumpStream.php
+++ b/src/PumpStream.php
@@ -64,7 +64,7 @@ final class PumpStream implements StreamInterface
         $this->metadata = [];
         $this->buffer = new BufferStream();
 
-        throw new \LogicException('PumpStream should never be unserialized');
+        throw new \LogicException(static::class.' should never be unserialized');
     }
 
     public function __toString(): string

--- a/tests/FnStreamTest.php
+++ b/tests/FnStreamTest.php
@@ -356,7 +356,7 @@ class FnStreamTest extends TestCase
     public function testDoNotAllowUnserialization(): void
     {
         $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('FnStream should never be unserialized');
+        $this->expectExceptionMessage(FnStream::class.' should never be unserialized');
         unserialize(self::serializedObject(FnStream::class));
     }
 
@@ -373,7 +373,7 @@ class FnStreamTest extends TestCase
             unserialize($payload);
             self::fail('Expected unserialization to fail.');
         } catch (\LogicException $e) {
-            self::assertSame('FnStream should never be unserialized', $e->getMessage());
+            self::assertSame(FnStream::class.' should never be unserialized', $e->getMessage());
         }
 
         self::assertSame(0, FnStreamUnserializeMarker::$calls);

--- a/tests/LazyOpenStreamTest.php
+++ b/tests/LazyOpenStreamTest.php
@@ -80,4 +80,13 @@ class LazyOpenStreamTest extends TestCase
         self::assertSame('foo', stream_get_contents($r));
         fclose($r);
     }
+
+    public function testDoNotAllowUnserialization(): void
+    {
+        $class = LazyOpenStream::class;
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage($class.' should never be unserialized');
+        unserialize(sprintf('O:%d:"%s":0:{}', strlen($class), $class));
+    }
 }

--- a/tests/PumpStreamTest.php
+++ b/tests/PumpStreamTest.php
@@ -337,7 +337,7 @@ class PumpStreamTest extends TestCase
             unserialize($payload);
             self::fail('Expected unserialization to fail.');
         } catch (\LogicException $e) {
-            self::assertSame('PumpStream should never be unserialized', $e->getMessage());
+            self::assertSame(PumpStream::class.' should never be unserialized', $e->getMessage());
         }
 
         self::assertSame(0, PumpStreamUnserializeMarker::$calls);


### PR DESCRIPTION
The stream classes that override `__unserialize()` with custom state cleanup (`FnStream`, `PumpStream`, and `LazyOpenStream`) hardcode their short class names in the refusal messages, while the shared `NonSerializableStreamTrait` reports the fully qualified class via `static::class`, so serializing and unserializing the same class produced differently styled messages. The overrides, including `FnStream::__wakeup()`, now build their messages with `static::class`, matching the trait and the equivalent cleanup in guzzle/guzzle#3791. The exception type and reject-only behavior are unchanged. The existing tests that pinned the short-name messages now assert the fully qualified form, and `LazyOpenStream`, which previously had no unserialization refusal coverage, gains a test.