### PR TITLE
Harden redactUserInfoInString against multiple @ separators

### DIFF
--- a/docs/uri-and-mime-helpers.md
+++ b/docs/uri-and-mime-helpers.md
@@ -29,6 +29,9 @@ embeds the URI exactly as given, for example transport error messages. A URI
 without `://` is treated as authority-form: a host and port with optional
 userinfo.
 
+A URI that does not parse has no trustworthy authority boundary, so everything
+between any scheme and its last `@` is redacted as a safe-side fallback.
+
 ## `GuzzleHttp\Psr7\Utils::uriFor`
 
 `public static function uriFor(string|UriInterface $uri): UriInterface`

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -486,6 +486,10 @@ final class Utils
      * error messages. A URI without "://" is treated as authority-form: a
      * host and port with optional userinfo.
      *
+     * A URI that does not parse has no trustworthy authority boundary, so
+     * everything between any scheme and its last "@" is redacted as a safe-side
+     * fallback.
+     *
      * @param string $subject Text that may embed the URI
      * @param string $uri     Raw URI whose userinfo is redacted in the text
      */
@@ -497,24 +501,27 @@ final class Utils
 
         $schemePosition = \strpos($uri, '://');
         $remainder = $schemePosition === false ? $uri : \substr($uri, $schemePosition + 3);
-        $authority = \substr($remainder, 0, \strcspn($remainder, '/?#'));
-        $atPosition = \strrpos($authority, '@');
 
-        if ($atPosition === false || $atPosition === 0) {
-            // The last '@' sits past a raw '/', '?', or '#': not userinfo in
-            // a parseable URI, but a URI that defeats parse_url() may carry
-            // the separator inside its credentials, so everything up to the
-            // last '@' is redacted as a safe-side fallback.
-            if (\parse_url($schemePosition === false ? 'http://'.$uri : $uri) !== false) {
-                return $subject;
-            }
-
+        if (\parse_url($schemePosition === false ? 'http://'.$uri : $uri) === false) {
+            // Raw '/', '?', or '#' separators may sit inside the credentials
+            // of a URI that defeats parse_url(), so the redaction cannot stop
+            // at the apparent authority.
             $atPosition = \strrpos($remainder, '@');
+
             if ($atPosition === false || $atPosition === 0) {
                 return $subject;
             }
 
             return \str_replace(\substr($remainder, 0, $atPosition).'@', '***@', $subject);
+        }
+
+        $authority = \substr($remainder, 0, \strcspn($remainder, '/?#'));
+        $atPosition = \strrpos($authority, '@');
+
+        if ($atPosition === false || $atPosition === 0) {
+            // A parseable URI with '@' only past its authority, or with an
+            // empty userinfo, carries no credentials to redact.
+            return $subject;
         }
 
         return \str_replace(\substr($authority, 0, $atPosition).'@', '***@', $subject);

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -609,6 +609,26 @@ class UtilsTest extends TestCase
             "Unsupported proxy syntax in 'http://user:se#cret@localhost:8125'",
             'http://user:se#cret@localhost:8125',
         ];
+        yield 'multiple raw at signs across a raw slash' => [
+            "Unsupported proxy syntax in 'http://***@real.example'",
+            "Unsupported proxy syntax in 'http://user:old@localhost:99999999/se:cret@real.example'",
+            'http://user:old@localhost:99999999/se:cret@real.example',
+        ];
+        yield 'multiple raw at signs across a raw question mark' => [
+            "Unsupported proxy syntax in 'http://***@real.example'",
+            "Unsupported proxy syntax in 'http://user:old@localhost:99999999?se:cret@real.example'",
+            'http://user:old@localhost:99999999?se:cret@real.example',
+        ];
+        yield 'multiple raw at signs across a raw hash' => [
+            "Unsupported proxy syntax in 'http://***@real.example'",
+            "Unsupported proxy syntax in 'http://user:old@localhost:99999999#se:cret@real.example'",
+            'http://user:old@localhost:99999999#se:cret@real.example',
+        ];
+        yield 'multiple raw at signs in authority-form' => [
+            "Unsupported proxy syntax in '***@real.example'",
+            "Unsupported proxy syntax in 'user:old@localhost:99999999/se:cret@real.example'",
+            'user:old@localhost:99999999/se:cret@real.example',
+        ];
         yield 'at sign only in path' => [
             "Failed to connect to 'http://localhost:8125/health@check'",
             "Failed to connect to 'http://localhost:8125/health@check'",
@@ -618,6 +638,11 @@ class UtilsTest extends TestCase
             'via http://localhost:8125?q=user@example.com',
             'via http://localhost:8125?q=user@example.com',
             'http://localhost:8125?q=user@example.com',
+        ];
+        yield 'at sign only in fragment' => [
+            'via http://localhost:8125#frag@ment',
+            'via http://localhost:8125#frag@ment',
+            'http://localhost:8125#frag@ment',
         ];
         yield 'at sign only before the scheme' => [
             'via we@ird://host',


### PR DESCRIPTION
`Utils::redactUserInfoInString()` trusts the apparent authority split before establishing that the URI parses: it clamps the authority at the first raw `/`, `?`, or `#` and replaces up to the last `@` inside it. For an unparseable URI carrying one `@` inside that apparent authority and another `@` after a raw separator, credential-like text between the separator and the final `@` survived in the subject text. The function now checks `parse_url()` first: an unparseable URI has no trustworthy authority boundary, so everything up to the last `@` of the remainder after any scheme is redacted as a safe-side fallback. Parseable URIs behave as before, including `@` characters that only appear in a valid path, query, or fragment. The PHPDoc and the docs page now state the fallback.