### PR TITLE
Harden absolute-form request-target parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,11 +48,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reject malformed `REQUEST_METHOD` and `SERVER_PROTOCOL` server values in `ServerRequest::fromGlobals()`
 - Reject zero-port `Host` and normalize leading-zero ports in `Message::parseRequest()`
 - Reject duplicate `Host` headers and validate present values for all request-target forms
+- Reject zero-port, hostless, and userinfo absolute-form request targets in `Message::parseRequest()`
 - Synchronize the `Host` header in `Request::withUri()` when the URI changes or Host is empty
 - Include the URI port in `Host` headers synthesized by `Message::toString()`
 - Include non-default URI ports in `Host` headers set by `Utils::modifyRequest()` URI changes
 - Accept `OPTIONS *` and `CONNECT` authority-form request targets in `Message::parseRequest()`
 - Reject malformed HTTP request/response start-lines
+- Reject empty and control-character request targets in `Request::withRequestTarget()`
 - Validate iterator chunks passed to `Utils::streamFor()`
 - Validate unsupported values passed to `Query::build()`
 - Reject non-finite float values in `Query::build()` and `MultipartStream` contents

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -278,6 +278,21 @@ For server globals, applications that need to reject malformed inbound `Host`
 headers should validate the original server parameters before calling
 `getUriFromGlobals()` or inspect them afterward.
 
+`Message::parseRequest()` now applies the same HTTP authority validation to
+absolute-form request targets. A zero or padded-zero port
+(`http://example.com:0/admin`) is rejected instead of producing a request
+whose synthesized `Host` header the same parser rejects elsewhere.
+Absolute-form targets with no URI host, such as `file:///etc/passwd`, are
+also rejected instead of producing a hostless request URI.
+
+Absolute-form targets whose authority contains userinfo are also rejected,
+including empty userinfo such as `http://@example.com/`. RFC 9110 deprecates
+userinfo in http(s) target URIs and directs recipients to treat its presence
+as an error; `Host` headers and CONNECT targets already reject it. These
+rules apply to absolute-form targets of every scheme.
+`ServerRequest::fromGlobals()` is unchanged and continues to strip
+`REQUEST_URI` userinfo.
+
 #### Request Host Synchronization
 
 `Request::withUri()` now applies PSR-7 Host header synchronization before using
@@ -410,6 +425,9 @@ hydrated, such as the `SERVER_PROTOCOL` value `INCLUDED` that Apache sets for
 server-side include subrequests, now throw `InvalidArgumentException`. Sanitize
 `$_SERVER` before calling `fromGlobals()` if such environments must be
 tolerated.
+
+`Request::withRequestTarget('')` throws `InvalidArgumentException`; omit the
+explicit request target to derive `/` or the URI-derived target automatically.
 
 #### Query Builder Values
 

--- a/src/Message.php
+++ b/src/Message.php
@@ -426,10 +426,11 @@ final class Message
             );
         }
 
-        if (Rfc9112::isAbsoluteFormRequestTarget($matches['target'])) {
+        $absoluteFormUri = self::parseAbsoluteFormRequestTarget($matches['target']);
+        if ($absoluteFormUri !== null) {
             return (new Request(
                 $matches['method'],
-                $matches['target'],
+                $absoluteFormUri,
                 $data['headers'],
                 $data['body'],
                 $matches['version']
@@ -458,6 +459,41 @@ final class Message
         }
 
         throw new \InvalidArgumentException('Invalid request string');
+    }
+
+    private static function parseAbsoluteFormRequestTarget(string $target): ?Uri
+    {
+        if (!Rfc9112::isAbsoluteFormRequestTarget($target)) {
+            return null;
+        }
+
+        $authority = substr($target, strpos($target, '//') + 2);
+        $authority = substr($authority, 0, strcspn($authority, '/?#'));
+
+        // RFC 9110 deprecates userinfo in message target URIs and directs
+        // recipients to treat its presence as an error, since it can obscure
+        // the authority. Host headers and CONNECT targets already reject it.
+        if (str_contains($authority, '@')) {
+            return null;
+        }
+
+        try {
+            $uri = new Uri($target);
+        } catch (\InvalidArgumentException $e) {
+            return null;
+        }
+
+        if ($uri->getHost() === '') {
+            return null;
+        }
+
+        try {
+            self::parseHostHeaderAuthority(self::composeAuthority($uri->getHost(), $uri->getPort()));
+        } catch (\InvalidArgumentException $e) {
+            return null;
+        }
+
+        return $uri;
     }
 
     private static function parseConnectAuthorityFormRequestTarget(string $method, string $target): ?Uri

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -358,6 +358,28 @@ class MessageTest extends TestCase
         self::assertSame('https://up.example//admin', (string) $request->getUri());
     }
 
+    /**
+     * @dataProvider validAbsoluteFormTargetProvider
+     */
+    public function testParseRequestAcceptsAbsoluteFormTarget(string $target, string $expectedHost, string $expectedUri): void
+    {
+        $request = Psr7\Message::parseRequest("GET {$target} HTTP/1.1\r\n\r\n");
+
+        self::assertSame($target, $request->getRequestTarget());
+        self::assertSame($expectedHost, $request->getHeaderLine('Host'));
+        self::assertSame($expectedUri, (string) $request->getUri());
+    }
+
+    public static function validAbsoluteFormTargetProvider(): iterable
+    {
+        yield 'non-default port' => ['http://up.example:8080/admin', 'up.example:8080', 'http://up.example:8080/admin'];
+        yield 'ipv6 non-default port' => ['http://[::1]:8080/admin?x=1', '[::1]:8080', 'http://[::1]:8080/admin?x=1'];
+        yield 'path at-sign' => ['http://up.example/admin@v1', 'up.example', 'http://up.example/admin@v1'];
+        yield 'query at-sign' => ['http://up.example?email=user@example.com', 'up.example', 'http://up.example?email=user@example.com'];
+        yield 'percent-encoded authority delimiters in host' => ['http://user%3Apass%40example.com/admin', 'user%3Apass%40example.com', 'http://user%3Apass%40example.com/admin'];
+        yield 'empty port' => ['http://up.example:/admin', 'up.example', 'http://up.example/admin'];
+    }
+
     public function testParsesOptionsAsteriskFormRequestTarget(): void
     {
         $req = "OPTIONS * HTTP/1.1\r\nHost: foo.com\r\n\r\n";
@@ -570,6 +592,17 @@ class MessageTest extends TestCase
         yield 'connect user info' => ['CONNECT user@up.example:443 HTTP/1.1'];
         yield 'connect path' => ['CONNECT up.example:443/ HTTP/1.1'];
         yield 'connect query' => ['CONNECT up.example:443?x=1 HTTP/1.1'];
+        yield 'absolute-form zero port' => ['GET http://up.example:0/admin HTTP/1.1'];
+        yield 'absolute-form ipv6 zero port' => ['GET http://[::1]:0/admin HTTP/1.1'];
+        yield 'absolute-form zero padded zero port' => ['GET http://up.example:0000/admin HTTP/1.1'];
+        yield 'absolute-form missing host' => ['GET file:///etc/passwd HTTP/1.1'];
+        yield 'absolute-form user info' => ['GET http://user:pass@up.example/admin HTTP/1.1'];
+        yield 'absolute-form authority-obscuring user info' => ['GET http://trusted.example@evil.example/admin HTTP/1.1'];
+        yield 'absolute-form empty user info' => ['GET http://@up.example/admin HTTP/1.1'];
+        yield 'absolute-form double at user info' => ['GET http://a@b@up.example/admin HTTP/1.1'];
+        yield 'absolute-form ipv6 user info' => ['GET http://u@[::1]:8080/admin HTTP/1.1'];
+        yield 'absolute-form user info zero port' => ['GET http://u@up.example:0/admin HTTP/1.1'];
+        yield 'absolute-form non-http user info' => ['GET ftp://u:p@files.example/x HTTP/1.1'];
         yield 'invalid protocol text' => ['GET / HTTP/foo'];
         yield 'invalid protocol segments' => ['GET / HTTP/1.1.1'];
         yield 'bare carriage return after version' => ["GET / HTTP/1.1\rX-Injected: yes"];


### PR DESCRIPTION
`Message::parseRequest()` already applies HTTP authority validation to `Host` headers and to origin-form, asterisk-form, and CONNECT request targets, but the absolute-form branch handed the raw target straight to the `Request` constructor. It now routes absolute-form targets through the same validation, so a zero or padded-zero port no longer produces a request whose synthesized `Host` header the same parser rejects elsewhere, hostless targets such as `file:///etc/passwd` no longer produce a hostless request URI, and targets whose authority contains userinfo are rejected per RFC 9110's guidance that recipients treat request-target userinfo as an error because it is likely obscuring the authority. This follows the direction of #684/#690 and #717/#722.

The userinfo guard runs on the raw authority bytes before URI normalization, so empty userinfo (`http://@example.com/`) and multi-`@` authorities are rejected rather than parsed into a sanitized URI whose preserved raw target downstream consumers could re-split at a different `@`; percent-encoded octets in a host such as `http://user%3Apass%40example.com/` remain accepted, matching `Host` header handling. The userinfo and hostless rules apply to absolute-form targets of every scheme, which is stricter than RFC 9110's http(s)-scoped SHOULD. Unparseable absolute-form targets now throw base `InvalidArgumentException` instead of `MalformedUriException` (a subclass, so existing catch sites are unaffected), matching the CONNECT helper. nginx and Apache 2.4 with default `HttpProtocolOptions Strict` also reject request-line userinfo, and curl never emits userinfo on the wire.

`ServerRequest::fromGlobals()` is deliberately unchanged: it consumes a locally-derived value rather than raw wire input, and keeps stripping `REQUEST_URI` userinfo and accepting port zero. `Message::toString()` can still serialize manually built port-zero or userinfo-target requests, so such round-trips no longer re-parse, as was already the case for the Host-header path. The upgrade guide also gains the previously missing note that `Request::withRequestTarget()` rejects empty and control-character targets, with a matching changelog entry.