### PR TITLE
Sync static helper PHPDoc with docs and wrap both to 80 columns

### DIFF
--- a/docs/header-and-query-helpers.md
+++ b/docs/header-and-query-helpers.md
@@ -1,18 +1,23 @@
 # Header and Query Helpers
 
-This page covers helper methods for parsing structured header values, splitting list headers, and parsing or building query strings. For basic message header behavior, see [PSR-7 Messages](psr-7-messages.md).
+This page covers helper methods for parsing structured header values, splitting
+list headers, and parsing or building query strings. For basic message header
+behavior, see [PSR-7 Messages](psr-7-messages.md).
 
 ## `GuzzleHttp\Psr7\Header::parse`
 
 `public static function parse(string|array $header): array`
 
-Parses semicolon-separated header parameters into associative arrays. Parameters without values receive an empty-string value.
+Parses semicolon-separated header parameters into associative arrays, one per
+comma-separated header value. Parameters without a value are appended as values
+under integer keys.
 
 ## `GuzzleHttp\Psr7\Header::splitList`
 
 `public static function splitList(string|string[] $header): string[]`
 
-Splits an HTTP header defined to contain a comma-separated list into each individual value:
+Splits an HTTP header defined to contain a comma-separated list into each
+individual value. Empty values are removed:
 
 ```php
 $knownEtags = Header::splitList($request->getHeader('if-none-match'));
@@ -20,13 +25,19 @@ $knownEtags = Header::splitList($request->getHeader('if-none-match'));
 
 Example headers include `accept`, `cache-control`, and `if-none-match`.
 
+This method must not be used to parse headers that are not defined as a list,
+such as `user-agent` or `set-cookie`.
+
 ## `GuzzleHttp\Psr7\Query::parse`
 
 `public static function parse(string $str, int|bool $urlEncoding = true): array`
 
 Parse a query string into an associative array.
 
-If multiple values are found for the same key, the value of that key-value pair becomes an array. This function does not parse nested PHP style arrays into an associative array. For example, `foo[a]=1&foo[b]=2` will be parsed into `['foo[a]' => '1', 'foo[b]' => '2']`.
+If multiple values are found for the same key, the value of that key-value pair
+becomes an array. This function does not parse nested PHP style arrays into an
+associative array. For example, `foo[a]=1&foo[b]=2` will be parsed into
+`['foo[a]' => '1', 'foo[b]' => '2']`.
 
 ## `GuzzleHttp\Psr7\Query::build`
 
@@ -34,7 +45,9 @@ If multiple values are found for the same key, the value of that key-value pair 
 
 Build a query string from an array of key-value pairs.
 
-This function can use the return value of `parse()` to build a query string. This function does not modify the provided keys when an array is encountered, unlike `http_build_query()`.
+This function can use the return value of `parse()` to build a query string.
+This function does not modify the provided keys when an array is encountered,
+unlike `http_build_query()`.
 
 ## `GuzzleHttp\Psr7\Utils::caselessRemove`
 

--- a/docs/message-helpers.md
+++ b/docs/message-helpers.md
@@ -1,6 +1,8 @@
 # Message Helpers
 
-This page covers static helper methods for converting, parsing, summarizing, rewinding, and cloning PSR-7 messages. For conceptual request and response behavior, start with [PSR-7 Messages](psr-7-messages.md).
+This page covers static helper methods for converting, parsing, summarizing,
+rewinding, and cloning PSR-7 messages. For conceptual request and response
+behavior, start with [PSR-7 Messages](psr-7-messages.md).
 
 ## `GuzzleHttp\Psr7\Message::toString`
 
@@ -21,7 +23,9 @@ Get a short summary of the message body.
 
 Will return `null` if the response is not printable.
 
-Reads seekable bodies from the beginning and restores the original cursor position before returning. Pass `null` for `$truncateAt` to use the default summary length.
+Reads seekable bodies from the beginning and restores the original cursor
+position before returning. Pass `null` for `$truncateAt` to use the default
+summary length.
 
 ## `GuzzleHttp\Psr7\Message::rewindBody`
 
@@ -29,7 +33,8 @@ Reads seekable bodies from the beginning and restores the original cursor positi
 
 Attempts to rewind a message body and throws an exception on failure.
 
-The body of the message will only be rewound if a call to `tell()` returns a value other than `0`.
+The body of the message will only be rewound if a call to `tell()` returns a
+value other than `0`.
 
 ## `GuzzleHttp\Psr7\Message::parseMessage`
 
@@ -37,7 +42,9 @@ The body of the message will only be rewound if a call to `tell()` returns a val
 
 Parses an HTTP message into an associative array.
 
-The array contains the `start-line` key containing the start line of the message, `headers` key containing an associative array of header array values, and a `body` key containing the body of the message.
+The array contains the `start-line` key containing the start line of the
+message, `headers` key containing an associative array of header array values,
+and a `body` key containing the body of the message.
 
 ## `GuzzleHttp\Psr7\Message::parseRequestUri`
 
@@ -45,15 +52,28 @@ The array contains the `start-line` key containing the start line of the message
 
 Constructs a URI for an HTTP request message.
 
+The URI is composed from the start-line path and the `Host` header, using
+`https` when the host's port is `443` and `http` otherwise. Without a `Host`
+header, only the path is returned, with extra leading slashes collapsed so an
+origin-form target cannot be parsed as a network-path reference with its own
+authority. An `InvalidArgumentException` is thrown when the `Host` header is
+invalid.
+
 ## `GuzzleHttp\Psr7\Message::parseRequest`
 
-`public static function parseRequest(string $message): Request`
+`public static function parseRequest(string $message): RequestInterface`
 
 Parses a request message string into a request object.
 
+The request-target must be in origin form, absolute form (without a userinfo
+component), authority form (`CONNECT`), or asterisk form (`OPTIONS`), and any
+`Host` header must be a single valid value; otherwise an
+`InvalidArgumentException` is thrown. Non-origin-form targets are preserved on
+the returned request via `withRequestTarget()`.
+
 ## `GuzzleHttp\Psr7\Message::parseResponse`
 
-`public static function parseResponse(string $message): Response`
+`public static function parseResponse(string $message): ResponseInterface`
 
 Parses a response message string into a response object.
 
@@ -63,13 +83,24 @@ Parses a response message string into a response object.
 
 Clone and modify a request with the given changes.
 
-This method is useful for reducing the number of clones needed to mutate a message.
+This method is useful for reducing the number of clones needed to mutate a
+message.
+
+The changes can be one of:
 
 - method: (string) Changes the HTTP method.
-- set_headers: (array) Sets the given headers. Values must be strings or arrays of strings.
-- remove_headers: (array) Remove the given headers. Values may be strings or integers.
-- body: (mixed) Sets the given body. Present non-null values are converted with `GuzzleHttp\Psr7\Utils::streamFor()`, including resources, streams, iterators, callable arrays, closures, invokable objects, and stringable objects. String inputs remain literal bodies.
-- uri: (UriInterface) Set the URI. When the URI contains a host, the Host header is updated from it, and combining this with an explicit Host entry in set_headers throws an InvalidArgumentException. Apply an intentional Host override separately with withHeader() afterwards.
+- set_headers: (array) Sets the given headers. Values must be strings or
+  non-empty arrays of strings.
+- remove_headers: (array) Remove the given headers. Values may be strings or
+  integers.
+- body: (mixed) Sets the given body. Present non-null values are converted with
+  `GuzzleHttp\Psr7\Utils::streamFor()`, including resources, streams, iterators,
+  callable arrays, closures, invokable objects, and stringable objects. String
+  inputs remain literal bodies.
+- uri: (UriInterface) Set the URI. When the URI contains a host, the Host header
+  is updated from it, and combining this with an explicit Host entry in
+  set_headers throws an InvalidArgumentException. Apply an intentional Host
+  override separately with withHeader() afterwards.
 - query: (string) Set the query string value of the URI.
 - version: (string) Set the protocol version.
 

--- a/docs/stream-helpers.md
+++ b/docs/stream-helpers.md
@@ -1,24 +1,36 @@
 # Stream Helpers
 
-This page covers `GuzzleHttp\Psr7\Utils` helper methods for creating, copying, hashing, reading, and safely opening PSR-7 streams. For stream implementations and decorators, see [Streams and Decorators](streams-and-decorators.md).
+This page covers `GuzzleHttp\Psr7\Utils` helper methods for creating, copying,
+hashing, reading, and safely opening PSR-7 streams. For stream implementations
+and decorators, see [Streams and Decorators](streams-and-decorators.md).
 
 ## `GuzzleHttp\Psr7\Utils::copyToStream`
 
 `public static function copyToStream(StreamInterface $source, StreamInterface $dest, int $maxLen = -1): int`
 
-Copy the contents of a stream into another stream until the given number of bytes have been read, returning the number of bytes copied as an `int`. On 32-bit PHP, an unbounded copy larger than `PHP_INT_MAX` bytes cannot be represented by that return type. 64-bit PHP is not affected.
+Copy the contents of a stream into another stream until the given number of
+bytes have been read, returning the number of bytes copied as an `int`. On
+32-bit PHP, an unbounded copy larger than `PHP_INT_MAX` bytes cannot be
+represented by that return type. 64-bit PHP is not affected.
 
-The destination must accept writes that make positive progress. Streams that return 0 as a backpressure or drop signal — a `BufferStream` past its high water mark, or a full `DroppingStream` — will cause this method to throw. For full copies, use a normal writable stream such as a file or `php://temp` stream.
+The destination must accept writes that make positive progress. Streams that
+return 0 as a backpressure or drop signal (a `BufferStream` at its high water
+mark, or a full `DroppingStream`) will cause this method to throw. For full
+copies, use a normal writable stream such as a file or `php://temp` stream.
 
-Throws `GuzzleHttp\Psr7\Exception\TimeoutException` when PHP-style timeout metadata can be detected after a source read or destination write cannot make progress.
+Throws `GuzzleHttp\Psr7\Exception\TimeoutException` when PHP-style timeout
+metadata can be detected after a source read or destination write cannot make
+progress.
 
 ## `GuzzleHttp\Psr7\Utils::copyToString`
 
 `public static function copyToString(StreamInterface $stream, int $maxLen = -1): string`
 
-Copy the contents of a stream into a string until the given number of bytes have been read.
+Copy the contents of a stream into a string until the given number of bytes have
+been read.
 
-Throws `GuzzleHttp\Psr7\Exception\TimeoutException` when PHP-style timeout metadata can be detected after a stream read cannot make progress.
+Throws `GuzzleHttp\Psr7\Exception\TimeoutException` when PHP-style timeout
+metadata can be detected after a stream read cannot make progress.
 
 ## `GuzzleHttp\Psr7\Utils::hash`
 
@@ -26,9 +38,11 @@ Throws `GuzzleHttp\Psr7\Exception\TimeoutException` when PHP-style timeout metad
 
 Calculate a hash of a stream.
 
-This method reads the entire stream to calculate a rolling hash, based on PHP's `hash_init` functions.
+This method reads the entire stream to calculate a rolling hash, based on PHP's
+`hash_init` functions.
 
-Throws `GuzzleHttp\Psr7\Exception\TimeoutException` when PHP-style timeout metadata can be detected after a stream read cannot make progress.
+Throws `GuzzleHttp\Psr7\Exception\TimeoutException` when PHP-style timeout
+metadata can be detected after a stream read cannot make progress.
 
 ## `GuzzleHttp\Psr7\Utils::readLine`
 
@@ -36,7 +50,8 @@ Throws `GuzzleHttp\Psr7\Exception\TimeoutException` when PHP-style timeout metad
 
 Read a line from the stream up to the maximum allowed buffer length.
 
-Throws `GuzzleHttp\Psr7\Exception\TimeoutException` when PHP-style timeout metadata can be detected after a stream read cannot make progress.
+Throws `GuzzleHttp\Psr7\Exception\TimeoutException` when PHP-style timeout
+metadata can be detected after a stream read cannot make progress.
 
 ## `GuzzleHttp\Psr7\Utils::streamFor`
 
@@ -44,7 +59,8 @@ Throws `GuzzleHttp\Psr7\Exception\TimeoutException` when PHP-style timeout metad
 
 Create a new stream based on the input type.
 
-Options are provided as an associative array that can contain the following keys:
+Options are provided as an associative array that can contain the following
+keys:
 
 - metadata: Array of custom metadata.
 - size: Size of the stream.
@@ -54,10 +70,28 @@ This method accepts the following `$resource` types:
 - `Psr\Http\Message\StreamInterface`: Returns the value as-is.
 - `string`: Creates a stream object that uses the given string as the contents.
 - `resource`: Creates a stream object that wraps the given PHP stream resource.
-- `Iterator`: If the provided value implements `Iterator`, then a read-only stream object will be created that wraps the given iterable. Each time the stream is read from, data from the iterator will fill a buffer and will be continuously called until the buffer is equal to the requested read size. Yielded strings, integers, finite floats, booleans, `null`, and stringable objects are converted to string chunks; non-finite floats and other values throw `UnexpectedValueException` when the stream is read. Values that stringify to an empty string are skipped while the iterator advances. Subsequent read calls will first read from the buffer and then call `next` on the underlying iterator until it is exhausted.
-- `object` with `__toString()`: If the object has the `__toString()` method, the object will be cast to a string and then a stream will be returned that uses the string value.
+- `Iterator`: If the provided value implements `Iterator`, then a read-only
+  stream object will be created that wraps the given iterable. Each time the
+  stream is read from, data from the iterator will fill a buffer and will be
+  continuously called until the buffer is equal to the requested read size.
+  Yielded strings, integers, finite floats, booleans, `null`, and stringable
+  objects are converted to string chunks; non-finite floats and other values
+  throw `UnexpectedValueException` when the stream is read. Values that
+  stringify to an empty string are skipped while the iterator advances.
+  Subsequent read calls will first read from the buffer and then call `next` on
+  the underlying iterator until it is exhausted.
+- `object` with `__toString()`: If the object has the `__toString()` method, the
+  object will be cast to a string and then a stream will be returned that uses
+  the string value.
 - `NULL`: When `null` is passed, an empty stream object is returned.
-- `callable`: When a callable array, closure, or invokable object is passed and no earlier resource or object rule applies, a read-only stream object will be created that invokes the given callable. The callable is invoked with the suggested number of bytes to read. The callable can return fewer or more bytes than requested, but MUST return a non-empty string to provide data and MUST return `false` or `null` when there is no more data to return. Any additional bytes will be buffered and used in subsequent reads. String inputs are always treated as string bodies, even when they name callable functions.
+- `callable`: When a callable array, closure, or invokable object is passed and
+  no earlier resource or object rule applies, a read-only stream object will be
+  created that invokes the given callable. The callable is invoked with the
+  suggested number of bytes to read. The callable can return fewer or more bytes
+  than requested, but MUST return a non-empty string to provide data and MUST
+  return `false` or `null` when there is no more data to return. Any additional
+  bytes will be buffered and used in subsequent reads. String inputs are always
+  treated as string bodies, even when they name callable functions.
 
 ```php
 $stream = GuzzleHttp\Psr7\Utils::streamFor('foo');
@@ -78,7 +112,8 @@ $stream = GuzzleHttp\Psr7\Utils::streamFor($generator(100));
 
 Safely opens a PHP stream resource using a filename.
 
-When `fopen()` fails, PHP normally raises a warning. This function adds an error handler that checks for errors and throws an exception instead.
+When `fopen()` fails, PHP normally raises a warning. This function adds an error
+handler that checks for errors and throws an exception instead.
 
 ## `GuzzleHttp\Psr7\Utils::tryGetContents`
 
@@ -86,9 +121,11 @@ When `fopen()` fails, PHP normally raises a warning. This function adds an error
 
 Safely gets the contents of a given stream.
 
-When `stream_get_contents()` fails, PHP normally raises a warning. This function adds an error handler that checks for errors and throws an exception instead.
+When `stream_get_contents()` fails, PHP normally raises a warning. This function
+adds an error handler that checks for errors and throws an exception instead.
 
-Throws `GuzzleHttp\Psr7\Exception\TimeoutException` when PHP-style timeout metadata can be detected after the stream read cannot make progress.
+Throws `GuzzleHttp\Psr7\Exception\TimeoutException` when PHP-style timeout
+metadata can be detected after the stream read cannot make progress.
 
 ## Related
 

--- a/docs/uri-and-mime-helpers.md
+++ b/docs/uri-and-mime-helpers.md
@@ -1,6 +1,9 @@
 # URI and MIME Helpers
 
-This page covers small helper methods for redacting URI user info, converting values into URI objects, and resolving MIME types from filenames or extensions. For URI resolution, normalization, and comparison helpers, see [URI Helpers](uri-helpers.md).
+This page covers small helper methods for redacting URI user info, converting
+values into URI objects, and resolving MIME types from filenames or extensions.
+For URI resolution, normalization, and comparison helpers, see
+[URI Helpers](uri-helpers.md).
 
 ## `GuzzleHttp\Psr7\Utils::redactUserInfo`
 
@@ -14,7 +17,9 @@ Redact the user info part of a URI.
 
 Returns a `UriInterface` for the given value.
 
-This function accepts a string or `UriInterface` and returns a `UriInterface` for the given value. If the value is already a `UriInterface`, it is returned as-is.
+This function accepts a string or `UriInterface` and returns a `UriInterface`
+for the given value. If the value is already a `UriInterface`, it is returned
+as-is.
 
 ## `GuzzleHttp\Psr7\MimeType::fromFilename`
 

--- a/docs/uri-helpers.md
+++ b/docs/uri-helpers.md
@@ -1,15 +1,19 @@
 # URI Helpers
 
-This page covers this package's `Psr\Http\Message\UriInterface` implementation and URI helper classes for classifying, composing, resolving, normalizing, comparing, and safely modifying URIs.
+This page covers this package's `Psr\Http\Message\UriInterface` implementation
+and URI helper classes for classifying, composing, resolving, normalizing,
+comparing, and safely modifying URIs.
 
-Aside from the standard `Psr\Http\Message\UriInterface` implementation provided by the `GuzzleHttp\Psr7\Uri` class,
-this library also provides additional static methods for working with URIs.
+Aside from the standard `Psr\Http\Message\UriInterface` implementation provided
+by the `GuzzleHttp\Psr7\Uri` class, this library also provides additional static
+methods for working with URIs.
 
 ## URI Types
 
-An instance of `Psr\Http\Message\UriInterface` can either be an absolute URI or a relative reference.
-An absolute URI has a scheme. A relative reference is used to express a URI relative to another URI,
-the base URI. Relative references can be divided into several forms according to
+An instance of `Psr\Http\Message\UriInterface` can either be an absolute URI or
+a relative reference. An absolute URI has a scheme. A relative reference is used
+to express a URI relative to another URI, the base URI. Relative references can
+be divided into several forms according to
 [RFC 3986 Section 4.2](https://datatracker.ietf.org/doc/html/rfc3986#section-4.2):
 
 - network-path references, e.g. `//example.com/path`
@@ -28,35 +32,37 @@ Whether the URI is absolute, i.e. it has a scheme.
 
 `public static function isNetworkPathReference(UriInterface $uri): bool`
 
-Whether the URI is a network-path reference. A relative reference that begins with two slash characters is
-termed a network-path reference.
+Whether the URI is a network-path reference. A relative reference that begins
+with two slash characters is termed a network-path reference.
 
 ### `GuzzleHttp\Psr7\Uri::isAbsolutePathReference`
 
 `public static function isAbsolutePathReference(UriInterface $uri): bool`
 
-Whether the URI is an absolute-path reference. A relative reference that begins with a single slash character is
-termed an absolute-path reference.
+Whether the URI is an absolute-path reference. A relative reference that begins
+with a single slash character is termed an absolute-path reference.
 
 ### `GuzzleHttp\Psr7\Uri::isRelativePathReference`
 
 `public static function isRelativePathReference(UriInterface $uri): bool`
 
-Whether the URI is a relative-path reference. A relative reference that does not begin with a slash character is
-termed a relative-path reference.
+Whether the URI is a relative-path reference. A relative reference that does not
+begin with a slash character is termed a relative-path reference.
 
 ### `GuzzleHttp\Psr7\Uri::isSameDocumentReference`
 
 `public static function isSameDocumentReference(UriInterface $uri, ?UriInterface $base = null): bool`
 
-Whether the URI is a same-document reference. A same-document reference refers to a URI that is, aside from its
-fragment component, identical to the base URI. When no base URI is given, only an empty URI reference
-(apart from its fragment) is considered a same-document reference.
+Whether the URI is a same-document reference. A same-document reference refers
+to a URI that is, aside from its fragment component, identical to the base URI.
+When no base URI is given, only an empty URI reference (apart from its fragment)
+is considered a same-document reference.
 
 ## URI Syntax Validation
 
-`GuzzleHttp\Psr7\Rfc3986` provides static methods for validating individual URI components against the
-grammar defined by [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986). They operate on raw
+`GuzzleHttp\Psr7\Rfc3986` provides static methods for validating individual URI
+components against the grammar defined by
+[RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986). They operate on raw
 component strings rather than on `Psr\Http\Message\UriInterface` instances.
 
 ### `GuzzleHttp\Psr7\Rfc3986::isValidScheme`
@@ -64,39 +70,47 @@ component strings rather than on `Psr\Http\Message\UriInterface` instances.
 `public static function isValidScheme(string $scheme): bool`
 
 Whether the string is a valid URI scheme. Per
-[RFC 3986 Section 3.1](https://datatracker.ietf.org/doc/html/rfc3986#section-3.1), a scheme must start
-with a letter, followed by any number of letters, digits, `+`, `-`, or `.`. The empty string is also
-accepted, since a URI reference may omit the scheme.
+[RFC 3986 Section 3.1](https://datatracker.ietf.org/doc/html/rfc3986#section-3.1),
+a scheme must start with a letter, followed by any number of letters, digits,
+`+`, `-`, or `.`. The empty string is also accepted, since a URI reference may
+omit the scheme.
 
 ### `GuzzleHttp\Psr7\Rfc3986::isValidHost`
 
 `public static function isValidHost(string $host): bool`
 
 Whether the string is a valid URI host. Per
-[RFC 3986 Section 3.2.2](https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.2), the host is an
-IP-literal, IPv4 address, or registered name. An empty host is accepted, since the authority, and thus the
-host, may be empty. Bracketed values are validated as IPv6 or IPvFuture literals; any other value is
-rejected if it contains control characters, whitespace, an authority or path delimiter (`/`, `?`, `#`, `@`,
-`\`), or an embedded colon denoting a port. Percent-encoding is validated the same way: malformed sequences
-(a `%` not followed by two hex digits) and percent-encoded octets that decode to one of the rejected bytes,
-to a bracket (`[`, `]`), or to `%` itself are invalid, while all other percent-encoded octets are accepted.
-Rejecting these percent-encoded octets is a deliberate guzzle host policy, stricter than the RFC 3986
-`reg-name` grammar, which permits any well-formed `pct-encoded` octet; it matches the stricter policy used
-throughout the library. RFC 6874 IPv6 zone identifiers (for example `[fe80::1%25eth0]`) are not supported.
+[RFC 3986 Section 3.2.2](https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.2),
+the host is an IP-literal, IPv4 address, or registered name. An empty host is
+accepted, since the authority, and thus the host, may be empty. Bracketed values
+are validated as IPv6 or IPvFuture literals; any other value is rejected if it
+contains control characters, whitespace, an authority or path delimiter (`/`,
+`?`, `#`, `@`, `\`), or an embedded colon denoting a port. Percent-encoding is
+validated the same way: malformed sequences (a `%` not followed by two hex
+digits) and percent-encoded octets that decode to one of the rejected bytes, to
+a bracket (`[`, `]`), or to `%` itself are invalid, while all other
+percent-encoded octets are accepted. Rejecting these percent-encoded octets is a
+deliberate guzzle host policy, stricter than the RFC 3986 `reg-name` grammar,
+which permits any well-formed `pct-encoded` octet; it matches the stricter
+policy used throughout the library. RFC 6874 IPv6 zone identifiers (for example
+`[fe80::1%25eth0]`) are not supported.
 
-Registered names are otherwise intentionally permissive: single-label hosts such as `localhost`,
-underscores, sub-delims, and raw or percent-encoded non-ASCII (IDN) data are accepted and preserved as
-given, with no punycode conversion. IDNA is treated as a client concern. Consumers that need DNS IDNs must
-perform the conversion themselves, for example via Guzzle's `idn_conversion` request option.
+Registered names are otherwise intentionally permissive: single-label hosts such
+as `localhost`, underscores, sub-delims, and raw or percent-encoded non-ASCII
+(IDN) data are accepted and preserved as given, with no punycode conversion.
+IDNA is treated as a client concern. Consumers that need DNS IDNs must perform
+the conversion themselves, for example via Guzzle's `idn_conversion` request
+option.
 
 ### `GuzzleHttp\Psr7\Rfc3986::isValidPort`
 
 `public static function isValidPort(string $port): bool`
 
-Whether the string is a valid port number. RFC 3986 defines the port as `*DIGIT`, which also permits an
-empty port and has no upper bound; this applies the stricter policy used throughout the library instead,
-accepting a non-empty run of digits (leading zeros are accepted and normalized) that resolves to a value
-in the range 0-65535.
+Whether the string is a valid port number. RFC 3986 defines the port as
+`*DIGIT`, which also permits an empty port and has no upper bound; this applies
+the stricter policy used throughout the library instead, accepting a non-empty
+run of digits (leading zeros are accepted and normalized) that resolves to a
+value in the range 0-65535.
 
 ## URI Components
 
@@ -106,65 +120,89 @@ Additional methods to work with URI components.
 
 `public static function isDefaultPort(UriInterface $uri): bool`
 
-Whether the URI has the default port of the current scheme. `Psr\Http\Message\UriInterface::getPort` may return null
-or the standard port. This method can be used independently of the implementation.
+Whether the URI has the default port of the current scheme.
+`Psr\Http\Message\UriInterface::getPort` may return null or the standard port.
+This method can be used independently of the implementation.
 
 ### `GuzzleHttp\Psr7\Uri::composeComponents`
 
-`public static function composeComponents($scheme, $authority, $path, $query, $fragment): string`
+`public static function composeComponents(?string $scheme, ?string $authority, string $path, ?string $query, ?string $fragment): string`
 
 Composes a URI reference string from its various components according to
-[RFC 3986 Section 5.3](https://datatracker.ietf.org/doc/html/rfc3986#section-5.3). Usually this method does not need
-to be called manually but instead is used indirectly via `Psr\Http\Message\UriInterface::__toString`.
+[RFC 3986 Section 5.3](https://datatracker.ietf.org/doc/html/rfc3986#section-5.3).
+Usually this method does not need to be called manually but instead is used
+indirectly via `Psr\Http\Message\UriInterface::__toString`.
+
+PSR-7 UriInterface treats an empty component the same as a missing component as
+`getQuery()`, `getFragment()` etc. always return a string. This explains the
+slight difference to RFC 3986 Section 5.3.
+
+Another adjustment is that the authority separator is added even when the
+authority is missing/empty for the "file" scheme. This is because PHP stream
+functions like `file_get_contents` only work with `file:///myfile` but not with
+`file:/myfile` although they are equivalent according to RFC 3986. But
+`file:///` is the more common syntax for the file scheme anyway (Chrome for
+example redirects to that format). The separator is omitted when such a URI has
+a rootless or empty path: adding it would turn the first path segment into the
+authority of the composed URI, or compose the string `file://`, which cannot be
+parsed back into a URI.
 
 ### `GuzzleHttp\Psr7\Uri::fromParts`
 
 `public static function fromParts(array $parts): UriInterface`
 
-Creates a URI from a hash of [`parse_url`](https://www.php.net/manual/en/function.parse-url.php) components.
-
+Creates a URI from a hash of
+[`parse_url`](https://www.php.net/manual/en/function.parse-url.php) components.
 
 ### `GuzzleHttp\Psr7\Uri::withQueryValue`
 
-`public static function withQueryValue(UriInterface $uri, $key, $value): UriInterface`
+`public static function withQueryValue(UriInterface $uri, string $key, ?string $value): UriInterface`
 
-Creates a new URI with a specific query string value. Any existing query string values that exactly match the
-provided key are removed and replaced with the given key value pair. A value of null will set the query string
-key without a value, e.g. "key" instead of "key=value".
+Creates a new URI with a specific query string value. Any existing query string
+values that exactly match the provided key are removed and replaced with the
+given key value pair. A value of null will set the query string key without a
+value, e.g. "key" instead of "key=value".
 
 ### `GuzzleHttp\Psr7\Uri::withQueryValues`
 
 `public static function withQueryValues(UriInterface $uri, array $keyValueArray): UriInterface`
 
-Creates a new URI with multiple query string values. It has the same behavior as `withQueryValue()` but for an
-associative array of key => value.
+Creates a new URI with multiple query string values. It has the same behavior as
+`withQueryValue()` but for an associative array of key => value.
 
 ### `GuzzleHttp\Psr7\Uri::withoutQueryValue`
 
-`public static function withoutQueryValue(UriInterface $uri, $key): UriInterface`
+`public static function withoutQueryValue(UriInterface $uri, string $key): UriInterface`
 
-Creates a new URI with a specific query string value removed. Any existing query string values that exactly match the
-provided key are removed.
+Creates a new URI with a specific query string value removed. Any existing query
+string values that exactly match the provided key are removed.
 
 ## Cross-Origin Detection
 
-`GuzzleHttp\Psr7\UriComparator` provides methods to determine if a modified URI should be considered cross-origin.
+`GuzzleHttp\Psr7\UriComparator` provides methods to determine if a modified URI
+should be considered cross-origin.
 
 ### `GuzzleHttp\Psr7\UriComparator::isCrossOrigin`
 
 `public static function isCrossOrigin(UriInterface $original, UriInterface $modified): bool`
 
-Determines if a modified URI should be considered cross-origin with respect to an original URI.
+Determines if a modified URI should be considered cross-origin with respect to
+an original URI.
 
-Two URIs are cross-origin when their scheme, host, or effective port differ. Host comparison is case-insensitive, and missing ports use the default port for `http` or `https`. Other schemes do not receive implicit default ports.
+Two URIs are cross-origin when their scheme, host, or effective port differ.
+Host comparison is case-insensitive, and missing ports use the default port for
+`http` or `https`. Other schemes do not receive implicit default ports.
 
-This helper only compares URI origins. It does not implement redirect handling or credential policy.
+This helper only compares URI origins. It does not implement redirect handling
+or credential policy.
 
 ## Reference Resolution
 
-`GuzzleHttp\Psr7\UriResolver` provides methods to resolve a URI reference in the context of a base URI according
-to [RFC 3986 Section 5](https://datatracker.ietf.org/doc/html/rfc3986#section-5). This is also what web
-browsers do when resolving a link in a document based on the current request URI.
+`GuzzleHttp\Psr7\UriResolver` provides methods to resolve a URI reference in the
+context of a base URI according to
+[RFC 3986 Section 5](https://datatracker.ietf.org/doc/html/rfc3986#section-5).
+This is also what web browsers do when resolving a link in a document based on
+the current request URI.
 
 ### `GuzzleHttp\Psr7\UriResolver::resolve`
 
@@ -179,18 +217,26 @@ Converts the relative URI into a new URI that is resolved against the base URI.
 Removes dot segments from a path and returns the new path according to
 [RFC 3986 Section 5.2.4](https://datatracker.ietf.org/doc/html/rfc3986#section-5.2.4).
 
+Excess `..` segments above the root of an absolute path are dropped without
+consuming the root, so the result can begin with `//` (e.g. `/..//a` becomes
+`//a`). Such a path is not valid for a URI without an authority (RFC 3986
+Section 3.3); `resolve()` and `UriNormalizer::normalize()` serialize it with a
+`/.` prefix in that case, like the WHATWG URL Standard.
+
 ### `GuzzleHttp\Psr7\UriResolver::relativize`
 
 `public static function relativize(UriInterface $base, UriInterface $target): UriInterface`
 
-Returns the target URI as a relative reference from the base URI. This method is the counterpart to `resolve()`:
+Returns the target URI as a relative reference from the base URI. This method is
+the counterpart to `resolve()`:
 
 ```php
 (string) $target === (string) UriResolver::resolve($base, UriResolver::relativize($base, $target))
 ```
 
-One use case is to use the current request URI as the base URI and then generate relative links in your documents
-to reduce the document size or offer self-contained downloadable document archives.
+One use case is to use the current request URI as the base URI and then generate
+relative links in your documents to reduce the document size or offer
+self-contained downloadable document archives.
 
 ```php
 $base = new Uri('http://example.com/a/b/');
@@ -201,18 +247,35 @@ echo UriResolver::relativize($base, new Uri('http://example.org/a/b/'));   // pr
 echo UriResolver::relativize($base, new Uri('http://example.com'));         // prints '//example.com'.
 ```
 
+This method also accepts a target that is already relative and will try to
+relativize it further. Only a relative-path reference will be returned as-is.
+
+```php
+echo UriResolver::relativize($base, new Uri('/a/b/c'));  // prints 'c' as well
+```
+
 ## Normalization and Comparison
 
-`GuzzleHttp\Psr7\UriNormalizer` provides methods to normalize and compare URIs according to
+`GuzzleHttp\Psr7\UriNormalizer` provides methods to normalize and compare URIs
+according to
 [RFC 3986 Section 6](https://datatracker.ietf.org/doc/html/rfc3986#section-6).
 
 ### `GuzzleHttp\Psr7\UriNormalizer::normalize`
 
-`public static function normalize(UriInterface $uri, $flags = self::PRESERVING_NORMALIZATIONS): UriInterface`
+`public static function normalize(UriInterface $uri, int $flags = self::PRESERVING_NORMALIZATIONS): UriInterface`
 
-Returns a normalized URI. The scheme and host component are already normalized to lowercase per PSR-7 UriInterface.
-This method adds additional normalizations that can be configured with the `$flags` parameter, which is a bitmask
-of normalizations to apply. The following normalizations are available:
+Returns a normalized URI. The scheme and host component are already normalized
+to lowercase per PSR-7 UriInterface. This method adds additional normalizations
+that can be configured with the `$flags` parameter, which is a bitmask of
+normalizations to apply.
+
+PSR-7 UriInterface cannot distinguish between an empty component and a missing
+component as `getQuery()`, `getFragment()` etc. always return a string. This
+means the URIs `/?#` and `/` are treated equivalent which is not necessarily
+true according to RFC 3986. But that difference is highly uncommon in reality.
+So this potential normalization is implied in PSR-7 as well.
+
+The following normalizations are available:
 
 - `UriNormalizer::PRESERVING_NORMALIZATIONS`
 
@@ -220,16 +283,18 @@ of normalizations to apply. The following normalizations are available:
 
 - `UriNormalizer::CAPITALIZE_PERCENT_ENCODING`
 
-    All letters within a percent-encoding triplet (e.g., "%3A") are case-insensitive, and should be capitalized.
+    All letters within a percent-encoding triplet (e.g., "%3A") are
+    case-insensitive, and should be capitalized.
 
     Example: `http://example.org/a%c2%b1b` → `http://example.org/a%C2%B1b`
 
 - `UriNormalizer::DECODE_UNRESERVED_CHARACTERS`
 
-    Decodes percent-encoded octets of unreserved characters. For consistency, percent-encoded octets in the ranges of
-    ALPHA (%41–%5A and %61–%7A), DIGIT (%30–%39), hyphen (%2D), period (%2E), underscore (%5F), or tilde (%7E) should
-    not be created by URI producers and, when found in a URI, should be decoded to their corresponding unreserved
-    characters by URI normalizers.
+    Decodes percent-encoded octets of unreserved characters. For consistency,
+    percent-encoded octets in the ranges of ALPHA (%41–%5A and %61–%7A), DIGIT
+    (%30–%39), hyphen (%2D), period (%2E), underscore (%5F), or tilde (%7E)
+    should not be created by URI producers and, when found in a URI, should be
+    decoded to their corresponding unreserved characters by URI normalizers.
 
     Example: `http://example.org/%7Eusern%61me/` → `http://example.org/~username/`
 
@@ -241,8 +306,9 @@ of normalizations to apply. The following normalizations are available:
 
 - `UriNormalizer::REMOVE_DEFAULT_HOST`
 
-    Removes the default host of the given URI scheme from the URI. Only the "file" scheme defines the default host
-    "localhost". All of `file:/myfile`, `file:///myfile`, and `file://localhost/myfile` are equivalent according to
+    Removes the default host of the given URI scheme from the URI. Only the
+    "file" scheme defines the default host "localhost". All of `file:/myfile`,
+    `file:///myfile`, and `file://localhost/myfile` are equivalent according to
     RFC 3986.
 
     Example: `file://localhost/myfile` → `file:///myfile`
@@ -255,35 +321,39 @@ of normalizations to apply. The following normalizations are available:
 
 - `UriNormalizer::REMOVE_DOT_SEGMENTS`
 
-    Removes unnecessary dot-segments. Dot-segments in relative-path references are not removed as it would
-    change the semantics of the URI reference.
+    Removes unnecessary dot-segments. Dot-segments in relative-path references
+    are not removed as it would change the semantics of the URI reference.
 
     Example: `http://example.org/../a/b/../c/./d.html` → `http://example.org/a/c/d.html`
 
 - `UriNormalizer::REMOVE_DUPLICATE_SLASHES`
 
-    Paths which include two or more adjacent slashes are converted to one. Webservers usually ignore duplicate slashes
-    and treat those URIs equivalent. But in theory those URIs do not need to be equivalent. So this normalization
+    Paths which include two or more adjacent slashes are converted to one.
+    Webservers usually ignore duplicate slashes and treat those URIs equivalent.
+    But in theory those URIs do not need to be equivalent. So this normalization
     may change the semantics. Encoded slashes (%2F) are not removed.
 
     Example: `http://example.org//foo///bar.html` → `http://example.org/foo/bar.html`
 
 - `UriNormalizer::SORT_QUERY_PARAMETERS`
 
-    Sort query parameters with their values in alphabetical order. However, the order of parameters in a URI may be
-    significant (this is not defined by the standard). So this normalization is not safe and may change the semantics
-    of the URI.
+    Sort query parameters with their values in alphabetical order. However, the
+    order of parameters in a URI may be significant (this is not defined by the
+    standard). So this normalization is not safe and may change the semantics of
+    the URI.
 
     Example: `?lang=en&article=fred` → `?article=fred&lang=en`
 
 ### `GuzzleHttp\Psr7\UriNormalizer::isEquivalent`
 
-`public static function isEquivalent(UriInterface $uri1, UriInterface $uri2, $normalizations = self::PRESERVING_NORMALIZATIONS): bool`
+`public static function isEquivalent(UriInterface $uri1, UriInterface $uri2, int $normalizations = self::PRESERVING_NORMALIZATIONS): bool`
 
-Whether two URIs can be considered equivalent. Both URIs are normalized automatically before comparison with the given
-`$normalizations` bitmask. The method also accepts relative URI references and returns true when they are equivalent.
-This of course assumes they will be resolved against the same base URI. If this is not the case, determination of
-equivalence or difference of relative references does not mean anything.
+Whether two URIs can be considered equivalent. Both URIs are normalized
+automatically before comparison with the given `$normalizations` bitmask. The
+method also accepts relative URI references and returns true when they are
+equivalent. This of course assumes they will be resolved against the same base
+URI. If this is not the case, determination of equivalence or difference of
+relative references does not mean anything.
 
 ## Related
 

--- a/src/Header.php
+++ b/src/Header.php
@@ -11,10 +11,9 @@ final class Header
     }
 
     /**
-     * Parse an array of header values containing ";" separated data into an
-     * array of associative arrays representing the header key value pair data
-     * of the header. When a parameter does not contain a value, but just
-     * contains a key, this function will inject a key with a '' string value.
+     * Parses semicolon-separated header parameters into associative arrays, one
+     * per comma-separated header value. Parameters without a value are appended
+     * as values under integer keys.
      *
      * @param string|array $header Header to parse into components.
      */
@@ -96,15 +95,16 @@ final class Header
     }
 
     /**
-     * Splits a HTTP header defined to contain a comma-separated list into
-     * each individual value. Empty values will be removed.
+     * Splits an HTTP header defined to contain a comma-separated list into each
+     * individual value. Empty values are removed.
      *
-     * Example headers include 'accept', 'cache-control' and 'if-none-match'.
+     * Example headers include `accept`, `cache-control`, and `if-none-match`.
      *
-     * This method must not be used to parse headers that are not defined as
-     * a list, such as 'user-agent' or 'set-cookie'.
+     * This method must not be used to parse headers that are not defined as a
+     * list, such as `user-agent` or `set-cookie`.
      *
-     * @param string|string[] $values Header value as returned by MessageInterface::getHeader()
+     * @param string|string[] $values Header value as returned by
+     *                                MessageInterface::getHeader()
      *
      * @return string[]
      */

--- a/src/Message.php
+++ b/src/Message.php
@@ -21,7 +21,8 @@ final class Message
     private const REQUEST_METHOD_TOKEN = '[!#$%&\'*+.^_`|~0-9A-Za-z-]+';
 
     /**
-     * Request-target bytes accepted by the start-line parser (no CTL, SP, or DEL), for use in a regex.
+     * Request-target bytes accepted by the start-line parser (no CTL, SP, or
+     * DEL), for use in a regex.
      */
     private const REQUEST_TARGET_CHARS = '[^\x00-\x20\x7F]+';
 
@@ -84,8 +85,12 @@ final class Message
      *
      * Will return `null` if the response is not printable.
      *
+     * Reads seekable bodies from the beginning and restores the original cursor
+     * position before returning. Pass `null` for `$truncateAt` to use the
+     * default summary length.
+     *
      * @param MessageInterface $message    The message to get the body summary
-     * @param int|null         $truncateAt The maximum allowed size of the summary
+     * @param int|null         $truncateAt Maximum allowed size of the summary
      */
     public static function bodySummary(MessageInterface $message, ?int $truncateAt = null): ?string
     {
@@ -205,9 +210,9 @@ final class Message
     /**
      * Parses an HTTP message into an associative array.
      *
-     * The array contains the "start-line" key containing the start line of
-     * the message, "headers" key containing an associative array of header
-     * array values, and a "body" key containing the body of the message.
+     * The array contains the `start-line` key containing the start line of the
+     * message, `headers` key containing an associative array of header array
+     * values, and a `body` key containing the body of the message.
      *
      * @param string $message HTTP request or response to parse.
      */
@@ -300,6 +305,13 @@ final class Message
 
     /**
      * Constructs a URI for an HTTP request message.
+     *
+     * The URI is composed from the start-line path and the `Host` header, using
+     * `https` when the host's port is `443` and `http` otherwise. Without a
+     * `Host` header, only the path is returned, with extra leading slashes
+     * collapsed so an origin-form target cannot be parsed as a network-path
+     * reference with its own authority. An `InvalidArgumentException` is thrown
+     * when the `Host` header is invalid.
      *
      * @param string $path    Path from the start-line
      * @param array  $headers Array of headers (each value an array).
@@ -413,6 +425,12 @@ final class Message
 
     /**
      * Parses a request message string into a request object.
+     *
+     * The request-target must be in origin form, absolute form (without a
+     * userinfo component), authority form (`CONNECT`), or asterisk form
+     * (`OPTIONS`), and any `Host` header must be a single valid value;
+     * otherwise an `InvalidArgumentException` is thrown. Non-origin-form
+     * targets are preserved on the returned request via `withRequestTarget()`.
      *
      * @param string $message Request message string.
      */

--- a/src/MimeType.php
+++ b/src/MimeType.php
@@ -1288,7 +1288,7 @@ final class MimeType
     ];
 
     /**
-     * Determines the mimetype of a file by looking at its extension.
+     * Determines the MIME type of a file by looking at its extension.
      *
      * @see https://raw.githubusercontent.com/jshttp/mime-db/master/db.json
      */
@@ -1298,7 +1298,7 @@ final class MimeType
     }
 
     /**
-     * Maps a file extensions to a mimetype.
+     * Maps a file extension to a MIME type.
      *
      * @see https://raw.githubusercontent.com/jshttp/mime-db/master/db.json
      */

--- a/src/Query.php
+++ b/src/Query.php
@@ -13,10 +13,10 @@ final class Query
     /**
      * Parse a query string into an associative array.
      *
-     * If multiple values are found for the same key, the value of that key
-     * value pair will become an array. This function does not parse nested
-     * PHP style arrays into an associative array (e.g., `foo[a]=1&foo[b]=2`
-     * will be parsed into `['foo[a]' => '1', 'foo[b]' => '2'])`.
+     * If multiple values are found for the same key, the value of that
+     * key-value pair becomes an array. This function does not parse nested PHP
+     * style arrays into an associative array. For example, `foo[a]=1&foo[b]=2`
+     * will be parsed into `['foo[a]' => '1', 'foo[b]' => '2']`.
      *
      * @param string   $str         Query string to parse
      * @param int|bool $urlEncoding How the query string is encoded
@@ -65,11 +65,11 @@ final class Query
     }
 
     /**
-     * Build a query string from an array of key value pairs.
+     * Build a query string from an array of key-value pairs.
      *
      * This function can use the return value of `parse()` to build a query
      * string. This function does not modify the provided keys when an array is
-     * encountered (like `http_build_query()` would).
+     * encountered, unlike `http_build_query()`.
      *
      * @param array     $params           Query string parameters.
      * @param int|false $encoding         Set to false to not encode,

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -219,22 +219,25 @@ class Uri implements UriInterface, \JsonSerializable
     }
 
     /**
-     * Composes a URI reference string from its various components.
+     * Composes a URI reference string from its various components according to
+     * RFC 3986 Section 5.3.
      *
-     * Usually this method does not need to be called manually but instead is used indirectly via
-     * `Psr\Http\Message\UriInterface::__toString`.
+     * Usually this method does not need to be called manually but instead is
+     * used indirectly via `Psr\Http\Message\UriInterface::__toString`.
      *
-     * PSR-7 UriInterface treats an empty component the same as a missing component as
-     * getQuery(), getFragment() etc. always return a string. This explains the slight
-     * difference to RFC 3986 Section 5.3.
+     * PSR-7 UriInterface treats an empty component the same as a missing
+     * component as `getQuery()`, `getFragment()` etc. always return a string.
+     * This explains the slight difference to RFC 3986 Section 5.3.
      *
-     * Another adjustment is that the authority separator is added even when the authority is missing/empty
-     * for the "file" scheme. This is because PHP stream functions like `file_get_contents` only work with
-     * `file:///myfile` but not with `file:/myfile` although they are equivalent according to RFC 3986. But
-     * `file:///` is the more common syntax for the file scheme anyway (Chrome for example redirects to
-     * that format). The separator is omitted when such a URI has a rootless or empty path: adding it would
-     * turn the first path segment into the authority of the composed URI, or compose the string `file://`,
-     * which cannot be parsed back into a URI.
+     * Another adjustment is that the authority separator is added even when the
+     * authority is missing/empty for the "file" scheme. This is because PHP
+     * stream functions like `file_get_contents` only work with `file:///myfile`
+     * but not with `file:/myfile` although they are equivalent according to RFC
+     * 3986. But `file:///` is the more common syntax for the file scheme anyway
+     * (Chrome for example redirects to that format). The separator is omitted
+     * when such a URI has a rootless or empty path: adding it would turn the
+     * first path segment into the authority of the composed URI, or compose the
+     * string `file://`, which cannot be parsed back into a URI.
      *
      * @see https://datatracker.ietf.org/doc/html/rfc3986#section-5.3
      */
@@ -271,8 +274,8 @@ class Uri implements UriInterface, \JsonSerializable
     /**
      * Whether the URI has the default port of the current scheme.
      *
-     * `Psr\Http\Message\UriInterface::getPort` may return null or the standard port. This method can be used
-     * independently of the implementation.
+     * `Psr\Http\Message\UriInterface::getPort` may return null or the standard
+     * port. This method can be used independently of the implementation.
      */
     public static function isDefaultPort(UriInterface $uri): bool
     {
@@ -283,17 +286,18 @@ class Uri implements UriInterface, \JsonSerializable
     /**
      * Whether the URI is absolute, i.e. it has a scheme.
      *
-     * An instance of UriInterface can either be an absolute URI or a relative reference. This method returns true
-     * if it is the former. An absolute URI has a scheme. A relative reference is used to express a URI relative
-     * to another URI, the base URI. Relative references can be divided into several forms:
-     * - network-path references, e.g. '//example.com/path'
-     * - absolute-path references, e.g. '/path'
-     * - relative-path references, e.g. 'subpath'
+     * An instance of UriInterface can either be an absolute URI or a relative
+     * reference. An absolute URI has a scheme. A relative reference is used to
+     * express a URI relative to another URI, the base URI. Relative references
+     * can be divided into several forms according to RFC 3986 Section 4.2:
+     * - network-path references, e.g. `//example.com/path`
+     * - absolute-path references, e.g. `/path`
+     * - relative-path references, e.g. `subpath`
      *
      * @see Uri::isNetworkPathReference
      * @see Uri::isAbsolutePathReference
      * @see Uri::isRelativePathReference
-     * @see https://datatracker.ietf.org/doc/html/rfc3986#section-4
+     * @see https://datatracker.ietf.org/doc/html/rfc3986#section-4.2
      */
     public static function isAbsolute(UriInterface $uri): bool
     {
@@ -303,7 +307,8 @@ class Uri implements UriInterface, \JsonSerializable
     /**
      * Whether the URI is a network-path reference.
      *
-     * A relative reference that begins with two slash characters is termed an network-path reference.
+     * A relative reference that begins with two slash characters is termed a
+     * network-path reference.
      *
      * @see https://datatracker.ietf.org/doc/html/rfc3986#section-4.2
      */
@@ -313,9 +318,10 @@ class Uri implements UriInterface, \JsonSerializable
     }
 
     /**
-     * Whether the URI is a absolute-path reference.
+     * Whether the URI is an absolute-path reference.
      *
-     * A relative reference that begins with a single slash character is termed an absolute-path reference.
+     * A relative reference that begins with a single slash character is termed
+     * an absolute-path reference.
      *
      * @see https://datatracker.ietf.org/doc/html/rfc3986#section-4.2
      */
@@ -330,7 +336,8 @@ class Uri implements UriInterface, \JsonSerializable
     /**
      * Whether the URI is a relative-path reference.
      *
-     * A relative reference that does not begin with a slash character is termed a relative-path reference.
+     * A relative reference that does not begin with a slash character is termed
+     * a relative-path reference.
      *
      * @see https://datatracker.ietf.org/doc/html/rfc3986#section-4.2
      */
@@ -344,9 +351,10 @@ class Uri implements UriInterface, \JsonSerializable
     /**
      * Whether the URI is a same-document reference.
      *
-     * A same-document reference refers to a URI that is, aside from its fragment
-     * component, identical to the base URI. When no base URI is given, only an empty
-     * URI reference (apart from its fragment) is considered a same-document reference.
+     * A same-document reference refers to a URI that is, aside from its
+     * fragment component, identical to the base URI. When no base URI is given,
+     * only an empty URI reference (apart from its fragment) is considered a
+     * same-document reference.
      *
      * @param UriInterface      $uri  The URI to check
      * @param UriInterface|null $base An optional base URI to compare against
@@ -387,10 +395,9 @@ class Uri implements UriInterface, \JsonSerializable
      * Creates a new URI with a specific query string value.
      *
      * Any existing query string values that exactly match the provided key are
-     * removed and replaced with the given key value pair.
-     *
-     * A value of null will set the query string key without a value, e.g. "key"
-     * instead of "key=value".
+     * removed and replaced with the given key value pair. A value of null will
+     * set the query string key without a value, e.g. "key" instead of
+     * "key=value".
      *
      * @param UriInterface $uri   URI to use as a base.
      * @param string       $key   Key to set.
@@ -406,9 +413,10 @@ class Uri implements UriInterface, \JsonSerializable
     }
 
     /**
-     * Creates a new URI with multiple specific query string values.
+     * Creates a new URI with multiple query string values.
      *
-     * It has the same behavior as withQueryValue() but for an associative array of key => value.
+     * It has the same behavior as `withQueryValue()` but for an associative
+     * array of key => value.
      *
      * @param UriInterface    $uri           URI to use as a base.
      * @param (string|null)[] $keyValueArray Associative array of key and values

--- a/src/UriComparator.php
+++ b/src/UriComparator.php
@@ -7,15 +7,24 @@ namespace GuzzleHttp\Psr7;
 use Psr\Http\Message\UriInterface;
 
 /**
- * Provides methods to determine if a modified URL should be considered cross-origin.
+ * Provides methods to determine if a modified URI should be considered
+ * cross-origin.
  *
  * @author Graham Campbell
  */
 final class UriComparator
 {
     /**
-     * Determines if a modified URL should be considered cross-origin with
-     * respect to an original URL.
+     * Determines if a modified URI should be considered cross-origin with
+     * respect to an original URI.
+     *
+     * Two URIs are cross-origin when their scheme, host, or effective port
+     * differ. Host comparison is case-insensitive, and missing ports use the
+     * default port for `http` or `https`. Other schemes do not receive implicit
+     * default ports.
+     *
+     * This helper only compares URI origins. It does not implement redirect
+     * handling or credential policy.
      */
     public static function isCrossOrigin(UriInterface $original, UriInterface $modified): bool
     {

--- a/src/UriNormalizer.php
+++ b/src/UriNormalizer.php
@@ -16,7 +16,8 @@ use Psr\Http\Message\UriInterface;
 final class UriNormalizer
 {
     /**
-     * Default normalizations which only include the ones that preserve semantics.
+     * Default normalizations which only include the ones that preserve
+     * semantics.
      */
     public const PRESERVING_NORMALIZATIONS =
         self::CAPITALIZE_PERCENT_ENCODING |
@@ -27,7 +28,8 @@ final class UriNormalizer
         self::REMOVE_DOT_SEGMENTS;
 
     /**
-     * All letters within a percent-encoding triplet (e.g., "%3A") are case-insensitive, and should be capitalized.
+     * All letters within a percent-encoding triplet (e.g., "%3A") are
+     * case-insensitive, and should be capitalized.
      *
      * Example: http://example.org/a%c2%b1b → http://example.org/a%C2%B1b
      */
@@ -36,9 +38,11 @@ final class UriNormalizer
     /**
      * Decodes percent-encoded octets of unreserved characters.
      *
-     * For consistency, percent-encoded octets in the ranges of ALPHA (%41–%5A and %61–%7A), DIGIT (%30–%39),
-     * hyphen (%2D), period (%2E), underscore (%5F), or tilde (%7E) should not be created by URI producers and,
-     * when found in a URI, should be decoded to their corresponding unreserved characters by URI normalizers.
+     * For consistency, percent-encoded octets in the ranges of ALPHA (%41–%5A
+     * and %61–%7A), DIGIT (%30–%39), hyphen (%2D), period (%2E), underscore
+     * (%5F), or tilde (%7E) should not be created by URI producers and, when
+     * found in a URI, should be decoded to their corresponding unreserved
+     * characters by URI normalizers.
      *
      * Example: http://example.org/%7Eusern%61me/ → http://example.org/~username/
      */
@@ -54,11 +58,12 @@ final class UriNormalizer
     /**
      * Removes the default host of the given URI scheme from the URI.
      *
-     * Only the "file" scheme defines the default host "localhost".
-     * All of `file:/myfile`, `file:///myfile`, and `file://localhost/myfile`
-     * are equivalent according to RFC 3986. The first format is not accepted
-     * by PHPs stream functions and thus already normalized implicitly to the
-     * second format in the Uri class. See `GuzzleHttp\Psr7\Uri::composeComponents`.
+     * Only the "file" scheme defines the default host "localhost". All of
+     * `file:/myfile`, `file:///myfile`, and `file://localhost/myfile` are
+     * equivalent according to RFC 3986. The first format is not accepted by
+     * PHPs stream functions and thus already normalized implicitly to the
+     * second format in the Uri class. See
+     * `GuzzleHttp\Psr7\Uri::composeComponents`.
      *
      * Example: file://localhost/myfile → file:///myfile
      */
@@ -84,9 +89,10 @@ final class UriNormalizer
     /**
      * Paths which include two or more adjacent slashes are converted to one.
      *
-     * Webservers usually ignore duplicate slashes and treat those URIs equivalent.
-     * But in theory those URIs do not need to be equivalent. So this normalization
-     * may change the semantics. Encoded slashes (%2F) are not removed.
+     * Webservers usually ignore duplicate slashes and treat those URIs
+     * equivalent. But in theory those URIs do not need to be equivalent. So
+     * this normalization may change the semantics. Encoded slashes (%2F) are
+     * not removed.
      *
      * Example: http://example.org//foo///bar.html → http://example.org/foo/bar.html
      */
@@ -95,26 +101,32 @@ final class UriNormalizer
     /**
      * Sort query parameters with their values in alphabetical order.
      *
-     * However, the order of parameters in a URI may be significant (this is not defined by the standard).
-     * So this normalization is not safe and may change the semantics of the URI.
+     * However, the order of parameters in a URI may be significant (this is not
+     * defined by the standard). So this normalization is not safe and may
+     * change the semantics of the URI.
      *
      * Example: ?lang=en&article=fred → ?article=fred&lang=en
      *
-     * Note: The sorting is neither locale nor Unicode aware (the URI query does not get decoded at all) as the
-     * purpose is to be able to compare URIs in a reproducible way, not to have the params sorted perfectly.
+     * Note: The sorting is neither locale nor Unicode aware (the URI query does
+     * not get decoded at all) as the purpose is to be able to compare URIs in a
+     * reproducible way, not to have the params sorted perfectly.
      */
     public const SORT_QUERY_PARAMETERS = 128;
 
     /**
      * Returns a normalized URI.
      *
-     * The scheme and host component are already normalized to lowercase per PSR-7 UriInterface.
-     * This methods adds additional normalizations that can be configured with the $flags parameter.
+     * The scheme and host component are already normalized to lowercase per
+     * PSR-7 UriInterface. This method adds additional normalizations that can
+     * be configured with the `$flags` parameter, which is a bitmask of
+     * normalizations to apply.
      *
-     * PSR-7 UriInterface cannot distinguish between an empty component and a missing component as
-     * getQuery(), getFragment() etc. always return a string. This means the URIs "/?#" and "/" are
-     * treated equivalent which is not necessarily true according to RFC 3986. But that difference
-     * is highly uncommon in reality. So this potential normalization is implied in PSR-7 as well.
+     * PSR-7 UriInterface cannot distinguish between an empty component and a
+     * missing component as `getQuery()`, `getFragment()` etc. always return a
+     * string. This means the URIs `/?#` and `/` are treated equivalent which is
+     * not necessarily true according to RFC 3986. But that difference is highly
+     * uncommon in reality. So this potential normalization is implied in PSR-7
+     * as well.
      *
      * @param UriInterface $uri   The URI to normalize
      * @param int          $flags A bitmask of normalizations to apply, see constants
@@ -177,10 +189,12 @@ final class UriNormalizer
     /**
      * Whether two URIs can be considered equivalent.
      *
-     * Both URIs are normalized automatically before comparison with the given $normalizations bitmask. The method also
-     * accepts relative URI references and returns true when they are equivalent. This of course assumes they will be
-     * resolved against the same base URI. If this is not the case, determination of equivalence or difference of
-     * relative references does not mean anything.
+     * Both URIs are normalized automatically before comparison with the given
+     * `$normalizations` bitmask. The method also accepts relative URI
+     * references and returns true when they are equivalent. This of course
+     * assumes they will be resolved against the same base URI. If this is not
+     * the case, determination of equivalence or difference of relative
+     * references does not mean anything.
      *
      * @param UriInterface $uri1           An URI to compare
      * @param UriInterface $uri2           An URI to compare

--- a/src/UriResolver.php
+++ b/src/UriResolver.php
@@ -16,13 +16,15 @@ use Psr\Http\Message\UriInterface;
 final class UriResolver
 {
     /**
-     * Removes dot segments from a path and returns the new path.
+     * Removes dot segments from a path and returns the new path according to
+     * RFC 3986 Section 5.2.4.
      *
-     * Excess ".." segments above the root of an absolute path are dropped without
-     * consuming the root, so the result can begin with "//" (e.g. "/..//a" becomes
-     * "//a"). Such a path is not valid for a URI without an authority (RFC 3986
-     * Section 3.3); resolve() and UriNormalizer::normalize() serialize it with a
-     * "/." prefix in that case, like the WHATWG URL Standard.
+     * Excess `..` segments above the root of an absolute path are dropped
+     * without consuming the root, so the result can begin with `//` (e.g.
+     * `/..//a` becomes `//a`). Such a path is not valid for a URI without an
+     * authority (RFC 3986 Section 3.3); `resolve()` and
+     * `UriNormalizer::normalize()` serialize it with a `/.` prefix in that
+     * case, like the WHATWG URL Standard.
      *
      * @see https://datatracker.ietf.org/doc/html/rfc3986#section-5.2.4
      */
@@ -63,15 +65,16 @@ final class UriResolver
     }
 
     /**
-     * Returns the path, prefixed with "/." when it would otherwise start the URI's
-     * string form with an authority-like "//".
+     * Returns the path, prefixed with "/." when it would otherwise start the
+     * URI's string form with an authority-like "//".
      *
-     * A URI without an authority cannot hold a path beginning with "//" (RFC 3986
-     * Section 3.3), but removeDotSegments() can produce one. The "/." prefix
-     * serializes such a path unambiguously, the same way the WHATWG URL Standard
-     * does, and resolves back to the same path. Hostless http and https Uri
-     * instances gain the default localhost host when the path is written, so the
-     * path cannot be mistaken for an authority and the prefix is not added.
+     * A URI without an authority cannot hold a path beginning with "//" (RFC
+     * 3986 Section 3.3), but removeDotSegments() can produce one. The "/."
+     * prefix serializes such a path unambiguously, the same way the WHATWG URL
+     * Standard does, and resolves back to the same path. Hostless http and
+     * https Uri instances gain the default localhost host when the path is
+     * written, so the path cannot be mistaken for an authority and the prefix
+     * is not added.
      *
      * @see https://url.spec.whatwg.org/#url-serializing
      *
@@ -91,7 +94,8 @@ final class UriResolver
     }
 
     /**
-     * Converts the relative URI into a new URI that is resolved against the base URI.
+     * Converts the relative URI into a new URI that is resolved against the
+     * base URI.
      *
      * @see https://datatracker.ietf.org/doc/html/rfc3986#section-5.2
      */
@@ -148,12 +152,13 @@ final class UriResolver
     /**
      * Returns the target URI as a relative reference from the base URI.
      *
-     * This method is the counterpart to resolve():
+     * This method is the counterpart to `resolve()`:
      *
      *    (string) $target === (string) UriResolver::resolve($base, UriResolver::relativize($base, $target))
      *
-     * One use-case is to use the current request URI as base URI and then generate relative links in your documents
-     * to reduce the document size or offer self-contained downloadable document archives.
+     * One use case is to use the current request URI as the base URI and then
+     * generate relative links in your documents to reduce the document size or
+     * offer self-contained downloadable document archives.
      *
      *    $base = new Uri('http://example.com/a/b/');
      *    echo UriResolver::relativize($base, new Uri('http://example.com/a/b/c'));  // prints 'c'.
@@ -162,8 +167,9 @@ final class UriResolver
      *    echo UriResolver::relativize($base, new Uri('http://example.org/a/b/'));   // prints '//example.org/a/b/'.
      *    echo UriResolver::relativize($base, new Uri('http://example.com'));         // prints '//example.com'.
      *
-     * This method also accepts a target that is already relative and will try to relativize it further. Only a
-     * relative-path reference will be returned as-is.
+     * This method also accepts a target that is already relative and will try
+     * to relativize it further. Only a relative-path reference will be returned
+     * as-is.
      *
      *    echo UriResolver::relativize($base, new Uri('/a/b/c'));  // prints 'c' as well
      */

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -16,7 +16,7 @@ final class Utils
     }
 
     /**
-     * Remove the items given by the keys, case insensitively from the data.
+     * Remove the items given by the keys from the data, case-insensitively.
      *
      * @param array<array-key, string|int> $keys
      */
@@ -39,11 +39,18 @@ final class Utils
 
     /**
      * Copy the contents of a stream into another stream until the given number
-     * of bytes have been read, returning the number of bytes copied.
+     * of bytes have been read, returning the number of bytes copied as an
+     * `int`. On 32-bit PHP, an unbounded copy larger than `PHP_INT_MAX` bytes
+     * cannot be represented by that return type. 64-bit PHP is not affected.
      *
      * The destination must accept writes that make positive progress. Streams
-     * that return 0 as a backpressure or drop signal (a BufferStream at its high
-     * water mark, or a full DroppingStream) will cause this method to throw.
+     * that return 0 as a backpressure or drop signal (a `BufferStream` at its
+     * high water mark, or a full `DroppingStream`) will cause this method to
+     * throw. For full copies, use a normal writable stream such as a file or
+     * `php://temp` stream.
+     *
+     * Throws `TimeoutException` when PHP-style timeout metadata can be detected
+     * after a source read or destination write cannot make progress.
      *
      * @param StreamInterface $source Stream to read from
      * @param StreamInterface $dest   Stream to write to
@@ -114,6 +121,9 @@ final class Utils
      * Copy the contents of a stream into a string until the given number of
      * bytes have been read.
      *
+     * Throws `TimeoutException` when PHP-style timeout metadata can be detected
+     * after a stream read cannot make progress.
+     *
      * @param StreamInterface $stream Stream to read
      * @param int             $maxLen Maximum number of bytes to read. Pass -1
      *                                to read the entire stream.
@@ -152,8 +162,11 @@ final class Utils
     /**
      * Calculate a hash of a stream.
      *
-     * This method reads the entire stream to calculate a rolling hash, based
-     * on PHP's `hash_init` functions.
+     * This method reads the entire stream to calculate a rolling hash, based on
+     * PHP's `hash_init` functions.
+     *
+     * Throws `TimeoutException` when PHP-style timeout metadata can be detected
+     * after a stream read cannot make progress.
      *
      * @param StreamInterface $stream    Stream to calculate the hash for
      * @param string          $algo      Hash algorithm (e.g. md5, crc32, etc)
@@ -197,10 +210,10 @@ final class Utils
      *   or non-empty arrays of strings.
      * - remove_headers: (array) Remove the given headers. Values may be
      *   strings or integers.
-     * - body: (mixed) Sets the given body. Present non-null values are converted
-     *   with self::streamFor(), including resources, streams, iterators, callable
-     *   arrays, closures, invokable objects, and stringable objects. String inputs
-     *   remain literal bodies.
+     * - body: (mixed) Sets the given body. Present non-null values are
+     *   converted with self::streamFor(), including resources, streams,
+     *   iterators, callable arrays, closures, invokable objects, and stringable
+     *   objects. String inputs remain literal bodies.
      * - uri: (UriInterface) Set the URI. When the URI contains a host, the
      *   Host header is updated from it, and combining this with an explicit
      *   Host entry in set_headers throws an InvalidArgumentException. Apply
@@ -424,6 +437,9 @@ final class Utils
     /**
      * Read a line from the stream up to the maximum allowed buffer length.
      *
+     * Throws `TimeoutException` when PHP-style timeout metadata can be detected
+     * after a stream read cannot make progress.
+     *
      * @param StreamInterface $stream    Stream to read from
      * @param int|null        $maxLength Maximum buffer length
      */
@@ -457,37 +473,41 @@ final class Utils
     /**
      * Create a new stream based on the input type.
      *
-     * Options is an associative array that can contain the following keys:
+     * Options are provided as an associative array that can contain the
+     * following keys:
      * - metadata: Array of custom metadata.
      * - size: Size of the stream.
      *
      * This method accepts the following `$resource` types:
      * - `Psr\Http\Message\StreamInterface`: Returns the value as-is.
-     * - `string`: Creates a stream object that uses the given string as the contents.
-     * - `resource`: Creates a stream object that wraps the given PHP stream resource.
-     * - `Iterator`: If the provided value implements `Iterator`, then a read-only
-     *   stream object will be created that wraps the given iterable. Each time the
-     *   stream is read from, data from the iterator will fill a buffer and will be
-     *   continuously called until the buffer is equal to the requested read size.
-     *   Yielded strings, integers, finite floats, booleans, `null`, and stringable
-     *   objects are converted to string chunks; non-finite floats and other values
-     *   throw `UnexpectedValueException` when the stream is read. Values that
+     * - `string`: Creates a stream object that uses the given string as the
+     *   contents.
+     * - `resource`: Creates a stream object that wraps the given PHP stream
+     *   resource.
+     * - `Iterator`: If the provided value implements `Iterator`, then a
+     *   read-only stream object will be created that wraps the given iterable.
+     *   Each time the stream is read from, data from the iterator will fill a
+     *   buffer and will be continuously called until the buffer is equal to the
+     *   requested read size. Yielded strings, integers, finite floats,
+     *   booleans, `null`, and stringable objects are converted to string
+     *   chunks; non-finite floats and other values throw
+     *   `UnexpectedValueException` when the stream is read. Values that
      *   stringify to an empty string are skipped while the iterator advances.
-     *   Subsequent read calls will first read from the buffer and then call `next`
-     *   on the underlying iterator until it is exhausted.
-     * - `object` with `__toString()`: If the object has the `__toString()` method,
-     *   the object will be cast to a string and then a stream will be returned that
-     *   uses the string value.
+     *   Subsequent read calls will first read from the buffer and then call
+     *   `next` on the underlying iterator until it is exhausted.
+     * - `object` with `__toString()`: If the object has the `__toString()`
+     *   method, the object will be cast to a string and then a stream will be
+     *   returned that uses the string value.
      * - `NULL`: When `null` is passed, an empty stream object is returned.
-     * - `callable`: When a callable array, closure, or invokable object is passed
-     *   and no earlier resource or object rule applies, a read-only stream object
-     *   will be created that invokes the given callable. The callable is invoked
-     *   with the suggested number of bytes to read. The callable can return fewer
-     *   or more bytes than requested, but MUST return a non-empty string when data
-     *   is available and `false` or `null` when there is no more data to return.
-     *   Any additional bytes will be buffered and used in subsequent reads. String
-     *   inputs are always treated as string bodies, even when they name callable
-     *   functions.
+     * - `callable`: When a callable array, closure, or invokable object is
+     *   passed and no earlier resource or object rule applies, a read-only
+     *   stream object will be created that invokes the given callable. The
+     *   callable is invoked with the suggested number of bytes to read. The
+     *   callable can return fewer or more bytes than requested, but MUST return
+     *   a non-empty string to provide data and MUST return `false` or `null`
+     *   when there is no more data to return. Any additional bytes will be
+     *   buffered and used in subsequent reads. String inputs are always treated
+     *   as string bodies, even when they name callable functions.
      *
      * @param resource|string|StreamInterface|callable|\Iterator|\Stringable|null $resource Entity body data
      * @param array{size?: int, metadata?: array}                                 $options  Additional options
@@ -576,8 +596,8 @@ final class Utils
     /**
      * Safely opens a PHP stream resource using a filename.
      *
-     * When fopen fails, PHP normally raises a warning. This function adds an
-     * error handler that checks for errors and throws an exception instead.
+     * When `fopen()` fails, PHP normally raises a warning. This function adds
+     * an error handler that checks for errors and throws an exception instead.
      *
      * @param string $filename File to open
      * @param string $mode     Mode used to open the file
@@ -625,9 +645,12 @@ final class Utils
     /**
      * Safely gets the contents of a given stream.
      *
-     * When stream_get_contents fails, PHP normally raises a warning. This
+     * When `stream_get_contents()` fails, PHP normally raises a warning. This
      * function adds an error handler that checks for errors and throws an
      * exception instead.
+     *
+     * Throws `TimeoutException` when PHP-style timeout metadata can be detected
+     * after a stream read cannot make progress.
      *
      * @param resource $stream
      *
@@ -678,11 +701,11 @@ final class Utils
     }
 
     /**
-     * Returns a UriInterface for the given value.
+     * Returns a `UriInterface` for the given value.
      *
-     * This function accepts a string or UriInterface and returns a
-     * UriInterface for the given value. If the value is already a
-     * UriInterface, it is returned as-is.
+     * This function accepts a string or `UriInterface` and returns a
+     * `UriInterface` for the given value. If the value is already a
+     * `UriInterface`, it is returned as-is.
      *
      * @param string|UriInterface $uri
      *


### PR DESCRIPTION
The `docs/*.md` helper reference pages and the PHPDoc on the static helper methods they describe had drifted apart and used different line widths. This aligns the two: for every static method documented in `uri-helpers.md`, `message-helpers.md`, `header-and-query-helpers.md`, `stream-helpers.md`, and `uri-and-mime-helpers.md`, the description prose is now consistent between the docs and the PHPDoc, and both are wrapped greedily at 80 columns (the whole comment line, including the ` * ` indent). Where the docs carry an inline markdown link, the PHPDoc keeps the plain text plus an `@see` tag instead. This is documentation and comments only; no signatures, types, or behavior change.

Reconciling the two surfaces surfaced several accuracy fixes that are applied on both sides after checking the code. `Header::parse` previously claimed valueless parameters receive an empty-string value; they are in fact appended as values under integer keys, so both descriptions now say that. Doc signatures for `Message::parseRequest`/`parseResponse` are corrected to their real `RequestInterface`/`ResponseInterface` return types, and `parseRequest`/`parseRequestUri` gain accurate descriptions of the current hardened request-target and Host handling. Assorted PHPDoc typos ("an network-path", "a absolute-path", "This methods adds") are fixed by adopting the docs wording.

The redundant `@throws TimeoutException` tags added to the `Utils` stream helpers are dropped, since `TimeoutException` extends `\RuntimeException` which is already documented; the timeout behavior is described inline in the prose instead. Code fences, tables, backtick signature lines, and long type-annotation tag lines (`@param` unions, array shapes) are left as-is, along with the illustrative `Example:` transformations and in-docblock code samples that cannot be wrapped without breaking them.
