### PR TITLE
Use locale-independent ASCII folding for header and host names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.12.5 - Upcoming
+
+### Changed
+
+- Compare header names and hosts with locale-independent ASCII lowercasing
+
 ## 2.12.4 - 2026-07-08
 
 ### Changed

--- a/src/Message.php
+++ b/src/Message.php
@@ -33,7 +33,7 @@ final class Message
         }
 
         foreach ($message->getHeaders() as $name => $values) {
-            if (is_string($name) && strtolower($name) === 'set-cookie') {
+            if (is_string($name) && strtr($name, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz') === 'set-cookie') {
                 foreach ($values as $value) {
                     $msg .= "\r\n{$name}: ".$value;
                 }
@@ -294,7 +294,7 @@ final class Message
             // Numeric array keys are converted to int by PHP.
             $k = (string) $k;
 
-            return strtolower($k) === 'host';
+            return strtr($k, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz') === 'host';
         });
 
         if (!$hostKey) {

--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -62,12 +62,12 @@ trait MessageTrait
 
     public function hasHeader($header): bool
     {
-        return isset($this->headerNames[strtolower($header)]);
+        return isset($this->headerNames[strtr($header, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz')]);
     }
 
     public function getHeader($header): array
     {
-        $header = strtolower($header);
+        $header = strtr($header, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz');
 
         if (!isset($this->headerNames[$header])) {
             return [];
@@ -103,7 +103,7 @@ trait MessageTrait
             }
         }
         $value = $this->normalizeHeaderValue($value);
-        $normalized = strtolower($header);
+        $normalized = strtr($header, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz');
 
         $new = clone $this;
         if (isset($new->headerNames[$normalized])) {
@@ -135,7 +135,7 @@ trait MessageTrait
             }
         }
         $value = $this->normalizeHeaderValue($value);
-        $normalized = strtolower($header);
+        $normalized = strtr($header, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz');
 
         $new = clone $this;
         if (isset($new->headerNames[$normalized])) {
@@ -154,7 +154,7 @@ trait MessageTrait
      */
     public function withoutHeader($header): MessageInterface
     {
-        $normalized = strtolower($header);
+        $normalized = strtr($header, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz');
 
         if (!isset($this->headerNames[$normalized])) {
             return $this;
@@ -218,7 +218,7 @@ trait MessageTrait
                 }
             }
             $value = $this->normalizeHeaderValue($value);
-            $normalized = strtolower($header);
+            $normalized = strtr($header, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz');
             if (isset($this->headerNames[$normalized])) {
                 $header = $this->headerNames[$normalized];
                 $this->headers[$header] = array_merge($this->headers[$header], $value);

--- a/src/MultipartStream.php
+++ b/src/MultipartStream.php
@@ -227,9 +227,9 @@ final class MultipartStream implements StreamInterface
      */
     private static function getHeader(array $headers, string $key): ?string
     {
-        $lowercaseHeader = strtolower($key);
+        $lowercaseHeader = strtr($key, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz');
         foreach ($headers as $k => $v) {
-            if (strtolower((string) $k) === $lowercaseHeader) {
+            if (strtr((string) $k, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz') === $lowercaseHeader) {
                 return $v;
             }
         }

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -220,7 +220,7 @@ class ServerRequest extends Request implements ServerRequestInterface
     private static function removeInvalidHostHeader(array $headers): array
     {
         foreach ($headers as $name => $value) {
-            if (strtolower((string) $name) !== 'host') {
+            if (strtr((string) $name, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz') !== 'host') {
                 continue;
             }
 

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -20,11 +20,11 @@ final class Utils
         $result = [];
 
         foreach ($keys as &$key) {
-            $key = strtolower((string) $key);
+            $key = strtr((string) $key, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz');
         }
 
         foreach ($data as $k => $v) {
-            if (!in_array(strtolower((string) $k), $keys)) {
+            if (!in_array(strtr((string) $k, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'), $keys)) {
                 $result[$k] = $v;
             }
         }
@@ -212,7 +212,7 @@ final class Utils
             if ($host !== '') {
                 if (isset($changes['set_headers']) && is_array($changes['set_headers'])) {
                     foreach (array_keys($changes['set_headers']) as $header) {
-                        if (strtolower((string) $header) === 'host') {
+                        if (strtr((string) $header, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz') === 'host') {
                             throw new \InvalidArgumentException(
                                 'Cannot modify request with both a URI containing a host and an explicit Host header.'
                             );
@@ -248,7 +248,7 @@ final class Utils
 
         $hasHost = false;
         foreach (array_keys($headers) as $header) {
-            if (strtolower((string) $header) === 'host') {
+            if (strtr((string) $header, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz') === 'host') {
                 $hasHost = true;
                 break;
             }
@@ -284,7 +284,7 @@ final class Utils
             $addedHeaders = [];
             foreach ($headers as $header => $value) {
                 $header = (string) $header;
-                $normalized = strtolower($header);
+                $normalized = strtr($header, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz');
 
                 if (isset($addedHeaders[$normalized])) {
                     /** @var RequestInterface */


### PR DESCRIPTION
PHP's `strtolower()` honors `LC_CTYPE` before PHP 8.2, so under single-byte locales such as Turkish an ASCII uppercase I folds to a non-ASCII byte and equivalent protocol elements stop comparing equal. This converts the sixteen header-name and host comparison sites (the `MessageTrait` case-insensitive header map, `Utils::caselessRemove` and its Host-header handling, `Message`, `ServerRequest`, and `MultipartStream`) to inline locale-independent `strtr()` ASCII folds, matching the approach `Uri` already uses for schemes and hosts. The remaining method-uppercasing and lookup sites follow in 2.13.0, which will also introduce public `Utils::asciiToLower()` and `Utils::asciiToUpper()` helpers that these inline folds will migrate to.