### PR TITLE
Unfold obsolete HTTP/1.0 line folding for all method tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Include non-default URI ports in `Host` headers set by `Utils::modifyRequest()` URI changes
 - Accept `OPTIONS *` and `CONNECT` authority-form request targets in `Message::parseRequest()`
 - Reject malformed HTTP request/response start-lines
+- Unfold obsolete HTTP/1.0 line folding for all valid request method tokens
 - Reject empty and control-character request targets in `Request::withRequestTarget()`
 - Validate iterator chunks passed to `Utils::streamFor()`
 - Validate unsupported values passed to `Query::build()`

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -429,6 +429,12 @@ tolerated.
 `Request::withRequestTarget('')` throws `InvalidArgumentException`; omit the
 explicit request target to derive `/` or the URI-derived target automatically.
 
+`Message::parseMessage()` no longer unfolds folded HTTP/1.0 messages whose
+start line carries control bytes in the request target; such messages now
+throw the obsolete-line-folding `InvalidArgumentException`.
+`Message::parseRequest()` and `Message::parseResponse()` rejected these
+messages either way.
+
 #### Query Builder Values
 
 `Query::build()` now rejects unsupported values instead of relying on PHP string

--- a/src/Message.php
+++ b/src/Message.php
@@ -13,6 +13,18 @@ final class Message
 {
     private const DEFAULT_BODY_SUMMARY_TRUNCATE_AT = 120;
 
+    /**
+     * Method token (tchar+) for use in a regex.
+     *
+     * @see https://datatracker.ietf.org/doc/html/rfc9110#section-5.6.2
+     */
+    private const REQUEST_METHOD_TOKEN = '[!#$%&\'*+.^_`|~0-9A-Za-z-]+';
+
+    /**
+     * Request-target bytes accepted by the start-line parser (no CTL, SP, or DEL), for use in a regex.
+     */
+    private const REQUEST_TARGET_CHARS = '[^\x00-\x20\x7F]+';
+
     private function __construct()
     {
     }
@@ -231,7 +243,11 @@ final class Message
 
         [$startLine, $rawHeaders] = $headerParts;
 
-        $versionMatch = preg_match("/(?:^HTTP\/|^[A-Z]+ \S+ HTTP\/)(\d+(?:\.\d+)?)/i", $startLine, $matches);
+        $versionMatch = preg_match(
+            '/(?:^HTTP\/|^'.self::REQUEST_METHOD_TOKEN.' '.self::REQUEST_TARGET_CHARS.' HTTP\/)(\d+(?:\.\d+)?)/i',
+            $startLine,
+            $matches
+        );
 
         if ($versionMatch === false) {
             throw new \RuntimeException('Unable to parse HTTP start line: '.preg_last_error_msg());
@@ -404,7 +420,11 @@ final class Message
     {
         $data = self::parseMessage($message);
         $matches = [];
-        $matched = preg_match('/^(?P<method>[!#$%&\'*+.^_`|~0-9A-Za-z-]+) (?P<target>[^\x00-\x20\x7F]+) HTTP\/(?P<version>\d+(?:\.\d+)?)$/D', $data['start-line'], $matches);
+        $matched = preg_match(
+            '/^(?P<method>'.self::REQUEST_METHOD_TOKEN.') (?P<target>'.self::REQUEST_TARGET_CHARS.') HTTP\/(?P<version>\d+(?:\.\d+)?)$/D',
+            $data['start-line'],
+            $matches
+        );
 
         if ($matched === false) {
             throw new \RuntimeException('Unable to parse request start line: '.preg_last_error_msg());

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -538,12 +538,45 @@ class MessageTest extends TestCase
         self::assertSame('Bar Bam', $request->getHeaderLine('Foo'));
     }
 
+    /**
+     * @dataProvider foldedTokenMethodProvider
+     */
+    public function testParsesRequestMessagesWithFoldedHeadersAndTokenMethodOnHttp10(string $method): void
+    {
+        $request = Psr7\Message::parseRequest("{$method} / HTTP/1.0\r\nFoo: Bar\r\n Bam\r\n\r\n");
+
+        self::assertSame($method, $request->getMethod());
+        self::assertSame('Bar Bam', $request->getHeaderLine('Foo'));
+    }
+
+    public static function foldedTokenMethodProvider(): iterable
+    {
+        yield 'underscore' => ['GET_DATA'];
+        yield 'hyphen' => ['M-SEARCH'];
+    }
+
+    public function testParseMessageRejectsFoldedHeadersWhenTargetHasControlBytes(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid header syntax: Obsolete line folding');
+
+        Psr7\Message::parseMessage("GET /a\x7Fb HTTP/1.0\r\nFoo: Bar\r\n Bam\r\n\r\n");
+    }
+
+    public function testParseMessageUnfoldsFoldedHeadersWithLowercaseHttp10StartLine(): void
+    {
+        $parsed = Psr7\Message::parseMessage("get / http/1.0\r\nFoo: Bar\r\n Bam\r\n\r\n");
+
+        self::assertSame('get / http/1.0', $parsed['start-line']);
+        self::assertSame(['Bar Bam'], $parsed['headers']['Foo']);
+    }
+
     public function testRequestParsingFailsWithFoldedHeadersOnHttp11(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid header syntax: Obsolete line folding');
 
-        Psr7\Message::parseResponse("GET_DATA / HTTP/1.1\r\nFoo: Bar\r\n Biz: Bam\r\n\r\n");
+        Psr7\Message::parseRequest("GET_DATA / HTTP/1.1\r\nFoo: Bar\r\n Biz: Bam\r\n\r\n");
     }
 
     public function testParsesRequestMessagesWhenHeaderDelimiterIsOnlyALineFeed(): void


### PR DESCRIPTION
`Message::parseMessage()` decides whether to unfold obsolete HTTP/1.0 line folding by sniffing the start line, but its method arm matched ASCII letters only, while `Message::parseRequest()` accepts the full RFC 9110 method token grammar. A folded HTTP/1.0 message therefore parsed or failed depending on which valid method token it used: `PUT` unfolded while `GET_DATA` or `M-SEARCH` threw. No surveyed implementation (nginx, Apache, llhttp, Go, HAProxy) keys obs-fold handling on the method token, and RFC 9112 permits either rejecting or replacing the folding, so the choice should not vary by method. The method and target character classes now live in shared constants from which both the sniff and the request start-line regex are built, so the two grammars cannot drift apart again; the request parser's compiled pattern is byte-for-byte unchanged.

Alongside the method widening, the sniff's target class tightens from `\S+` to the parser's `[^\x00-\x20\x7F]+`: `parseMessage()` no longer unfolds folded HTTP/1.0 messages whose start-line target carries control bytes and instead throws the obsolete-line-folding exception, while `parseRequest()` and `parseResponse()` rejected such messages either way. The sniff deliberately remains case-insensitive and prefix-only, so its existing leniency toward lowercase `http/1.0` start lines and trailing bytes after the version is unchanged, and the lowercase behavior is now pinned by a test. The change also fixes a test that called `parseResponse()` on a request message.