### PR TITLE
Add `Utils::redactUserInfoInString()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `GuzzleHttp\Psr7\Exception\TimeoutException` for timed-out stream operations
+- Add `GuzzleHttp\Psr7\Utils::redactUserInfoInString()` to redact the userinfo of a raw URI string within text
 - Promote `GuzzleHttp\Psr7\Rfc3986` to public API with `isValidScheme()`, `isValidHost()`, and `isValidPort()`
 
 ### Changed

--- a/docs/uri-and-mime-helpers.md
+++ b/docs/uri-and-mime-helpers.md
@@ -11,6 +11,24 @@ For URI resolution, normalization, and comparison helpers, see
 
 Redact the user info part of a URI.
 
+Returns the URI with the whole userinfo component replaced by `***` when one
+is present, so neither the username nor the password survives into logs and
+diagnostics. A URI without userinfo is returned unchanged.
+
+## `GuzzleHttp\Psr7\Utils::redactUserInfoInString`
+
+`public static function redactUserInfoInString(string $subject, string $uri): string`
+
+Redacts the userinfo of a raw URI string wherever it appears in a subject
+string.
+
+The needle is taken verbatim from the raw URI rather than from parsed
+components, so credentials that URI normalization would rewrite, such as raw
+control bytes or unencoded reserved characters, are still found in text that
+embeds the URI exactly as given, for example transport error messages. A URI
+without `://` is treated as authority-form: a host and port with optional
+userinfo.
+
 ## `GuzzleHttp\Psr7\Utils::uriFor`
 
 `public static function uriFor(string|UriInterface $uri): UriInterface`

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -471,6 +471,51 @@ final class Utils
     }
 
     /**
+     * Redacts the userinfo of a raw URI string wherever it appears in a
+     * subject string.
+     *
+     * The needle is taken verbatim from the raw URI rather than from parsed
+     * components, so credentials that URI normalization would rewrite, such
+     * as raw control bytes or unencoded reserved characters, are still found
+     * in text that embeds the URI exactly as given, for example transport
+     * error messages. A URI without "://" is treated as authority-form: a
+     * host and port with optional userinfo.
+     *
+     * @param string $subject Text that may embed the URI
+     * @param string $uri     Raw URI whose userinfo is redacted in the text
+     */
+    public static function redactUserInfoInString(string $subject, string $uri): string
+    {
+        if (\strpos($uri, '@') === false) {
+            return $subject;
+        }
+
+        $schemePosition = \strpos($uri, '://');
+        $remainder = $schemePosition === false ? $uri : \substr($uri, $schemePosition + 3);
+        $authority = \substr($remainder, 0, \strcspn($remainder, '/?#'));
+        $atPosition = \strrpos($authority, '@');
+
+        if ($atPosition === false || $atPosition === 0) {
+            // The last '@' sits past a raw '/', '?', or '#': not userinfo in
+            // a parseable URI, but a URI that defeats parse_url() may carry
+            // the separator inside its credentials, so everything up to the
+            // last '@' is redacted as a safe-side fallback.
+            if (\parse_url($schemePosition === false ? 'http://'.$uri : $uri) !== false) {
+                return $subject;
+            }
+
+            $atPosition = \strrpos($remainder, '@');
+            if ($atPosition === false || $atPosition === 0) {
+                return $subject;
+            }
+
+            return \str_replace(\substr($remainder, 0, $atPosition).'@', '***@', $subject);
+        }
+
+        return \str_replace(\substr($authority, 0, $atPosition).'@', '***@', $subject);
+    }
+
+    /**
      * Create a new stream based on the input type.
      *
      * Options are provided as an associative array that can contain the

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -464,6 +464,11 @@ final class Utils
 
     /**
      * Redact the user info part of a URI.
+     *
+     * Returns the URI with the whole userinfo component replaced by "***"
+     * when one is present, so neither the username nor the password survives
+     * into logs and diagnostics. A URI without userinfo is returned
+     * unchanged.
      */
     public static function redactUserInfo(UriInterface $uri): UriInterface
     {

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -517,87 +517,121 @@ class UtilsTest extends TestCase
         self::assertSame('', Psr7\Utils::readLine($s));
     }
 
-    public function testRedactUserInfo(): void
+    /**
+     * @dataProvider redactUserInfoProvider
+     */
+    public function testRedactUserInfo(string $expected, string $uri): void
     {
-        self::assertSame(
-            'http://***@localhost/',
-            (string) Psr7\Utils::redactUserInfo(new Psr7\Uri('http://my_user:secretPass@localhost/'))
-        );
-
-        self::assertSame(
-            'http://***@localhost/',
-            (string) Psr7\Utils::redactUserInfo(new Psr7\Uri('http://ghp_TOKEN@localhost/'))
-        );
-
-        self::assertSame(
-            'http://localhost/',
-            (string) Psr7\Utils::redactUserInfo(new Psr7\Uri('http://localhost/'))
-        );
+        self::assertSame($expected, (string) Psr7\Utils::redactUserInfo(new Psr7\Uri($uri)));
     }
 
-    public function testRedactUserInfoInString(): void
+    public static function redactUserInfoProvider(): iterable
     {
-        self::assertSame(
+        yield 'username and password' => ['http://***@localhost/', 'http://my_user:secretPass@localhost/'];
+        yield 'username only' => ['http://***@localhost/', 'http://ghp_TOKEN@localhost/'];
+        yield 'empty password' => ['http://***@localhost/', 'http://user:@localhost/'];
+        yield 'percent-encoded userinfo' => ['http://***@localhost/', 'http://us%40er:p%23ss@localhost/'];
+        yield 'rest of the uri preserved' => ['https://***@example.com:8443/path?q=1#frag', 'https://user:pass@example.com:8443/path?q=1#frag'];
+        yield 'ipv6 host' => ['http://***@[::1]:8080/', 'http://user:pass@[::1]:8080/'];
+        yield 'already redacted' => ['http://***@localhost/', 'http://***@localhost/'];
+        yield 'no userinfo' => ['http://localhost/', 'http://localhost/'];
+    }
+
+    public function testRedactUserInfoReturnsSameInstanceWithoutUserInfo(): void
+    {
+        $uri = new Psr7\Uri('http://localhost/');
+
+        self::assertSame($uri, Psr7\Utils::redactUserInfo($uri));
+    }
+
+    /**
+     * @dataProvider redactUserInfoInStringProvider
+     */
+    public function testRedactUserInfoInString(string $expected, string $subject, string $uri): void
+    {
+        self::assertSame($expected, Psr7\Utils::redactUserInfoInString($subject, $uri));
+    }
+
+    public static function redactUserInfoInStringProvider(): iterable
+    {
+        yield 'full uri embedded' => [
             "Failed to connect to 'http://***@localhost:8125'",
-            Psr7\Utils::redactUserInfoInString(
-                "Failed to connect to 'http://my_user:secretPass@localhost:8125'",
-                'http://my_user:secretPass@localhost:8125'
-            )
-        );
-
-        self::assertSame(
+            "Failed to connect to 'http://my_user:secretPass@localhost:8125'",
+            'http://my_user:secretPass@localhost:8125',
+        ];
+        yield 'embedded without scheme' => [
             'Could not resolve ***@localhost',
-            Psr7\Utils::redactUserInfoInString('Could not resolve ghp_TOKEN@localhost', 'http://ghp_TOKEN@localhost/')
-        );
-
-        self::assertSame(
+            'Could not resolve ghp_TOKEN@localhost',
+            'http://ghp_TOKEN@localhost/',
+        ];
+        yield 'multiple occurrences' => [
             'via http://***@localhost and http://***@localhost',
-            Psr7\Utils::redactUserInfoInString('via http://user:pass@localhost and http://user:pass@localhost', 'http://user:pass@localhost')
-        );
-    }
-
-    public function testRedactUserInfoInStringWithAuthorityFormUri(): void
-    {
-        self::assertSame(
+            'via http://user:pass@localhost and http://user:pass@localhost',
+            'http://user:pass@localhost',
+        ];
+        yield 'authority-form uri' => [
             "Unsupported proxy syntax in '***@localhost:8125'",
-            Psr7\Utils::redactUserInfoInString("Unsupported proxy syntax in 'user:pass@localhost:8125'", 'user:pass@localhost:8125')
-        );
-    }
-
-    public function testRedactUserInfoInStringWithRawControlBytes(): void
-    {
-        $uri = "http://user:se\x01cr\x7Fet@localhost:8125";
-
-        self::assertSame(
+            "Unsupported proxy syntax in 'user:pass@localhost:8125'",
+            'user:pass@localhost:8125',
+        ];
+        yield 'non-http scheme' => [
+            'via socks5h://***@localhost:1080',
+            'via socks5h://user:pass@localhost:1080',
+            'socks5h://user:pass@localhost:1080',
+        ];
+        yield 'ipv6 host' => [
+            'via http://***@[::1]:8080',
+            'via http://user:pass@[::1]:8080',
+            'http://user:pass@[::1]:8080',
+        ];
+        yield 'raw control bytes in credentials' => [
             'Failed to connect to http://***@localhost:8125',
-            Psr7\Utils::redactUserInfoInString('Failed to connect to '.$uri, $uri)
-        );
-    }
-
-    public function testRedactUserInfoInStringWithRawSeparatorsInCredentials(): void
-    {
-        foreach (['/', '?', '#'] as $separator) {
-            $uri = 'http://user:se'.$separator.'cret@localhost:8125';
-
-            self::assertSame(
-                "Unsupported proxy syntax in 'http://***@localhost:8125'",
-                Psr7\Utils::redactUserInfoInString("Unsupported proxy syntax in '".$uri."'", $uri)
-            );
-        }
-    }
-
-    public function testRedactUserInfoInStringLeavesUriWithAtInPathUntouched(): void
-    {
-        $error = "Failed to connect to 'http://localhost:8125/health@check'";
-
-        self::assertSame($error, Psr7\Utils::redactUserInfoInString($error, 'http://localhost:8125/health@check'));
-    }
-
-    public function testRedactUserInfoInStringLeavesUriWithoutUserInfoUntouched(): void
-    {
-        self::assertSame('error text', Psr7\Utils::redactUserInfoInString('error text', 'http://localhost:8125'));
-        self::assertSame('error text', Psr7\Utils::redactUserInfoInString('error text', ''));
-        self::assertSame('http://@localhost', Psr7\Utils::redactUserInfoInString('http://@localhost', 'http://@localhost'));
+            "Failed to connect to http://user:se\x01cr\x7Fet@localhost:8125",
+            "http://user:se\x01cr\x7Fet@localhost:8125",
+        ];
+        yield 'raw at sign in credentials' => [
+            'http://***@localhost',
+            'http://user:p@ss@localhost',
+            'http://user:p@ss@localhost',
+        ];
+        yield 'raw slash in credentials' => [
+            "Unsupported proxy syntax in 'http://***@localhost:8125'",
+            "Unsupported proxy syntax in 'http://user:se/cret@localhost:8125'",
+            'http://user:se/cret@localhost:8125',
+        ];
+        yield 'raw question mark in credentials' => [
+            "Unsupported proxy syntax in 'http://***@localhost:8125'",
+            "Unsupported proxy syntax in 'http://user:se?cret@localhost:8125'",
+            'http://user:se?cret@localhost:8125',
+        ];
+        yield 'raw hash in credentials' => [
+            "Unsupported proxy syntax in 'http://***@localhost:8125'",
+            "Unsupported proxy syntax in 'http://user:se#cret@localhost:8125'",
+            'http://user:se#cret@localhost:8125',
+        ];
+        yield 'at sign only in path' => [
+            "Failed to connect to 'http://localhost:8125/health@check'",
+            "Failed to connect to 'http://localhost:8125/health@check'",
+            'http://localhost:8125/health@check',
+        ];
+        yield 'at sign only in query' => [
+            'via http://localhost:8125?q=user@example.com',
+            'via http://localhost:8125?q=user@example.com',
+            'http://localhost:8125?q=user@example.com',
+        ];
+        yield 'at sign only before the scheme' => [
+            'via we@ird://host',
+            'via we@ird://host',
+            'we@ird://host',
+        ];
+        yield 'uri not embedded in subject' => [
+            'Connection refused',
+            'Connection refused',
+            'http://user:pass@localhost',
+        ];
+        yield 'no userinfo' => ['error text', 'error text', 'http://localhost:8125'];
+        yield 'empty uri' => ['error text', 'error text', ''];
+        yield 'empty userinfo' => ['http://@localhost', 'http://@localhost', 'http://@localhost'];
     }
 
     public function testCalculatesHash(): void

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -535,6 +535,71 @@ class UtilsTest extends TestCase
         );
     }
 
+    public function testRedactUserInfoInString(): void
+    {
+        self::assertSame(
+            "Failed to connect to 'http://***@localhost:8125'",
+            Psr7\Utils::redactUserInfoInString(
+                "Failed to connect to 'http://my_user:secretPass@localhost:8125'",
+                'http://my_user:secretPass@localhost:8125'
+            )
+        );
+
+        self::assertSame(
+            'Could not resolve ***@localhost',
+            Psr7\Utils::redactUserInfoInString('Could not resolve ghp_TOKEN@localhost', 'http://ghp_TOKEN@localhost/')
+        );
+
+        self::assertSame(
+            'via http://***@localhost and http://***@localhost',
+            Psr7\Utils::redactUserInfoInString('via http://user:pass@localhost and http://user:pass@localhost', 'http://user:pass@localhost')
+        );
+    }
+
+    public function testRedactUserInfoInStringWithAuthorityFormUri(): void
+    {
+        self::assertSame(
+            "Unsupported proxy syntax in '***@localhost:8125'",
+            Psr7\Utils::redactUserInfoInString("Unsupported proxy syntax in 'user:pass@localhost:8125'", 'user:pass@localhost:8125')
+        );
+    }
+
+    public function testRedactUserInfoInStringWithRawControlBytes(): void
+    {
+        $uri = "http://user:se\x01cr\x7Fet@localhost:8125";
+
+        self::assertSame(
+            'Failed to connect to http://***@localhost:8125',
+            Psr7\Utils::redactUserInfoInString('Failed to connect to '.$uri, $uri)
+        );
+    }
+
+    public function testRedactUserInfoInStringWithRawSeparatorsInCredentials(): void
+    {
+        foreach (['/', '?', '#'] as $separator) {
+            $uri = 'http://user:se'.$separator.'cret@localhost:8125';
+
+            self::assertSame(
+                "Unsupported proxy syntax in 'http://***@localhost:8125'",
+                Psr7\Utils::redactUserInfoInString("Unsupported proxy syntax in '".$uri."'", $uri)
+            );
+        }
+    }
+
+    public function testRedactUserInfoInStringLeavesUriWithAtInPathUntouched(): void
+    {
+        $error = "Failed to connect to 'http://localhost:8125/health@check'";
+
+        self::assertSame($error, Psr7\Utils::redactUserInfoInString($error, 'http://localhost:8125/health@check'));
+    }
+
+    public function testRedactUserInfoInStringLeavesUriWithoutUserInfoUntouched(): void
+    {
+        self::assertSame('error text', Psr7\Utils::redactUserInfoInString('error text', 'http://localhost:8125'));
+        self::assertSame('error text', Psr7\Utils::redactUserInfoInString('error text', ''));
+        self::assertSame('http://@localhost', Psr7\Utils::redactUserInfoInString('http://@localhost', 'http://@localhost'));
+    }
+
     public function testCalculatesHash(): void
     {
         $s = Psr7\Utils::streamFor('foobazbar');


### PR DESCRIPTION
Guzzle's cURL handler redacts proxy credentials embedded in libcurl error text, and the needle has to be taken verbatim from the raw configured string: `Uri` normalization rewrites raw control bytes and percent-encoding, so a needle derived from parsed components can miss the substring that actually appears in the error, leaving credentials intact. That extraction logic currently lives in Guzzle, duplicating URI authority handling, and just grew a fix for credentials containing a raw `/`, `?`, or `#` (guzzle/guzzle#3806). This moves the primitive to psr7 where the redaction policy already lives.

`Utils::redactUserInfoInString($subject, $uri)` takes the userinfo verbatim from the raw authority, up to the last `@` before the first `/`, `?`, or `#`, and replaces it with `***` wherever it appears in the subject, matching `redactUserInfo()`'s 3.0 policy. A parseable URI whose only `@` sits in the path is left untouched, while a URI that defeats `parse_url()` falls back to redacting everything up to the last `@` as a safe side, since those are exactly the strings libcurl embeds whole in errors such as `Unsupported proxy syntax in '...'`. Strings without `://` are treated as authority-form. Guzzle 8.0 will delegate its proxy redaction to this function.