### PR TITLE
Harden URI host percent-encoding validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Percent-encode raw control bytes in userinfo before bracketed IP-literal hosts instead of parsing mutated values
 - Reject invalid UTF-8 and preserve percent-sequences in userinfo before bracketed IP-literal hosts
 - Normalize percent-encoded octets in the URI host to uppercase hex
-- Reject malformed percent-sequences and percent-encoded delimiter, control, and DEL octets in URI hosts
+- Reject malformed percent-sequences and percent-encoded bytes forbidden by the URI host policy
 - Trim header list elements with only spaces, horizontal tabs, and line terminators in `Header::splitList()`
 - Report header parameter PCRE failures explicitly in `Header::parse()`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Percent-encode raw control bytes in userinfo before bracketed IP-literal hosts instead of parsing mutated values
 - Reject invalid UTF-8 and preserve percent-sequences in userinfo before bracketed IP-literal hosts
 - Normalize percent-encoded octets in the URI host to uppercase hex
+- Reject malformed percent-sequences and percent-encoded delimiter, control, and DEL octets in URI hosts
 - Trim header list elements with only spaces, horizontal tabs, and line terminators in `Header::splitList()`
 - Report header parameter PCRE failures explicitly in `Header::parse()`
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -293,6 +293,16 @@ rules apply to absolute-form targets of every scheme.
 `ServerRequest::fromGlobals()` is unchanged and continues to strip
 `REQUEST_URI` userinfo.
 
+URI hosts now validate percent-encoding. Malformed sequences such as
+`ex%zz`, and percent-encoded octets that decode to bytes the raw host
+grammar already rejects — controls, space, DEL, `/`, `?`, `#`, `@`, `\`,
+`:`, `[`, `]`, and `%` itself — throw `MalformedUriException` from URI
+parsing and `InvalidArgumentException` from `Uri::withHost()`, and are
+rejected wherever hosts are validated, including `Host` headers and request
+targets in `Message::parseRequest()`. curl and WHATWG-conformant browsers
+also reject these hosts. Other percent-encoded octets, including UTF-8 data
+such as `a%C3%A9b`, remain accepted and are normalized to uppercase hex.
+
 #### Request Host Synchronization
 
 `Request::withUri()` now applies PSR-7 Host header synchronization before using

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -219,16 +219,18 @@ fragment may follow a bracketed IP-literal host. Trailing bytes that are
 neither, such as `http://[::1]:80@evil/` or `http://[::1]:80x/`, are now
 rejected instead of being reparsed into a different host.
 
-Parsing still URL-decodes hosts before validation. Bracketed hosts containing
-bytes that change under URL decoding, such as `+` or percent-encoded octets,
-therefore are not guaranteed to match `withHost()` acceptance. For example,
-`withHost('[v1.fe80::a+en1]')` is accepted, while parsing
-`http://[v1.fe80::a+en1]/` is rejected.
+Parsing still URL-decodes registered-name hosts before validation, so a literal
+`+` in a bracketed IP-literal decodes to a space and is rejected:
+`withHost('[v1.fe80::a+en1]')` accepts the literal while parsing
+`http://[v1.fe80::a+en1]/` rejects it. Percent-encoding inside a bracketed
+IP-literal is now rejected during parsing as well, since RFC 3986 IP-literals
+contain no percent-encoding, so `http://[%3A%3A1]/` no longer decodes to `[::1]`;
+this matches `withHost()` and `Rfc3986::isValidHost()`.
 
-Percent-encoded octets in the URI host are now normalized to uppercase hex, so
-hosts such as `%2fhost` and `a%c3%a9b` are represented as `%2Fhost` and
-`a%C3%A9b`. Malformed percent sequences in registered-name hosts are still
-accepted unchanged.
+Percent-encoded octets in a registered-name host are normalized to uppercase
+hex, so a host such as `a%c3%a9b` is represented as `a%C3%A9b`. Malformed
+percent sequences and percent-encoded octets that decode to a byte forbidden in
+a host, such as `ex%zz` and `%2fhost`, are rejected.
 
 `Uri::fromParts()` accepts integer and decimal digit string ports, but floats and
 other port values are no longer cast.
@@ -299,9 +301,11 @@ grammar already rejects — controls, space, DEL, `/`, `?`, `#`, `@`, `\`,
 `:`, `[`, `]`, and `%` itself — throw `MalformedUriException` from URI
 parsing and `InvalidArgumentException` from `Uri::withHost()`, and are
 rejected wherever hosts are validated, including `Host` headers and request
-targets in `Message::parseRequest()`. curl and WHATWG-conformant browsers
-also reject these hosts. Other percent-encoded octets, including UTF-8 data
-such as `a%C3%A9b`, remain accepted and are normalized to uppercase hex.
+targets in `Message::parseRequest()`. WHATWG-conformant browsers reject all of
+these hosts; curl 8.7.1 rejects them too, except encoded DEL (`%7F`), which it
+decodes and forwards to name resolution. Other percent-encoded octets,
+including UTF-8 data such as `a%C3%A9b`, remain accepted and are normalized to
+uppercase hex.
 
 #### Request Host Synchronization
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -219,13 +219,14 @@ fragment may follow a bracketed IP-literal host. Trailing bytes that are
 neither, such as `http://[::1]:80@evil/` or `http://[::1]:80x/`, are now
 rejected instead of being reparsed into a different host.
 
-Parsing still URL-decodes registered-name hosts before validation, so a literal
-`+` in a bracketed IP-literal decodes to a space and is rejected:
-`withHost('[v1.fe80::a+en1]')` accepts the literal while parsing
-`http://[v1.fe80::a+en1]/` rejects it. Percent-encoding inside a bracketed
-IP-literal is now rejected during parsing as well, since RFC 3986 IP-literals
-contain no percent-encoding, so `http://[%3A%3A1]/` no longer decodes to `[::1]`;
-this matches `withHost()` and `Rfc3986::isValidHost()`.
+Parsing still URL-decodes bracketed IP-literal hosts before validation
+(registered-name hosts round-trip unchanged), so a literal `+` in a bracketed
+IP-literal decodes to a space and is rejected: `withHost('[v1.fe80::a+en1]')`
+accepts the literal while parsing `http://[v1.fe80::a+en1]/` rejects it.
+Percent-encoding inside a bracketed IP-literal is now rejected during parsing as
+well, since RFC 3986 IP-literals contain no percent-encoding, so
+`http://[%3A%3A1]/` no longer decodes to `[::1]`; this matches `withHost()` and
+`Rfc3986::isValidHost()`.
 
 Percent-encoded octets in a registered-name host are normalized to uppercase
 hex, so a host such as `a%c3%a9b` is represented as `a%C3%A9b`. Malformed
@@ -295,17 +296,16 @@ rules apply to absolute-form targets of every scheme.
 `ServerRequest::fromGlobals()` is unchanged and continues to strip
 `REQUEST_URI` userinfo.
 
-URI hosts now validate percent-encoding. Malformed sequences such as
-`ex%zz`, and percent-encoded octets that decode to bytes the raw host
-grammar already rejects — controls, space, DEL, `/`, `?`, `#`, `@`, `\`,
-`:`, `[`, `]`, and `%` itself — throw `MalformedUriException` from URI
-parsing and `InvalidArgumentException` from `Uri::withHost()`, and are
-rejected wherever hosts are validated, including `Host` headers and request
-targets in `Message::parseRequest()`. WHATWG-conformant browsers reject all of
-these hosts; curl 8.7.1 rejects them too, except encoded DEL (`%7F`), which it
-decodes and forwards to name resolution. Other percent-encoded octets,
-including UTF-8 data such as `a%C3%A9b`, remain accepted and are normalized to
-uppercase hex.
+URI hosts now validate percent-encoding. Malformed sequences such as `ex%zz`,
+and percent-encoded octets that decode to bytes the raw host grammar already
+rejects (controls, space, DEL, `/`, `?`, `#`, `@`, `\`, `:`, `[`, `]`, and `%`
+itself) throw `MalformedUriException` from URI parsing and
+`InvalidArgumentException` from `Uri::withHost()`, and are rejected wherever
+hosts are validated, including `Host` headers and request targets in
+`Message::parseRequest()`. WHATWG-conformant browsers reject all of these hosts;
+curl rejects them too, except encoded DEL (`%7F`), which it decodes and forwards
+to name resolution. Other percent-encoded octets, including UTF-8 data such as
+`a%C3%A9b`, remain accepted and are normalized to uppercase hex.
 
 #### Request Host Synchronization
 

--- a/docs/uri-helpers.md
+++ b/docs/uri-helpers.md
@@ -77,8 +77,15 @@ Whether the string is a valid URI host. Per
 IP-literal, IPv4 address, or registered name. An empty host is accepted, since the authority — and thus
 the host — may be empty. Bracketed values are validated as IPv6 or IPvFuture literals; any other value is
 rejected if it contains control characters, whitespace, an authority or path delimiter (`/`, `?`, `#`,
-`@`, `\`), or an embedded colon denoting a port. RFC 6874 IPv6 zone identifiers (for example
-`[fe80::1%25eth0]`) are not supported.
+`@`, `\`), or an embedded colon denoting a port. Percent-encoding is validated the same way: malformed
+sequences (a `%` not followed by two hex digits) and percent-encoded octets that decode to one of the
+rejected bytes — or to `%` itself — are invalid, while all other percent-encoded octets are accepted.
+RFC 6874 IPv6 zone identifiers (for example `[fe80::1%25eth0]`) are not supported.
+
+Registered names are otherwise intentionally permissive: single-label hosts such as `localhost`,
+underscores, sub-delims, and raw or percent-encoded non-ASCII (IDN) data are accepted and preserved as
+given, with no punycode conversion. IDNA is treated as a client concern — HTTP clients such as guzzle
+(via its `idn_conversion` request option), curl, and browsers apply it before a URL is serialized.
 
 ### `GuzzleHttp\Psr7\Rfc3986::isValidPort`
 

--- a/docs/uri-helpers.md
+++ b/docs/uri-helpers.md
@@ -80,12 +80,15 @@ rejected if it contains control characters, whitespace, an authority or path del
 `@`, `\`), or an embedded colon denoting a port. Percent-encoding is validated the same way: malformed
 sequences (a `%` not followed by two hex digits) and percent-encoded octets that decode to one of the
 rejected bytes — or to `%` itself — are invalid, while all other percent-encoded octets are accepted.
-RFC 6874 IPv6 zone identifiers (for example `[fe80::1%25eth0]`) are not supported.
+Rejecting these percent-encoded octets is a deliberate guzzle host policy, stricter than the RFC 3986
+`reg-name` grammar, which permits any well-formed `pct-encoded` octet; it matches the stricter policy
+used throughout the library. RFC 6874 IPv6 zone identifiers (for example `[fe80::1%25eth0]`) are not
+supported.
 
 Registered names are otherwise intentionally permissive: single-label hosts such as `localhost`,
 underscores, sub-delims, and raw or percent-encoded non-ASCII (IDN) data are accepted and preserved as
-given, with no punycode conversion. IDNA is treated as a client concern — HTTP clients such as guzzle
-(via its `idn_conversion` request option), curl, and browsers apply it before a URL is serialized.
+given, with no punycode conversion. IDNA is treated as a client concern — consumers that need DNS IDNs
+must perform the conversion themselves, for example via Guzzle's `idn_conversion` request option.
 
 ### `GuzzleHttp\Psr7\Rfc3986::isValidPort`
 

--- a/docs/uri-helpers.md
+++ b/docs/uri-helpers.md
@@ -74,21 +74,20 @@ accepted, since a URI reference may omit the scheme.
 
 Whether the string is a valid URI host. Per
 [RFC 3986 Section 3.2.2](https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.2), the host is an
-IP-literal, IPv4 address, or registered name. An empty host is accepted, since the authority — and thus
-the host — may be empty. Bracketed values are validated as IPv6 or IPvFuture literals; any other value is
-rejected if it contains control characters, whitespace, an authority or path delimiter (`/`, `?`, `#`,
-`@`, `\`), or an embedded colon denoting a port. Percent-encoding is validated the same way: malformed
-sequences (a `%` not followed by two hex digits) and percent-encoded octets that decode to one of the
-rejected bytes — or to `%` itself — are invalid, while all other percent-encoded octets are accepted.
+IP-literal, IPv4 address, or registered name. An empty host is accepted, since the authority, and thus the
+host, may be empty. Bracketed values are validated as IPv6 or IPvFuture literals; any other value is
+rejected if it contains control characters, whitespace, an authority or path delimiter (`/`, `?`, `#`, `@`,
+`\`), or an embedded colon denoting a port. Percent-encoding is validated the same way: malformed sequences
+(a `%` not followed by two hex digits) and percent-encoded octets that decode to one of the rejected bytes,
+to a bracket (`[`, `]`), or to `%` itself are invalid, while all other percent-encoded octets are accepted.
 Rejecting these percent-encoded octets is a deliberate guzzle host policy, stricter than the RFC 3986
-`reg-name` grammar, which permits any well-formed `pct-encoded` octet; it matches the stricter policy
-used throughout the library. RFC 6874 IPv6 zone identifiers (for example `[fe80::1%25eth0]`) are not
-supported.
+`reg-name` grammar, which permits any well-formed `pct-encoded` octet; it matches the stricter policy used
+throughout the library. RFC 6874 IPv6 zone identifiers (for example `[fe80::1%25eth0]`) are not supported.
 
 Registered names are otherwise intentionally permissive: single-label hosts such as `localhost`,
 underscores, sub-delims, and raw or percent-encoded non-ASCII (IDN) data are accepted and preserved as
-given, with no punycode conversion. IDNA is treated as a client concern — consumers that need DNS IDNs
-must perform the conversion themselves, for example via Guzzle's `idn_conversion` request option.
+given, with no punycode conversion. IDNA is treated as a client concern. Consumers that need DNS IDNs must
+perform the conversion themselves, for example via Guzzle's `idn_conversion` request option.
 
 ### `GuzzleHttp\Psr7\Rfc3986::isValidPort`
 

--- a/src/Rfc3986.php
+++ b/src/Rfc3986.php
@@ -61,8 +61,9 @@ final class Rfc3986
      * host is accepted, since the authority (and thus the host) may be empty.
      * Bracketed values are validated as IPv6 / IPvFuture literals; any other
      * value is rejected if it contains control characters, whitespace, an
-     * authority or path delimiter (`/ ? # @ \`), or an embedded colon denoting
-     * a port.
+     * authority or path delimiter (`/ ? # @ \`), an embedded colon denoting
+     * a port, a malformed percent-sequence, or a percent-encoded octet that
+     * decodes to one of those rejected bytes or to `%` itself.
      *
      * @see https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.2
      */
@@ -86,7 +87,11 @@ final class Rfc3986
             return self::isValidIpLiteralHost($host);
         }
 
-        return !str_contains($host, ':');
+        if (str_contains($host, ':')) {
+            return false;
+        }
+
+        return !str_contains($host, '%') || self::hasValidHostPercentEncoding($host);
     }
 
     /**
@@ -111,6 +116,22 @@ final class Rfc3986
         }
 
         return strlen($normalized) <= 5 && (int) $normalized <= 0xFFFF;
+    }
+
+    private static function hasValidHostPercentEncoding(string $host): bool
+    {
+        // Mirror of the raw reg-name policy above for percent-encoded octets:
+        // reject malformed sequences (RFC 3986 requires "%" HEXDIG HEXDIG) and
+        // octets that decode to bytes the raw grammar rejects - C0 controls,
+        // SP, DEL, the delimiters / ? # @ \ [ ], the port colon, and % itself.
+        // Octets decoding to any other byte (unreserved, sub-delims, and
+        // non-ASCII UTF-8 data) remain accepted.
+        $invalidEncoding = preg_match(
+            '/%(?![0-9A-Fa-f]{2})|%(?:[01][0-9A-Fa-f]|2[035F]|3[AF]|40|5[BCD]|7F)/i',
+            $host
+        );
+
+        return $invalidEncoding === 0;
     }
 
     private static function isValidIpLiteralHost(string $host): bool

--- a/src/Rfc3986.php
+++ b/src/Rfc3986.php
@@ -63,7 +63,7 @@ final class Rfc3986
      * value is rejected if it contains control characters, whitespace, an
      * authority or path delimiter (`/ ? # @ \`), an embedded colon denoting
      * a port, a malformed percent-sequence, or a percent-encoded octet that
-     * decodes to one of those rejected bytes or to `%` itself.
+     * decodes to one of those rejected bytes, to a bracket, or to `%` itself.
      *
      * @see https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.2
      */
@@ -127,7 +127,7 @@ final class Rfc3986
         // Octets decoding to any other byte (unreserved, sub-delims, and
         // non-ASCII UTF-8 data) remain accepted.
         $invalidEncoding = preg_match(
-            '/%(?![0-9A-Fa-f]{2})|%(?:[01][0-9A-Fa-f]|2[035F]|3[AF]|40|5[BCD]|7F)/i',
+            '/%(?!'.self::HEX_OCTET.')|%(?:[01][0-9A-Fa-f]|2[035F]|3[AF]|40|5[BCD]|7F)/i',
             $host
         );
 

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -121,6 +121,14 @@ class Uri implements UriInterface, \JsonSerializable
                 return false;
             }
 
+            // RFC 3986 IP-literals contain no percent-encoding, so reject any
+            // "%" in the bracketed host rather than letting the urldecode()
+            // below turn an encoded octet into a different literal. This keeps
+            // parsing aligned with withHost()/Rfc3986::isValidHost().
+            if (str_contains($matches[4], '%')) {
+                return false;
+            }
+
             $prefix = $matches[1];
 
             if ($matches[3] === '@') {

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -286,6 +286,7 @@ final class Utils
         // Match Request::__construct() by adding a Host header when one is not provided.
         if (!$hasHost && $uri->getHost() !== '') {
             $host = $uri->getHost();
+            Uri::assertValidHost($host);
 
             if (($port = $uri->getPort()) !== null) {
                 $host .= ':'.$port;

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -267,6 +267,7 @@ class MessageTest extends TestCase
         yield 'http leading zero default port' => ['foo.com:000080', 'http://foo.com/'];
         yield 'leading zero non-default port' => ['foo.com:0008080', 'http://foo.com:8080/'];
         yield 'maximum port' => ['foo.com:65535', 'http://foo.com:65535/'];
+        yield 'percent-encoded host' => ['ex%61mple.com', 'http://ex%61mple.com/'];
         yield 'ipv6' => ['[::1]', 'http://[::1]/'];
         yield 'ipv6 port' => ['[::1]:443', 'https://[::1]/'];
         yield 'ipv6 https leading zero default port' => ['[::1]:000443', 'https://[::1]/'];

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -161,6 +161,8 @@ class MessageTest extends TestCase
     {
         yield 'empty' => [''];
         yield 'userinfo delimiter' => ['trusted.example@evil.example'];
+        yield 'percent-encoded userinfo delimiters' => ['user%3Apass%40example.com'];
+        yield 'percent-encoded slash' => ['ex%2Fample.com'];
         yield 'path delimiter' => ['example.com/path'];
         yield 'query delimiter' => ['example.com?query'];
         yield 'fragment delimiter' => ['example.com#fragment'];
@@ -376,7 +378,7 @@ class MessageTest extends TestCase
         yield 'ipv6 non-default port' => ['http://[::1]:8080/admin?x=1', '[::1]:8080', 'http://[::1]:8080/admin?x=1'];
         yield 'path at-sign' => ['http://up.example/admin@v1', 'up.example', 'http://up.example/admin@v1'];
         yield 'query at-sign' => ['http://up.example?email=user@example.com', 'up.example', 'http://up.example?email=user@example.com'];
-        yield 'percent-encoded authority delimiters in host' => ['http://user%3Apass%40example.com/admin', 'user%3Apass%40example.com', 'http://user%3Apass%40example.com/admin'];
+        yield 'percent-encoded host' => ['http://ex%61mple.com/admin', 'ex%61mple.com', 'http://ex%61mple.com/admin'];
         yield 'empty port' => ['http://up.example:/admin', 'up.example', 'http://up.example/admin'];
     }
 
@@ -636,6 +638,7 @@ class MessageTest extends TestCase
         yield 'absolute-form ipv6 user info' => ['GET http://u@[::1]:8080/admin HTTP/1.1'];
         yield 'absolute-form user info zero port' => ['GET http://u@up.example:0/admin HTTP/1.1'];
         yield 'absolute-form non-http user info' => ['GET ftp://u:p@files.example/x HTTP/1.1'];
+        yield 'absolute-form percent-encoded host delimiters' => ['GET http://user%3Apass%40example.com/admin HTTP/1.1'];
         yield 'invalid protocol text' => ['GET / HTTP/foo'];
         yield 'invalid protocol segments' => ['GET / HTTP/1.1.1'];
         yield 'bare carriage return after version' => ["GET / HTTP/1.1\rX-Injected: yes"];

--- a/tests/Rfc3986Test.php
+++ b/tests/Rfc3986Test.php
@@ -113,6 +113,7 @@ class Rfc3986Test extends TestCase
         yield 'percent-encoded NUL in reg-name' => ['ex%00ample.com', false];
         yield 'percent-encoded LF in reg-name' => ['ex%0Aample.com', false];
         yield 'percent-encoded lowercase LF in reg-name' => ['ex%0aample.com', false];
+        yield 'percent-encoded unit separator boundary in reg-name' => ['ex%1Fample.com', false];
         yield 'percent-encoded SP in reg-name' => ['ex%20ample.com', false];
         yield 'percent-encoded DEL in reg-name' => ['ex%7Fample.com', false];
         yield 'percent-encoded slash in reg-name' => ['ex%2Fample.com', false];

--- a/tests/Rfc3986Test.php
+++ b/tests/Rfc3986Test.php
@@ -101,9 +101,36 @@ class Rfc3986Test extends TestCase
         yield 'high byte 0x80 in reg-name (lenient)' => ["a\x80b", true];
         yield 'high byte 0xFF in reg-name (lenient)' => ["a\xFFb", true];
         yield 'raw UTF-8 e-acute in reg-name (lenient)' => ["h\xC3\xA9llo", true];
-        yield 'unencoded percent sign in reg-name (lenient)' => ['ex%ample', true];
-        yield 'malformed percent-encoding in reg-name (lenient)' => ['ex%zz', true];
         yield 'non-blocklisted ASCII punctuation in reg-name (lenient)' => ['a<b>{c}|^`"', true];
+
+        // Percent-encoding in reg-names: malformed sequences and octets that
+        // decode to bytes the raw grammar rejects are invalid; other octets,
+        // including non-ASCII UTF-8 data, remain accepted.
+        yield 'unencoded percent sign in reg-name' => ['ex%ample', false];
+        yield 'malformed percent-encoding in reg-name' => ['ex%zz', false];
+        yield 'truncated percent-encoding at end of reg-name' => ['example.com%4', false];
+        yield 'double percent before valid octet' => ['ex%%41mple', false];
+        yield 'percent-encoded NUL in reg-name' => ['ex%00ample.com', false];
+        yield 'percent-encoded LF in reg-name' => ['ex%0Aample.com', false];
+        yield 'percent-encoded lowercase LF in reg-name' => ['ex%0aample.com', false];
+        yield 'percent-encoded SP in reg-name' => ['ex%20ample.com', false];
+        yield 'percent-encoded DEL in reg-name' => ['ex%7Fample.com', false];
+        yield 'percent-encoded slash in reg-name' => ['ex%2Fample.com', false];
+        yield 'percent-encoded lowercase slash in reg-name' => ['ex%2fample.com', false];
+        yield 'percent-encoded question mark in reg-name' => ['ex%3Fample.com', false];
+        yield 'percent-encoded hash in reg-name' => ['ex%23ample.com', false];
+        yield 'percent-encoded at sign in reg-name' => ['ex%40ample.com', false];
+        yield 'percent-encoded colon in reg-name' => ['ex%3Aample.com', false];
+        yield 'percent-encoded open bracket in reg-name' => ['ex%5Bample.com', false];
+        yield 'percent-encoded backslash in reg-name' => ['ex%5Cample.com', false];
+        yield 'percent-encoded close bracket in reg-name' => ['ex%5Dample.com', false];
+        yield 'percent-encoded percent in reg-name' => ['ex%25ample.com', false];
+        yield 'percent-encoded unreserved letter in reg-name' => ['ex%61mple.com', true];
+        yield 'percent-encoded sub-delim plus in reg-name' => ['ex%2Bample.com', true];
+        yield 'percent-encoded exclamation boundary octet' => ['ex%21ample.com', true];
+        yield 'percent-encoded tilde boundary octet' => ['ex%7Eample.com', true];
+        yield 'percent-encoded UTF-8 pair in reg-name' => ['a%C3%A9b', true];
+        yield 'percent-encoded lone high byte in reg-name' => ['ex%FFample.com', true];
 
         // Reg-name byte boundaries around the forbidden range [\x00-\x20\x7F].
         yield 'byte 0x21 boundary (bang, just above forbidden range)' => ["a\x21b", true];

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -513,6 +513,10 @@ class ServerRequestTest extends TestCase
                 'https://www.example.org/blog/article.php?id=10&user=foo',
                 array_merge($server, ['HTTP_HOST' => 'example.com\\evil']),
             ],
+            'Host header with percent-encoded delimiter' => [
+                'https://www.example.org/blog/article.php?id=10&user=foo',
+                array_merge($server, ['HTTP_HOST' => 'ex%2Fample.com']),
+            ],
             'Host header with space' => [
                 'https://www.example.org/blog/article.php?id=10&user=foo',
                 array_merge($server, ['HTTP_HOST' => 'bad host']),
@@ -687,6 +691,15 @@ class ServerRequestTest extends TestCase
             'evil.example',
             null,
             '/admin',
+            '',
+        ];
+
+        yield 'absolute-form target with percent-encoded host delimiter is treated as a path' => [
+            ['REQUEST_URI' => 'http://ex%2Fample.com/x', 'HTTP_HOST' => 'good.example'],
+            'http://good.example/http://ex%2Fample.com/x',
+            'good.example',
+            null,
+            '/http://ex%2Fample.com/x',
             '',
         ];
 
@@ -876,6 +889,15 @@ class ServerRequestTest extends TestCase
             'up.example',
             443,
             '',
+            '',
+        ];
+
+        yield 'connect authority-form with percent-encoded host delimiter is treated as a path' => [
+            ['REQUEST_METHOD' => 'CONNECT', 'REQUEST_URI' => 'ex%2Fample.com:443', 'HTTP_HOST' => 'good.example'],
+            'http://good.example/ex%2Fample.com:443',
+            'good.example',
+            null,
+            '/ex%2Fample.com:443',
             '',
         ];
 

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -1019,6 +1019,26 @@ class UriTest extends TestCase
     }
 
     /**
+     * @dataProvider getBracketedHostsWithPercentEncoding
+     */
+    public function testParseRejectsPercentEncodingInBracketedHost(string $uri): void
+    {
+        $this->expectException(MalformedUriException::class);
+
+        new Uri($uri);
+    }
+
+    public static function getBracketedHostsWithPercentEncoding(): iterable
+    {
+        // RFC 3986 IP-literals contain no percent-encoding. Parsing must not
+        // urldecode these into valid literals that the component API rejects.
+        yield 'encoded colons decode to IPv6' => ['http://[%3A%3A1]/'];
+        yield 'encoded colon in IPvFuture' => ['http://[v1.a%3Ab]/'];
+        yield 'encoded plus in IPvFuture' => ['http://[v1.fe80::a%2Ben1]/'];
+        yield 'encoded unreserved in IPvFuture' => ['http://[v1.a%61b]/'];
+    }
+
+    /**
      * @dataProvider getInvalidBracketedIpLiteralSuffixes
      */
     public function testParseRejectsInvalidBracketedIpLiteralSuffix(string $input): void

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -876,24 +876,47 @@ class UriTest extends TestCase
 
     public function testHostPercentEncodingIsNormalizedToUppercaseHex(): void
     {
-        $uri = new Uri('http://%2fhost/');
-        self::assertSame('%2Fhost', $uri->getHost());
-        self::assertSame('http://%2Fhost/', (string) $uri);
+        $uri = new Uri('http://a%c3%a9b/');
+        self::assertSame('a%C3%A9b', $uri->getHost());
+        self::assertSame('http://a%C3%A9b/', (string) $uri);
 
-        $uri = (new Uri())->withHost('EX%2fAMPLE');
-        self::assertSame('ex%2Fample', $uri->getHost());
-
-        $uri = (new Uri())->withHost('a%c3%a9b');
+        $uri = (new Uri())->withHost('A%c3%a9B');
         self::assertSame('a%C3%A9b', $uri->getHost());
     }
 
-    public function testMalformedPercentEncodingInHostStaysAccepted(): void
+    /**
+     * @dataProvider getHostsWithInvalidPercentEncoding
+     */
+    public function testParseRejectsHostsWithInvalidPercentEncoding(string $host): void
     {
-        $uri = (new Uri())->withHost('ex%zz');
-        self::assertSame('ex%zz', $uri->getHost());
+        $this->expectException(MalformedUriException::class);
 
-        $uri = new Uri('http://ex%zz/');
-        self::assertSame('ex%zz', $uri->getHost());
+        new Uri("http://{$host}/");
+    }
+
+    /**
+     * @dataProvider getHostsWithInvalidPercentEncoding
+     */
+    public function testWithHostRejectsInvalidPercentEncoding(string $host): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        (new Uri())->withHost($host);
+    }
+
+    public static function getHostsWithInvalidPercentEncoding(): iterable
+    {
+        yield 'malformed percent-encoding' => ['ex%zz'];
+        yield 'bare percent sign' => ['ex%ample.com'];
+        yield 'percent-encoded NUL' => ['ex%00ample.com'];
+        yield 'percent-encoded slash' => ['ex%2Fample.com'];
+        yield 'percent-encoded percent' => ['ex%25ample.com'];
+    }
+
+    public function testPercentEncodedNonDelimiterOctetsInHostStayAccepted(): void
+    {
+        $uri = new Uri('http://ex%61mple%FFcom/');
+        self::assertSame('ex%61mple%FFcom', $uri->getHost());
     }
 
     public function testCommonNonDnsHostsStayValid(): void

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -1451,6 +1451,24 @@ class UtilsTest extends TestCase
         self::assertSame('1', $modified->getHeaderLine('X-Test'));
     }
 
+    public function testModifyRequestValidatesReaddedHostFromCustomUri(): void
+    {
+        $uri = new class('http://safe.example/') extends Psr7\Uri {
+            public function getHost(): string
+            {
+                return 'ex%2Fample.com';
+            }
+        };
+        $request = (new Psr7\Request('GET', 'http://safe.example/', ['Host' => 'safe.example']))
+            ->withUri($uri, true)
+            ->withoutHeader('Host');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid host');
+
+        Psr7\Utils::modifyRequest($request, ['set_headers' => ['X-Test' => '1']]);
+    }
+
     /**
      * @dataProvider hostHeaderCaseProvider
      */


### PR DESCRIPTION
`Rfc3986::isValidHost()` already rejected raw control bytes, whitespace, DEL, the delimiters `/ ? # @ \`, and port colons, but their percent-encoded forms were accepted everywhere, as were malformed sequences such as `ex%zz` or a bare `%`. Host validation now rejects malformed percent-sequences and any percent-encoded octet decoding to a byte the raw grammar rejects, plus `%25`. Both host-validation call sites route through this predicate, so the rule reaches URI parsing, `Uri::withHost()`, `Host` headers, request targets, and server globals at once. This deliberate guzzle host policy, stricter than RFC 3986 `reg-name` grammar, closes the decode-then-split confusion class: a consumer that percent-decodes a host before routing or allow-listing would see a different authority than this parser validated. It supersedes #839's `user%3Apass%40example.com` acceptance, keeping Host headers and request targets consistent.

WHATWG-conformant browsers reject the full forbidden set; curl (verified on 8.7.1 and 8.21.0) rejects it too, except encoded DEL (`%7F`), which it percent-decodes and forwards to name resolution — itself an instance of the divergence this change closes. All other percent-encoded octets stay accepted and continue to normalize to uppercase hex, including UTF-8 data such as `a%C3%A9b` and lone high bytes, pending the 4.0 Unicode/IDN host decision in #643. The docs also record the intentionally permissive registered-name policy: single-label hosts, underscores, sub-delims, and raw or percent-encoded IDN data are preserved as given, with IDNA left to clients.

Two review-driven items landed here as well. URI-string parsing previously URL-decoded a bracketed IP-literal before validation, so `http://[%3A%3A1]/` parsed to `[::1]` while `withHost('[%3A%3A1]')` rejected the literal; since RFC 3986 IP-literals contain no percent-encoding, parsing now rejects any `%` inside a bracketed host, aligning it with the component API. And `Utils::modifyRequest()` now validates the host in its fallback Host-synthesis path, matching the validation its uri-change path already performs. `Message::toString()` remains a serializer and is intentionally not made a validator (see #643).

On server globals: a newly invalid host in an absolute-form or CONNECT `REQUEST_URI` never itself throws — it takes the pre-existing fallback that treats the whole request target as a path — while that fallback retains its documented `SERVER_PORT` validation, so a malformed `SERVER_PORT` still throws exactly as it does for origin-form requests. An invalid `HTTP_HOST` continues to fall back to `SERVER_NAME`, `SERVER_ADDR`, or the default host. Precedent: #831/#836 and #839.
