### PR TITLE
Validate the Host synthesized by Message::toString()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reject zero-port, hostless, and userinfo absolute-form request targets in `Message::parseRequest()`
 - Synchronize the `Host` header in `Request::withUri()` when the URI changes or Host is empty
 - Include the URI port in `Host` headers synthesized by `Message::toString()`
+- Validate the Host header synthesized by `Message::toString()` from the request URI
 - Include non-default URI ports in `Host` headers set by `Utils::modifyRequest()` URI changes
 - Accept `OPTIONS *` and `CONNECT` authority-form request targets in `Message::parseRequest()`
 - Reject malformed HTTP request/response start-lines

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -333,6 +333,12 @@ after calling `withUri()` or preserve a non-empty Host header explicitly.
 serializing a request without a `Host` header. Generated `Host` lines include
 non-null URI ports.
 
+`Message::toString()` also validates the host it synthesizes from the request
+URI and throws `InvalidArgumentException` for an invalid host, closing a header-
+injection vector. This affects only a custom `UriInterface` implementation that
+returns an invalid host when the request has no stored `Host` header; first-
+party `Uri` instances always carry a valid host and are unaffected.
+
 #### URI Paths and Request Targets
 
 `Uri::getPath()` now normalizes multiple leading slashes to one slash when

--- a/src/Message.php
+++ b/src/Message.php
@@ -73,6 +73,8 @@ final class Message
             return '';
         }
 
+        Uri::assertValidHost($host);
+
         if (($port = $uri->getPort()) !== null) {
             $host .= ':'.$port;
         }

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -62,6 +62,42 @@ class MessageTest extends TestCase
         );
     }
 
+    public function testToStringRejectsCrlfHostSynthesizedFromUri(): void
+    {
+        $uri = new class('http://safe.example/') extends Psr7\Uri {
+            public function getHost(): string
+            {
+                return "a\r\nX-Injected: yes";
+            }
+        };
+        $request = (new Psr7\Request('GET', 'http://safe.example/', ['Host' => 'safe.example']))
+            ->withUri($uri, true)
+            ->withoutHeader('Host');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid host');
+
+        Psr7\Message::toString($request);
+    }
+
+    public function testToStringRejectsDelimiterHostSynthesizedFromUri(): void
+    {
+        $uri = new class('http://safe.example/') extends Psr7\Uri {
+            public function getHost(): string
+            {
+                return 'ex%2Fample.com';
+            }
+        };
+        $request = (new Psr7\Request('GET', 'http://safe.example/', ['Host' => 'safe.example']))
+            ->withUri($uri, true)
+            ->withoutHeader('Host');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid host');
+
+        Psr7\Message::toString($request);
+    }
+
     public function testConvertsResponsesToStrings(): void
     {
         $response = new Psr7\Response(200, [


### PR DESCRIPTION
`Message::toString()` synthesizes a `Host` line from the request URI when the request carries no stored `Host` header, but `hostHeaderFromUri()` read `getHost()` off the `UriInterface` and concatenated it into the raw message with no validation. A first-party `Uri` validates its host on construction and so is unaffected, but `toString()` accepts any `UriInterface`, and a custom implementation returning a host containing CR/LF injected an extra header line into guzzle's own output. This validates the synthesized host via the existing `Uri::assertValidHost()`, throwing `InvalidArgumentException` for an invalid host, matching the validation already applied to the analogous URI-derived host paths in `Request` and `Utils::modifyRequest()`. It stays within the serializer-only boundary from #643 by validating only the one `Host` line guzzle itself composes, not arbitrary caller-supplied header values a custom `MessageInterface` returns. The change is limited to a private method with a single caller on the no-stored-Host branch, so no first-party usage changes; the only affected inputs are custom `UriInterface` implementations with an invalid host, which were already emitting invalid or injected output.
