### PR TITLE
Cover tryGetContents timeout branches and complete timeout notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use PHP debug type names in type error messages
 - Changed `Utils::copyToStream()` to throw when destination streams cannot make progress
 - Throw `TimeoutException` from `Stream` read/write and `Utils` copy/hash/readLine on stream timeouts
+- Throw `TimeoutException` from `AppendStream::read()`, `CachingStream::read()`, and `Utils::tryGetContents()` on stream timeouts
 - Re-throw `TimeoutException` from `InflateStream` when the decoded source stream times out
 - Close the compressed source stream from `InflateStream::close()`
 - Return the number of bytes copied from `Utils::copyToStream()`

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -526,6 +526,7 @@ writable stream such as a file or `php://temp` stream.
 Timed-out stream operations now throw
 `GuzzleHttp\Psr7\Exception\TimeoutException`, which extends
 `RuntimeException`. `Stream::read()`, `Stream::write()`,
+`AppendStream::read()`, `CachingStream::read()`, `InflateStream::read()`,
 `Utils::copyToStream()`, `Utils::copyToString()`, `Utils::hash()`,
 `Utils::readLine()`, and `Utils::tryGetContents()` detect PHP-style stream
 timeout metadata when a read or write operation cannot make progress. Timeout

--- a/composer.json
+++ b/composer.json
@@ -90,7 +90,10 @@
     "autoload-dev": {
         "psr-4": {
             "GuzzleHttp\\Tests\\Psr7\\": "tests/"
-        }
+        },
+        "files": [
+            "tests/PhpStreamMock.php"
+        ]
     },
     "config": {
         "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -90,10 +90,7 @@
     "autoload-dev": {
         "psr-4": {
             "GuzzleHttp\\Tests\\Psr7\\": "tests/"
-        },
-        "files": [
-            "tests/PhpStreamMock.php"
-        ]
+        }
     },
     "config": {
         "allow-plugins": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,7 +5,7 @@
     colors="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
-    bootstrap="vendor/autoload.php"
+    bootstrap="tests/bootstrap.php"
     convertDeprecationsToExceptions="true"
 >
     <testsuites>

--- a/tests/PhpStreamMock.php
+++ b/tests/PhpStreamMock.php
@@ -130,6 +130,12 @@ function stream_get_contents($stream, ?int $length = null, int $offset = -1)
         return PhpStreamMock::$streamGetContentsResult;
     }
 
+    // PHP 7.4's stream_get_contents() rejects a null length, so pass only the
+    // stream when no length was requested (the sole call site does).
+    if ($length === null) {
+        return \stream_get_contents($stream);
+    }
+
     return $offset === -1
         ? \stream_get_contents($stream, $length)
         : \stream_get_contents($stream, $length, $offset);

--- a/tests/PhpStreamMock.php
+++ b/tests/PhpStreamMock.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GuzzleHttp\Tests\Psr7;
+
+/**
+ * Shared mutable state for the `GuzzleHttp\Psr7` stream-function overrides
+ * defined below. Tests toggle these flags to drive low-level read, write, and
+ * timeout paths deterministically without real sockets or timeouts.
+ */
+final class PhpStreamMock
+{
+    public static bool $isFReadError = false;
+    public static bool $isFReadZero = false;
+    public static bool $isFReadException = false;
+    public static bool $isFWriteError = false;
+    public static bool $isFWriteZero = false;
+    public static bool $isFWriteException = false;
+    public static bool $isStreamTimedOut = false;
+    public static bool $isStreamMetadataError = false;
+    public static bool $streamGetContentsReturnsFalse = false;
+    public static ?string $streamGetContentsResult = null;
+    public static ?\Throwable $streamGetContentsThrowable = null;
+
+    public static function reset(): void
+    {
+        self::$isFReadError = false;
+        self::$isFReadZero = false;
+        self::$isFReadException = false;
+        self::$isFWriteError = false;
+        self::$isFWriteZero = false;
+        self::$isFWriteException = false;
+        self::$isStreamTimedOut = false;
+        self::$isStreamMetadataError = false;
+        self::$streamGetContentsReturnsFalse = false;
+        self::$streamGetContentsResult = null;
+        self::$streamGetContentsThrowable = null;
+    }
+}
+
+namespace GuzzleHttp\Psr7;
+
+use GuzzleHttp\Tests\Psr7\PhpStreamMock;
+
+/**
+ * @param resource $handle
+ *
+ * @return string|false
+ */
+function fread($handle, int $length)
+{
+    if (PhpStreamMock::$isFReadException) {
+        throw new \ErrorException('Some read error');
+    }
+
+    if (PhpStreamMock::$isFReadError) {
+        return false;
+    }
+
+    if (PhpStreamMock::$isFReadZero) {
+        return '';
+    }
+
+    return \fread($handle, $length);
+}
+
+/**
+ * @param resource $handle
+ *
+ * @return int|false
+ */
+function fwrite($handle, string $string, ?int $length = null)
+{
+    if (PhpStreamMock::$isFWriteException) {
+        throw new \ErrorException('Some write error');
+    }
+
+    if (PhpStreamMock::$isFWriteError) {
+        return false;
+    }
+
+    if (PhpStreamMock::$isFWriteZero) {
+        return 0;
+    }
+
+    if ($length === null) {
+        return \fwrite($handle, $string);
+    }
+
+    return \fwrite($handle, $string, $length);
+}
+
+/**
+ * @param resource $stream
+ *
+ * @return array<string, mixed>
+ */
+function stream_get_meta_data($stream): array
+{
+    if (PhpStreamMock::$isStreamMetadataError) {
+        throw new \RuntimeException('metadata failed');
+    }
+
+    $metadata = \stream_get_meta_data($stream);
+
+    if (PhpStreamMock::$isStreamTimedOut) {
+        $metadata['timed_out'] = true;
+    }
+
+    return $metadata;
+}
+
+/**
+ * @param resource $stream
+ *
+ * @return string|false
+ */
+function stream_get_contents($stream, ?int $length = null, int $offset = -1)
+{
+    if (PhpStreamMock::$streamGetContentsThrowable !== null) {
+        throw PhpStreamMock::$streamGetContentsThrowable;
+    }
+
+    if (PhpStreamMock::$streamGetContentsReturnsFalse) {
+        return false;
+    }
+
+    if (PhpStreamMock::$streamGetContentsResult !== null) {
+        return PhpStreamMock::$streamGetContentsResult;
+    }
+
+    return $offset === -1
+        ? \stream_get_contents($stream, $length)
+        : \stream_get_contents($stream, $length, $offset);
+}

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -15,25 +15,9 @@ use PHPUnit\Framework\TestCase;
  */
 class StreamTest extends TestCase
 {
-    public static bool $isFReadError = false;
-    public static bool $isFReadZero = false;
-    public static bool $isFReadException = false;
-    public static bool $isFWriteError = false;
-    public static bool $isFWriteZero = false;
-    public static bool $isFWriteException = false;
-    public static bool $isStreamTimedOut = false;
-    public static bool $isStreamMetadataError = false;
-
     protected function tearDown(): void
     {
-        self::$isFReadError = false;
-        self::$isFReadZero = false;
-        self::$isFReadException = false;
-        self::$isFWriteError = false;
-        self::$isFWriteZero = false;
-        self::$isFWriteException = false;
-        self::$isStreamTimedOut = false;
-        self::$isStreamMetadataError = false;
+        PhpStreamMock::reset();
     }
 
     public function testConstructorThrowsExceptionOnInvalidArgument(): void
@@ -280,7 +264,7 @@ class StreamTest extends TestCase
 
     public function testStreamReadingFreadFalse(): void
     {
-        self::$isFReadError = true;
+        PhpStreamMock::$isFReadError = true;
         $r = fopen('php://temp', 'r');
         $stream = new Stream($r);
         $this->expectException(\RuntimeException::class);
@@ -289,12 +273,12 @@ class StreamTest extends TestCase
         try {
             $stream->read(1);
         } catch (\Exception $e) {
-            self::$isFReadError = false;
+            PhpStreamMock::$isFReadError = false;
             $stream->close();
             throw $e;
         }
 
-        self::$isFReadError = false;
+        PhpStreamMock::$isFReadError = false;
         $stream->close();
     }
 
@@ -324,8 +308,8 @@ class StreamTest extends TestCase
 
     public function testStreamReadingFreadFalseWhenTimedOutThrowsTimeoutException(): void
     {
-        self::$isFReadError = true;
-        self::$isStreamTimedOut = true;
+        PhpStreamMock::$isFReadError = true;
+        PhpStreamMock::$isStreamTimedOut = true;
         $r = fopen('php://temp', 'r+');
         $stream = new Stream($r);
 
@@ -341,8 +325,8 @@ class StreamTest extends TestCase
 
     public function testStreamReadingEmptyStringWhenTimedOutThrowsTimeoutException(): void
     {
-        self::$isFReadZero = true;
-        self::$isStreamTimedOut = true;
+        PhpStreamMock::$isFReadZero = true;
+        PhpStreamMock::$isStreamTimedOut = true;
         $r = fopen('php://temp', 'r+');
         $stream = new Stream($r);
 
@@ -358,8 +342,8 @@ class StreamTest extends TestCase
 
     public function testStreamReadingFreadExceptionWhenTimedOutThrowsTimeoutExceptionWithPrevious(): void
     {
-        self::$isFReadException = true;
-        self::$isStreamTimedOut = true;
+        PhpStreamMock::$isFReadException = true;
+        PhpStreamMock::$isStreamTimedOut = true;
         $r = fopen('php://temp', 'r+');
         $stream = new Stream($r);
 
@@ -377,7 +361,7 @@ class StreamTest extends TestCase
 
     public function testStreamReadingEmptyStringWithoutTimeoutReturnsEmptyString(): void
     {
-        self::$isFReadZero = true;
+        PhpStreamMock::$isFReadZero = true;
         $r = fopen('php://temp', 'r+');
         $stream = new Stream($r);
 
@@ -390,7 +374,7 @@ class StreamTest extends TestCase
 
     public function testStreamReadingFreadFalseWithoutTimeoutThrowsRuntimeException(): void
     {
-        self::$isFReadError = true;
+        PhpStreamMock::$isFReadError = true;
         $r = fopen('php://temp', 'r+');
         $stream = new Stream($r);
 
@@ -407,7 +391,7 @@ class StreamTest extends TestCase
 
     public function testStreamWritingFwriteFalseThrowsRuntimeException(): void
     {
-        self::$isFWriteError = true;
+        PhpStreamMock::$isFWriteError = true;
         $r = fopen('php://temp', 'w+');
         $stream = new Stream($r);
 
@@ -423,8 +407,8 @@ class StreamTest extends TestCase
 
     public function testStreamWritingFwriteFalseWhenTimedOutThrowsTimeoutException(): void
     {
-        self::$isFWriteError = true;
-        self::$isStreamTimedOut = true;
+        PhpStreamMock::$isFWriteError = true;
+        PhpStreamMock::$isStreamTimedOut = true;
         $r = fopen('php://temp', 'w+');
         $stream = new Stream($r);
 
@@ -440,8 +424,8 @@ class StreamTest extends TestCase
 
     public function testStreamWritingZeroBytesWhenTimedOutThrowsTimeoutException(): void
     {
-        self::$isFWriteZero = true;
-        self::$isStreamTimedOut = true;
+        PhpStreamMock::$isFWriteZero = true;
+        PhpStreamMock::$isStreamTimedOut = true;
         $r = fopen('php://temp', 'w+');
         $stream = new Stream($r);
 
@@ -457,7 +441,7 @@ class StreamTest extends TestCase
 
     public function testStreamWritingZeroBytesWithoutTimeoutReturnsZero(): void
     {
-        self::$isFWriteZero = true;
+        PhpStreamMock::$isFWriteZero = true;
         $r = fopen('php://temp', 'w+');
         $stream = new Stream($r);
 
@@ -475,9 +459,9 @@ class StreamTest extends TestCase
         $stream = new Stream($r);
         self::assertSame(4, $stream->getSize());
 
-        self::$isFWriteException = true;
-        self::$isStreamTimedOut = true;
-        self::$isStreamMetadataError = true;
+        PhpStreamMock::$isFWriteException = true;
+        PhpStreamMock::$isStreamTimedOut = true;
+        PhpStreamMock::$isStreamMetadataError = true;
 
         try {
             self::assertSame(0, $stream->write(''));
@@ -506,7 +490,7 @@ class StreamTest extends TestCase
     {
         $r = fopen('php://temp', 'w+');
         $stream = new Stream($r);
-        self::$isStreamTimedOut = true;
+        PhpStreamMock::$isStreamTimedOut = true;
 
         try {
             self::assertSame(3, $stream->write('foo'));
@@ -517,8 +501,8 @@ class StreamTest extends TestCase
 
     public function testStreamWritingFwriteExceptionWhenTimedOutThrowsTimeoutExceptionWithPrevious(): void
     {
-        self::$isFWriteException = true;
-        self::$isStreamTimedOut = true;
+        PhpStreamMock::$isFWriteException = true;
+        PhpStreamMock::$isStreamTimedOut = true;
         $r = fopen('php://temp', 'w+');
         $stream = new Stream($r);
 
@@ -536,7 +520,7 @@ class StreamTest extends TestCase
 
     public function testStreamWritingFwriteExceptionWithoutTimeoutThrowsRuntimeExceptionWithPrevious(): void
     {
-        self::$isFWriteException = true;
+        PhpStreamMock::$isFWriteException = true;
         $r = fopen('php://temp', 'w+');
         $stream = new Stream($r);
 
@@ -555,10 +539,10 @@ class StreamTest extends TestCase
 
     public function testStreamWritingFwriteFalseWhenMetadataProbeFailsPreservesGenericRuntimeException(): void
     {
-        self::$isFWriteError = true;
+        PhpStreamMock::$isFWriteError = true;
         $r = fopen('php://temp', 'w+');
         $stream = new Stream($r);
-        self::$isStreamMetadataError = true;
+        PhpStreamMock::$isStreamMetadataError = true;
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Unable to write to stream');
@@ -794,76 +778,4 @@ class StreamTest extends TestCase
             $stream->close();
         }
     }
-}
-
-namespace GuzzleHttp\Psr7;
-
-use GuzzleHttp\Tests\Psr7\StreamTest;
-
-/**
- * @param resource $handle
- *
- * @return string|false
- */
-function fread($handle, int $length)
-{
-    if (StreamTest::$isFReadException) {
-        throw new \ErrorException('Some read error');
-    }
-
-    if (StreamTest::$isFReadError) {
-        return false;
-    }
-
-    if (StreamTest::$isFReadZero) {
-        return '';
-    }
-
-    return \fread($handle, $length);
-}
-
-/**
- * @param resource $handle
- *
- * @return int|false
- */
-function fwrite($handle, string $string, ?int $length = null)
-{
-    if (StreamTest::$isFWriteException) {
-        throw new \ErrorException('Some write error');
-    }
-
-    if (StreamTest::$isFWriteError) {
-        return false;
-    }
-
-    if (StreamTest::$isFWriteZero) {
-        return 0;
-    }
-
-    if ($length === null) {
-        return \fwrite($handle, $string);
-    }
-
-    return \fwrite($handle, $string, $length);
-}
-
-/**
- * @param resource $stream
- *
- * @return array<string, mixed>
- */
-function stream_get_meta_data($stream): array
-{
-    if (StreamTest::$isStreamMetadataError) {
-        throw new \RuntimeException('metadata failed');
-    }
-
-    $metadata = \stream_get_meta_data($stream);
-
-    if (StreamTest::$isStreamTimedOut) {
-        $metadata['timed_out'] = true;
-    }
-
-    return $metadata;
 }

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -13,6 +13,11 @@ use Psr\Http\Message\UriInterface;
 
 class UtilsTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        PhpStreamMock::reset();
+    }
+
     public function testCopiesToString(): void
     {
         $s = Psr7\Utils::streamFor('foobaz');
@@ -627,6 +632,56 @@ class UtilsTest extends TestCase
         $this->expectExceptionMessage('Unable to read stream contents');
 
         Psr7\Utils::tryGetContents($r);
+    }
+
+    public function testTryGetContentsThrowsTimeoutWhenReadReturnsFalseAndResourceTimedOut(): void
+    {
+        PhpStreamMock::$streamGetContentsReturnsFalse = true;
+        PhpStreamMock::$isStreamTimedOut = true;
+        $resource = Psr7\Utils::tryFopen('php://temp', 'r+');
+
+        $this->expectException(Psr7\Exception\TimeoutException::class);
+        $this->expectExceptionMessage('Unable to read stream contents: timed out');
+
+        try {
+            Psr7\Utils::tryGetContents($resource);
+        } finally {
+            fclose($resource);
+        }
+    }
+
+    public function testTryGetContentsThrowsTimeoutWhenPartialReadTimesOut(): void
+    {
+        PhpStreamMock::$streamGetContentsResult = 'partial';
+        PhpStreamMock::$isStreamTimedOut = true;
+        $resource = Psr7\Utils::tryFopen('php://temp', 'r+');
+
+        $this->expectException(Psr7\Exception\TimeoutException::class);
+        $this->expectExceptionMessage('Unable to read stream contents: timed out');
+
+        try {
+            Psr7\Utils::tryGetContents($resource);
+        } finally {
+            fclose($resource);
+        }
+    }
+
+    public function testTryGetContentsWrapsReadFailureWhenResourceTimedOut(): void
+    {
+        $previous = new \ErrorException('read failed');
+        PhpStreamMock::$streamGetContentsThrowable = $previous;
+        PhpStreamMock::$isStreamTimedOut = true;
+        $resource = Psr7\Utils::tryFopen('php://temp', 'r+');
+
+        try {
+            Psr7\Utils::tryGetContents($resource);
+            self::fail('Expected timeout exception.');
+        } catch (Psr7\Exception\TimeoutException $e) {
+            self::assertSame('Unable to read stream contents: timed out', $e->getMessage());
+            self::assertSame($previous, $e->getPrevious());
+        } finally {
+            fclose($resource);
+        }
     }
 
     public function testCreatesUriForValue(): void

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__.'/../vendor/autoload.php';
+
+// Define the GuzzleHttp\Psr7 stream-function overrides before any test runs, so
+// they bind ahead of the first call site. Loading them here rather than through
+// composer autoload keeps them out of static analysis, which only bootstraps the
+// composer autoloader.
+require __DIR__.'/PhpStreamMock.php';


### PR DESCRIPTION
Timeout detection is new public 3.0 behavior, but `Utils::tryGetContents()`'s three timeout-classification branches (a `false` read, a partial read, and a thrown read, each with timed-out resource metadata) had no test coverage, and the release notes under-reported the timeout API surface. This adds deterministic coverage for those branches and completes the enumeration.

Because `tryGetContents()` operates on a raw resource and consults native `stream_get_contents()`/`stream_get_meta_data()` rather than a `StreamInterface`, the existing interface-level timeout fakes cannot reach it, so the tests use `GuzzleHttp\Psr7`-namespaced function overrides. `StreamTest` already defined such overrides at the bottom of its file; to add a `stream_get_contents()` override without a fatal redeclare, this moves the shared overrides and their state into a new `tests/PhpStreamMock.php` registered through `composer.json` `autoload-dev.files`, so every override is defined before any call site binds. `StreamTest` now drives the same overrides through `PhpStreamMock` with no behavior change.

The changelog and upgrade guide now also list `AppendStream::read()`, `CachingStream::read()`, and `Utils::tryGetContents()` (and `InflateStream::read()` in the upgrade guide) among the APIs that throw `TimeoutException`, which the previous enumeration omitted. No runtime code changes.
