### PR TITLE
Add locale-independent ASCII case folding helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.13.0 - Upcoming
+
+### Added
+
+- Add locale-independent Utils::asciiToLower and Utils::asciiToUpper helpers
+
+### Changed
+
+- Use locale-independent ASCII case folding everywhere case is normalized
+
 ## 2.12.5 - Upcoming
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -455,6 +455,28 @@ string. This function does not modify the provided keys when an array is
 encountered (like `http_build_query()` would).
 
 
+## `GuzzleHttp\Psr7\Utils::asciiToLower`
+
+`public static function asciiToLower(string $string): string`
+
+Converts ASCII uppercase letters in a string to lowercase.
+
+Unlike strtolower(), which honors LC_CTYPE before PHP 8.2, the conversion is
+locale-independent and leaves every non-ASCII byte unchanged, as HTTP protocol
+elements require.
+
+
+## `GuzzleHttp\Psr7\Utils::asciiToUpper`
+
+`public static function asciiToUpper(string $string): string`
+
+Converts ASCII lowercase letters in a string to uppercase.
+
+Unlike strtoupper(), which honors LC_CTYPE before PHP 8.2, the conversion is
+locale-independent and leaves every non-ASCII byte unchanged, as HTTP protocol
+elements require.
+
+
 ## `GuzzleHttp\Psr7\Utils::caselessRemove`
 
 `public static function caselessRemove(iterable<string> $keys, $keys, array $data): array`

--- a/src/Message.php
+++ b/src/Message.php
@@ -33,7 +33,7 @@ final class Message
         }
 
         foreach ($message->getHeaders() as $name => $values) {
-            if (is_string($name) && strtr($name, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz') === 'set-cookie') {
+            if (is_string($name) && Utils::asciiToLower($name) === 'set-cookie') {
                 foreach ($values as $value) {
                     $msg .= "\r\n{$name}: ".$value;
                 }
@@ -294,7 +294,7 @@ final class Message
             // Numeric array keys are converted to int by PHP.
             $k = (string) $k;
 
-            return strtr($k, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz') === 'host';
+            return Utils::asciiToLower($k) === 'host';
         });
 
         if (!$hostKey) {

--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -62,12 +62,12 @@ trait MessageTrait
 
     public function hasHeader($header): bool
     {
-        return isset($this->headerNames[strtr($header, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz')]);
+        return isset($this->headerNames[Utils::asciiToLower($header)]);
     }
 
     public function getHeader($header): array
     {
-        $header = strtr($header, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz');
+        $header = Utils::asciiToLower($header);
 
         if (!isset($this->headerNames[$header])) {
             return [];
@@ -103,7 +103,7 @@ trait MessageTrait
             }
         }
         $value = $this->normalizeHeaderValue($value);
-        $normalized = strtr($header, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz');
+        $normalized = Utils::asciiToLower($header);
 
         $new = clone $this;
         if (isset($new->headerNames[$normalized])) {
@@ -135,7 +135,7 @@ trait MessageTrait
             }
         }
         $value = $this->normalizeHeaderValue($value);
-        $normalized = strtr($header, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz');
+        $normalized = Utils::asciiToLower($header);
 
         $new = clone $this;
         if (isset($new->headerNames[$normalized])) {
@@ -154,7 +154,7 @@ trait MessageTrait
      */
     public function withoutHeader($header): MessageInterface
     {
-        $normalized = strtr($header, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz');
+        $normalized = Utils::asciiToLower($header);
 
         if (!isset($this->headerNames[$normalized])) {
             return $this;
@@ -218,7 +218,7 @@ trait MessageTrait
                 }
             }
             $value = $this->normalizeHeaderValue($value);
-            $normalized = strtr($header, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz');
+            $normalized = Utils::asciiToLower($header);
             if (isset($this->headerNames[$normalized])) {
                 $header = $this->headerNames[$normalized];
                 $this->headers[$header] = array_merge($this->headers[$header], $value);

--- a/src/MimeType.php
+++ b/src/MimeType.php
@@ -1300,6 +1300,6 @@ final class MimeType
      */
     public static function fromExtension(string $extension): ?string
     {
-        return self::MIME_TYPES[strtolower($extension)] ?? null;
+        return self::MIME_TYPES[Utils::asciiToLower($extension)] ?? null;
     }
 }

--- a/src/MultipartStream.php
+++ b/src/MultipartStream.php
@@ -227,9 +227,9 @@ final class MultipartStream implements StreamInterface
      */
     private static function getHeader(array $headers, string $key): ?string
     {
-        $lowercaseHeader = strtr($key, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz');
+        $lowercaseHeader = Utils::asciiToLower($key);
         foreach ($headers as $k => $v) {
-            if (strtr((string) $k, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz') === $lowercaseHeader) {
+            if (Utils::asciiToLower((string) $k) === $lowercaseHeader) {
                 return $v;
             }
         }

--- a/src/Request.php
+++ b/src/Request.php
@@ -47,7 +47,7 @@ class Request implements RequestInterface
         }
 
         self::warnOnMethodCasingChange($method);
-        $this->method = strtoupper($method);
+        $this->method = Utils::asciiToUpper($method);
         $this->uri = $uri;
         $this->setHeaders($headers);
         $this->protocol = $version;
@@ -108,7 +108,7 @@ class Request implements RequestInterface
         $this->assertMethod($method);
         self::warnOnMethodCasingChange($method);
         $new = clone $this;
-        $new->method = strtoupper($method);
+        $new->method = Utils::asciiToUpper($method);
 
         return $new;
     }
@@ -184,7 +184,7 @@ class Request implements RequestInterface
 
     private static function warnOnMethodCasingChange(string $method): void
     {
-        if ($method !== strtoupper($method)) {
+        if ($method !== Utils::asciiToUpper($method)) {
             \trigger_deprecation(
                 'guzzlehttp/psr7',
                 '2.11',

--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -165,7 +165,7 @@ class ServerRequest extends Request implements ServerRequestInterface
      */
     public static function fromGlobals(): ServerRequestInterface
     {
-        $method = strtoupper(self::getServerParam('REQUEST_METHOD') ?? 'GET');
+        $method = Utils::asciiToUpper(self::getServerParam('REQUEST_METHOD') ?? 'GET');
         $headers = self::removeInvalidHostHeader(self::getAllHeaders());
         $uri = self::getUriFromGlobals();
         $body = new CachingStream(new LazyOpenStream('php://input', 'r+'));
@@ -220,7 +220,7 @@ class ServerRequest extends Request implements ServerRequestInterface
     private static function removeInvalidHostHeader(array $headers): array
     {
         foreach ($headers as $name => $value) {
-            if (strtr((string) $name, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz') !== 'host') {
+            if (Utils::asciiToLower((string) $name) !== 'host') {
                 continue;
             }
 

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -696,7 +696,7 @@ class Uri implements UriInterface, \JsonSerializable
             throw new \InvalidArgumentException('Scheme must be a string');
         }
 
-        $scheme = \strtr($scheme, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz');
+        $scheme = Utils::asciiToLower($scheme);
 
         if ($scheme !== '' && !preg_match('/^[a-z][a-z0-9.+-]*$/D', $scheme)) {
             \trigger_deprecation(
@@ -739,7 +739,7 @@ class Uri implements UriInterface, \JsonSerializable
             throw new \InvalidArgumentException('Host must be a string');
         }
 
-        $host = \strtr($host, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz');
+        $host = Utils::asciiToLower($host);
         self::assertValidHost($host);
 
         return $host;

--- a/src/UriNormalizer.php
+++ b/src/UriNormalizer.php
@@ -192,7 +192,7 @@ final class UriNormalizer
         $regex = '/(?:%[A-Fa-f0-9]{2})++/';
 
         $callback = function (array $match): string {
-            return strtoupper($match[0]);
+            return Utils::asciiToUpper($match[0]);
         };
 
         return $uri

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -11,6 +11,30 @@ use Psr\Http\Message\UriInterface;
 final class Utils
 {
     /**
+     * Converts ASCII uppercase letters in a string to lowercase.
+     *
+     * Unlike strtolower(), which honors LC_CTYPE before PHP 8.2, the
+     * conversion is locale-independent and leaves every non-ASCII byte
+     * unchanged, as HTTP protocol elements require.
+     */
+    public static function asciiToLower(string $string): string
+    {
+        return strtr($string, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz');
+    }
+
+    /**
+     * Converts ASCII lowercase letters in a string to uppercase.
+     *
+     * Unlike strtoupper(), which honors LC_CTYPE before PHP 8.2, the
+     * conversion is locale-independent and leaves every non-ASCII byte
+     * unchanged, as HTTP protocol elements require.
+     */
+    public static function asciiToUpper(string $string): string
+    {
+        return strtr($string, 'abcdefghijklmnopqrstuvwxyz', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ');
+    }
+
+    /**
      * Remove the items given by the keys, case insensitively from the data.
      *
      * @param (string|int)[] $keys
@@ -20,11 +44,11 @@ final class Utils
         $result = [];
 
         foreach ($keys as &$key) {
-            $key = strtr((string) $key, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz');
+            $key = self::asciiToLower((string) $key);
         }
 
         foreach ($data as $k => $v) {
-            if (!in_array(strtr((string) $k, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'), $keys)) {
+            if (!in_array(self::asciiToLower((string) $k), $keys)) {
                 $result[$k] = $v;
             }
         }
@@ -212,7 +236,7 @@ final class Utils
             if ($host !== '') {
                 if (isset($changes['set_headers']) && is_array($changes['set_headers'])) {
                     foreach (array_keys($changes['set_headers']) as $header) {
-                        if (strtr((string) $header, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz') === 'host') {
+                        if (self::asciiToLower((string) $header) === 'host') {
                             throw new \InvalidArgumentException(
                                 'Cannot modify request with both a URI containing a host and an explicit Host header.'
                             );
@@ -248,7 +272,7 @@ final class Utils
 
         $hasHost = false;
         foreach (array_keys($headers) as $header) {
-            if (strtr((string) $header, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz') === 'host') {
+            if (self::asciiToLower((string) $header) === 'host') {
                 $hasHost = true;
                 break;
             }
@@ -284,7 +308,7 @@ final class Utils
             $addedHeaders = [];
             foreach ($headers as $header => $value) {
                 $header = (string) $header;
-                $normalized = strtr($header, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz');
+                $normalized = self::asciiToLower($header);
 
                 if (isset($addedHeaders[$normalized])) {
                     /** @var RequestInterface */

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -13,6 +13,24 @@ use Psr\Http\Message\UriInterface;
 
 class UtilsTest extends TestCase
 {
+    public function testAsciiToLower(): void
+    {
+        self::assertSame('abcdefghijklmnopqrstuvwxyz', Psr7\Utils::asciiToLower('ABCDEFGHIJKLMNOPQRSTUVWXYZ'));
+        self::assertSame('x-checksum', Psr7\Utils::asciiToLower('X-Checksum'));
+        self::assertSame('0123456789 -_.!~*\'()', Psr7\Utils::asciiToLower('0123456789 -_.!~*\'()'));
+        self::assertSame("\xC4\xB0i", Psr7\Utils::asciiToLower("\xC4\xB0I"));
+        self::assertSame('', Psr7\Utils::asciiToLower(''));
+    }
+
+    public function testAsciiToUpper(): void
+    {
+        self::assertSame('ABCDEFGHIJKLMNOPQRSTUVWXYZ', Psr7\Utils::asciiToUpper('abcdefghijklmnopqrstuvwxyz'));
+        self::assertSame('X-CHECKSUM', Psr7\Utils::asciiToUpper('x-Checksum'));
+        self::assertSame('0123456789 -_.!~*\'()', Psr7\Utils::asciiToUpper('0123456789 -_.!~*\'()'));
+        self::assertSame("\xC4\xB1I", Psr7\Utils::asciiToUpper("\xC4\xB1i"));
+        self::assertSame('', Psr7\Utils::asciiToUpper(''));
+    }
+
     public function testCopiesToString(): void
     {
         $s = Psr7\Utils::streamFor('foobaz');


### PR DESCRIPTION
This introduces public `Utils::asciiToLower()` and `Utils::asciiToUpper()` helpers that fold ASCII letters with `strtr()`, because `strtolower()` and `strtoupper()` honor `LC_CTYPE` before PHP 8.2 and can corrupt protocol elements under single-byte locales such as Turkish; non-ASCII bytes pass through unchanged. Every case-normalization site in the library now uses the helpers: the 2.12.5 inline folds, the remaining method and percent-encoding uppercasing in `Request`, `ServerRequest`, and `UriNormalizer`, the `MimeType` extension lookup, and `Uri`'s pre-existing scheme and host folds. The helpers are documented in the README and unit-tested, including non-ASCII byte passthrough, and dependent packages will adopt them via the `^2.13` constraint.