### PR TITLE
Harden bracketed IP-literal authority parsing on 2.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Anchor server port and response start-line patterns to the true end of input
 - Treat host-less origin-form request targets starting with `//` as paths in `Message::parseRequest()`
+- Reject raw DEL bytes in bracketed IP-literal hosts instead of parsing a mutated host
+- Reject invalid bytes after a bracketed IP-literal host instead of reparsing a different host
 
 ## 2.12.3 - 2026-06-23
 

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -99,9 +99,11 @@ class Uri implements UriInterface, \JsonSerializable
             return self::parsePathNoSchemeReference($url);
         }
 
-        // Preserve bracketed IPv6 literals before encoding, including dotted IPv4 tails.
+        // Preserve bracketed IPv6 literals before encoding, including dotted IPv4
+        // tails. DEL (\x7F) is excluded so a raw-DEL host falls through to the
+        // general path and is rejected rather than silently mutated by parse_url().
         $prefix = '';
-        $ipv6Prefix = preg_match('%\A([0-9A-Za-z+.-]+://\[[^\]\x00-\x20/?#@]+\])(.*)\z%s', $url, $matches);
+        $ipv6Prefix = preg_match('%\A([0-9A-Za-z+.-]+://\[[^\]\x00-\x20\x7F/?#@]+\])(.*)\z%s', $url, $matches);
 
         if ($ipv6Prefix === false) {
             return false;
@@ -111,7 +113,11 @@ class Uri implements UriInterface, \JsonSerializable
             /** @var array{0:string, 1:string, 2:string} $matches */
             $suffix = $matches[2];
 
-            if ($suffix !== '' && strpos(':/?#', $suffix[0]) === false) {
+            // After the bracketed host only an optional numeric port and/or a
+            // path, query, or fragment may follow. Anything else (for example
+            // `:80@evil` or `:80x`) would let parse_url() reinterpret a
+            // different host.
+            if (preg_match('%\A(?::[0-9]*)?(?:[/?#].*)?\z%s', $suffix) !== 1) {
                 return false;
             }
 

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -157,6 +157,48 @@ class UriTest extends TestCase
     }
 
     /**
+     * @dataProvider getAmbiguousBracketedIpLiteralSuffixes
+     */
+    public function testParseRejectsAmbiguousBracketedIpLiteralSuffix(string $uri): void
+    {
+        $this->expectException(MalformedUriException::class);
+
+        new Uri($uri);
+    }
+
+    public static function getAmbiguousBracketedIpLiteralSuffixes(): iterable
+    {
+        yield 'userinfo after port' => ['http://[::1]:80@evil/'];
+        yield 'userinfo after empty port' => ['http://[::1]:@evil/'];
+        yield 'non-numeric port' => ['http://[::1]:80x/'];
+        yield 'trailing bytes' => ['http://[::1]foo/'];
+    }
+
+    public function testParseRejectsDelInBracketedIpLiteralHost(): void
+    {
+        $this->expectException(MalformedUriException::class);
+
+        new Uri("http://[v1.a\x7Fb]/");
+    }
+
+    /**
+     * @dataProvider getValidBracketedIpLiteralUris
+     */
+    public function testParsePreservesValidBracketedIpLiteral(string $uri, string $host): void
+    {
+        self::assertSame($host, (new Uri($uri))->getHost());
+    }
+
+    public static function getValidBracketedIpLiteralUris(): iterable
+    {
+        yield 'plain' => ['http://[::1]/', '[::1]'];
+        yield 'port + path + query + fragment' => ['http://[::1]:8080/x?q#f', '[::1]'];
+        yield 'userinfo' => ['http://user:pw@[::1]:80/a', '[::1]'];
+        yield 'empty port' => ['http://[::1]:', '[::1]'];
+        yield 'ipvfuture' => ['http://[v1.abc]/', '[v1.abc]'];
+    }
+
+    /**
      * @dataProvider getPathNoSchemeReferencesWithColonInLaterSegment
      */
     public function testParsesPathNoSchemeReferenceWithColonInLaterSegment(string $input, string $path, string $query = '', string $fragment = '', ?string $expectedString = null): void


### PR DESCRIPTION
This backports the minimal `Uri::parse()` fast-path hardening from #831 to the 2.12 line. The bracketed IP-literal fast path only checked the first byte after the bracketed host, so a suffix such as `:80@evil` or `:80x` slipped through to `parse_url()`, which reinterpreted the authority and produced a different host, for example `http://[::1]:80@evil/` resolving its host to `evil`. The suffix is now validated to be an optional numeric port (which may be empty) followed by an optional path, query, or fragment, so these malformed authorities are rejected rather than reparsed.

The fast path also passed raw DEL bytes in bracketed hosts straight to `parse_url()`, which rewrites them to `_`, so `http://[v1.a\x7Fb]/` was silently accepted with its host mutated to `[v1.a_b]`. DEL is now excluded from the bracketed host capture, and such hosts are rejected as invalid. The userinfo changes in #831 have no 2.12 counterpart because this fast path captures no userinfo, and network-path and userinfo authority forms continue to behave as before. New tests cover the rejected suffixes, the DEL host, and the preserved valid bracketed forms.
