### PR TITLE
Drop 3.0.0 changelog entries now shipped in 2.12.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,8 +77,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Validate bracketed IP-literal hosts consistently between parsing and `withHost()`, including userinfo forms
 - Percent-encode raw control bytes in userinfo before bracketed IP-literal hosts instead of parsing mutated values
 - Reject invalid UTF-8 and preserve percent-sequences in userinfo before bracketed IP-literal hosts
-- Reject raw DEL bytes in bracketed IP-literal hosts instead of parsing a mutated host
-- Reject invalid bytes after a bracketed IP-literal host instead of reparsing a different host
 - Normalize percent-encoded octets in the URI host to uppercase hex
 - Trim header list elements with only spaces, horizontal tabs, and line terminators in `Header::splitList()`
 - Report header parameter PCRE failures explicitly in `Header::parse()`


### PR DESCRIPTION
The bracketed IP-literal DEL and suffix hardening from #831 now also ships on the 2.12 line via #836, whose changelog entries use the same wording and will reach this branch under 2.12.4 through the normal changelog merge-up. The unreleased 3.0.0 section only lists changes relative to the 2.x line, so this drops the two entries that would otherwise appear twice. The two userinfo entries remain because the 2.12 fast path carries no userinfo group and they are 3.0-only.
