### PR TITLE
Cover manual guard-rail exceptions in tests

### DIFF
--- a/tests/HeaderTest.php
+++ b/tests/HeaderTest.php
@@ -225,4 +225,27 @@ class HeaderTest extends TestCase
     {
         self::assertSame($result, Psr7\Header::splitList($header));
     }
+
+    public static function nonStringSplitListValueProvider(): array
+    {
+        return [
+            'top-level integer' => [1],
+            'integer element' => [[1]],
+            'mixed element list' => [['ok', 1]],
+            'object element' => [[new \stdClass()]],
+        ];
+    }
+
+    /**
+     * @dataProvider nonStringSplitListValueProvider
+     *
+     * @param mixed $values
+     */
+    public function testSplitListRejectsNonStringValues($values): void
+    {
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('$header must either be a string or an array containing strings.');
+
+        Psr7\Header::splitList($values);
+    }
 }

--- a/tests/LazyOpenStreamTest.php
+++ b/tests/LazyOpenStreamTest.php
@@ -89,4 +89,62 @@ class LazyOpenStreamTest extends TestCase
         $this->expectExceptionMessage($class.' should never be unserialized');
         unserialize(sprintf('O:%d:"%s":0:{}', strlen($class), $class));
     }
+
+    public function testUnserializationCannotOpenFileFromDestructor(): void
+    {
+        LazyOpenStreamUnserializeStringCastOnDestruct::$casts = [];
+        $payload = self::serializedObjectWithProperties(LazyOpenStreamUnserializeStringCastOnDestruct::class, [
+            'stream' => self::serializedObjectWithProperties(LazyOpenStream::class, [
+                self::privateProperty(LazyOpenStream::class, 'filename') => serialize($this->fname),
+                self::privateProperty(LazyOpenStream::class, 'mode') => serialize('w+'),
+            ]),
+        ]);
+
+        try {
+            unserialize($payload);
+            self::fail('Expected unserialization to fail.');
+        } catch (\LogicException $e) {
+            self::assertSame(LazyOpenStream::class.' should never be unserialized', $e->getMessage());
+        }
+
+        self::assertSame([''], LazyOpenStreamUnserializeStringCastOnDestruct::$casts);
+        self::assertFileDoesNotExist($this->fname);
+    }
+
+    private static function privateProperty(string $class, string $property): string
+    {
+        return "\0".$class."\0".$property;
+    }
+
+    /**
+     * @param array<string, string> $properties Serialized property values indexed by property name.
+     */
+    private static function serializedObjectWithProperties(string $class, array $properties): string
+    {
+        $body = '';
+        foreach ($properties as $name => $serializedValue) {
+            $body .= serialize($name).$serializedValue;
+        }
+
+        return sprintf('O:%d:"%s":%d:{%s}', strlen($class), $class, count($properties), $body);
+    }
+}
+
+final class LazyOpenStreamUnserializeStringCastOnDestruct
+{
+    /** @var mixed */
+    public $stream;
+
+    /** @var list<string> */
+    public static array $casts = [];
+
+    public function __destruct()
+    {
+        try {
+            if ($this->stream instanceof LazyOpenStream) {
+                self::$casts[] = (string) $this->stream;
+            }
+        } catch (\Throwable $e) {
+        }
+    }
 }

--- a/tests/NonSerializableStreamTraitTest.php
+++ b/tests/NonSerializableStreamTraitTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GuzzleHttp\Tests\Psr7;
+
+use GuzzleHttp\Psr7;
+use PHPUnit\Framework\TestCase;
+
+class NonSerializableStreamTraitTest extends TestCase
+{
+    /**
+     * @dataProvider streamFactoryProvider
+     */
+    public function testDoNotAllowSerialization(string $class, callable $factory): void
+    {
+        if ($class === Psr7\InflateStream::class && !extension_loaded('zlib')) {
+            self::markTestSkipped('zlib is required for InflateStream serialization coverage.');
+        }
+
+        $stream = $factory();
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage($class.' should never be serialized');
+
+        serialize($stream);
+    }
+
+    /**
+     * @dataProvider inheritedUnserializeClassProvider
+     */
+    public function testDoNotAllowUnserialization(string $class): void
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage($class.' should never be unserialized');
+
+        unserialize(sprintf('O:%d:"%s":0:{}', strlen($class), $class));
+    }
+
+    public static function streamFactoryProvider(): array
+    {
+        return [
+            Psr7\AppendStream::class => [Psr7\AppendStream::class, static fn () => new Psr7\AppendStream()],
+            Psr7\BufferStream::class => [Psr7\BufferStream::class, static fn () => new Psr7\BufferStream()],
+            Psr7\CachingStream::class => [Psr7\CachingStream::class, static fn () => new Psr7\CachingStream(Psr7\Utils::streamFor('body'))],
+            Psr7\DroppingStream::class => [Psr7\DroppingStream::class, static fn () => new Psr7\DroppingStream(Psr7\Utils::streamFor(''), 1)],
+            Psr7\FnStream::class => [Psr7\FnStream::class, static fn () => new Psr7\FnStream([])],
+            Psr7\InflateStream::class => [Psr7\InflateStream::class, static fn () => new Psr7\InflateStream(Psr7\Utils::streamFor(gzencode('body')))],
+            Psr7\LazyOpenStream::class => [Psr7\LazyOpenStream::class, static fn () => new Psr7\LazyOpenStream('/path/to/nonexistent', 'r')],
+            Psr7\LimitStream::class => [Psr7\LimitStream::class, static fn () => new Psr7\LimitStream(Psr7\Utils::streamFor('body'), 1)],
+            Psr7\MultipartStream::class => [Psr7\MultipartStream::class, static fn () => new Psr7\MultipartStream([], 'guard')],
+            Psr7\NoSeekStream::class => [Psr7\NoSeekStream::class, static fn () => new Psr7\NoSeekStream(Psr7\Utils::streamFor('body'))],
+            Psr7\PumpStream::class => [Psr7\PumpStream::class, static fn () => new Psr7\PumpStream(static fn (): bool => false)],
+            Psr7\Stream::class => [Psr7\Stream::class, static fn () => new Psr7\Stream(Psr7\Utils::tryFopen('php://temp', 'r+'))],
+        ];
+    }
+
+    public static function inheritedUnserializeClassProvider(): array
+    {
+        // FnStream, PumpStream, and LazyOpenStream override __unserialize()
+        // and are covered by their own test files.
+        return [
+            Psr7\AppendStream::class => [Psr7\AppendStream::class],
+            Psr7\BufferStream::class => [Psr7\BufferStream::class],
+            Psr7\CachingStream::class => [Psr7\CachingStream::class],
+            Psr7\DroppingStream::class => [Psr7\DroppingStream::class],
+            Psr7\InflateStream::class => [Psr7\InflateStream::class],
+            Psr7\LimitStream::class => [Psr7\LimitStream::class],
+            Psr7\MultipartStream::class => [Psr7\MultipartStream::class],
+            Psr7\NoSeekStream::class => [Psr7\NoSeekStream::class],
+            Psr7\Stream::class => [Psr7\Stream::class],
+        ];
+    }
+}


### PR DESCRIPTION
Native type declarations cannot protect hand-written throw statements, so a refactor could weaken or delete them without any test failing. This tests-only change pins three such guard rails: the manual `TypeError` that `Header::splitList()` raises for non-string values (including the top-level scalar case its untyped signature admits), the `LogicException`s from `NonSerializableStreamTrait` covering native `serialize()` for all twelve stream classes and `unserialize()` for the nine that inherit the trait's `__unserialize()`, and the gadget-defense path in `LazyOpenStream::__unserialize()`, which must install an inert `BufferStream` before throwing so that a destructor string-cast during unserialization failure cleanup cannot trigger a lazy file open. The new gadget test asserts the cast completes inertly and that a sentinel file with a create-capable mode is never created.