### PR TITLE
Wrap README prose to 80 columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 # Guzzle PSR-7
 
-`guzzlehttp/psr7` is a PSR-7 HTTP message implementation for PHP. It provides request, response, URI, uploaded file, and stream objects that work with Guzzle and any other library using the PSR-7 interfaces.
+`guzzlehttp/psr7` is a PSR-7 HTTP message implementation for PHP. It provides
+request, response, URI, uploaded file, and stream objects that work with Guzzle
+and any other library using the PSR-7 interfaces.
 
-Use this package directly when you need to create or inspect PSR-7 messages without sending HTTP requests. If you only want to make HTTP requests, install [`guzzlehttp/guzzle`](https://github.com/guzzle/guzzle/blob/8.0/README.md) instead; it already depends on this package.
+Use this package directly when you need to create or inspect PSR-7 messages
+without sending HTTP requests. If you only want to make HTTP requests, install
+[`guzzlehttp/guzzle`](https://github.com/guzzle/guzzle/blob/8.0/README.md)
+instead; it already depends on this package.
 
 ## Installation
 
@@ -34,7 +39,10 @@ echo $response->getStatusCode();
 echo $stream;
 ```
 
-PSR-7 messages and URIs are immutable. Methods such as `withHeader()` and `withUri()` return a changed copy instead of modifying the original object. Streams are mutable body handles; reading, writing, seeking, and closing a stream can change its cursor, contents, or usability.
+PSR-7 messages and URIs are immutable. Methods such as `withHeader()` and
+`withUri()` return a changed copy instead of modifying the original object.
+Streams are mutable body handles; reading, writing, seeking, and closing a
+stream can change its cursor, contents, or usability.
 
 ```php
 $request = $request->withHeader('Accept', 'application/json');
@@ -55,14 +63,25 @@ $request = $request->withHeader('Accept', 'application/json');
 
 ## Security
 
-If you discover a security vulnerability within this package, please send an email to security@tidelift.com. All security vulnerabilities will be promptly addressed. Please do not disclose security-related issues publicly until a fix has been announced. Please see [Security Policy](https://github.com/guzzle/psr7/security/policy) for more information.
+If you discover a security vulnerability within this package, please send an
+email to security@tidelift.com. All security vulnerabilities will be promptly
+addressed. Please do not disclose security-related issues publicly until a fix
+has been announced. Please see
+[Security Policy](https://github.com/guzzle/psr7/security/policy) for more
+information.
 
 ## License
 
-Guzzle is made available under the MIT License (MIT). Please see [License File](LICENSE) for more information.
+Guzzle is made available under the MIT License (MIT). Please see
+[License File](LICENSE) for more information.
 
 ## For Enterprise
 
 Available as part of the Tidelift Subscription
 
-The maintainers of Guzzle and thousands of other packages are working with Tidelift to deliver commercial support and maintenance for the open source dependencies you use to build your applications. Save time, reduce risk, and improve code health, while paying the maintainers of the exact dependencies you use. [Learn more.](https://tidelift.com/subscription/pkg/packagist-guzzlehttp-psr7?utm_source=packagist-guzzlehttp-psr7&utm_medium=referral&utm_campaign=enterprise&utm_term=repo)
+The maintainers of Guzzle and thousands of other packages are working with
+Tidelift to deliver commercial support and maintenance for the open source
+dependencies you use to build your applications. Save time, reduce risk, and
+improve code health, while paying the maintainers of the exact dependencies you
+use.
+[Learn more.](https://tidelift.com/subscription/pkg/packagist-guzzlehttp-psr7?utm_source=packagist-guzzlehttp-psr7&utm_medium=referral&utm_campaign=enterprise&utm_term=repo)


### PR DESCRIPTION
Reflows the README prose to a greedy 80-column width so the Markdown reads consistently and diffs stay small. Only line breaks change; no wording changes, and badges, code blocks, tables, and links are left untouched. There are no code changes.