### PR TITLE
Document custom MultipartStream boundary '0' preservation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Stop adding default `Content-Length` to `multipart/form-data` parts (RFC 7578 §4.8)
 - Escape multipart `Content-Disposition` parameters and reject unsafe boundaries and part headers
 - Preserve trailing whitespace in custom `MultipartStream` part header values
+- Preserve explicit custom `MultipartStream` boundary `'0'` instead of replacing it with a generated boundary
 - Made static utility classes non-instantiable
 - Validate bracketed IP-literal hosts consistently between parsing and `withHost()`, including userinfo forms
 - Normalize percent-encoded octets in the URI host to uppercase hex

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -634,6 +634,11 @@ Explicit custom boundaries are now validated using RFC 2046 multipart boundary
 syntax. Omit the boundary or pass `null` to continue using a generated random
 boundary.
 
+The string `'0'` is now treated as an explicit custom boundary and is serialized
+literally. In 2.x, PHP truthiness caused `new MultipartStream($elements, '0')`
+to use a generated random boundary. Omit the boundary or pass `null` when you
+want a generated boundary.
+
 Custom multipart part header names and values are also validated before
 serialization. Header names must be valid HTTP tokens, and header values must be
 strings without CR, LF, or other invalid control bytes.


### PR DESCRIPTION
A custom `MultipartStream` boundary of `'0'` is now preserved and serialized literally, but the release notes did not mention this 2.x-to-3.0 change. In 2.x the boundary was assigned with `$boundary ?: bin2hex(random_bytes(20))`, so PHP truthiness replaced `'0'` with a generated random boundary. In 3.0 the nullable constructor parameter and RFC 2046 validation make `'0'` a valid explicit boundary that is serialized as `--0`.

Raw multipart bytes matter for snapshot tests, request signatures, reproducible fixtures, and peers requiring fixed boundaries, so this behavior change is worth calling out. This adds a changelog bullet and an upgrade-guide paragraph next to the existing custom-boundary notes. It is documentation only; the runtime behavior is already covered by the existing `getBoundary()` test for `'0'`.
