### PR TITLE
Add locale-independent ASCII case folding helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,10 @@
   where they are accepted and we need to cast to a string, we should branch on
   `\is_finite($value)`, using `(string) $value` for the finite case and
   `\is_nan($value) ? 'NAN' : ($value > 0 ? 'INF' : '-INF')` otherwise.
+- Never call `strtolower()`, `strtoupper()`, `strcasecmp()`, `stripos()`, or
+  other locale-sensitive case functions; use the locale-independent
+  `Utils::asciiToLower()`, `Utils::asciiToUpper()`, `Utils::caselessEquals()`,
+  and `Utils::caselessContains()` helpers instead.
 - Changes in behavior need a `CHANGELOG.md` entry in the unreleased section of
   the target branch and an `UPGRADING.md` note when the behavior differs between
   major versions.

--- a/docs/header-and-query-helpers.md
+++ b/docs/header-and-query-helpers.md
@@ -49,6 +49,40 @@ This function can use the return value of `parse()` to build a query string.
 This function does not modify the provided keys when an array is encountered,
 unlike `http_build_query()`.
 
+## `GuzzleHttp\Psr7\Utils::asciiToLower`
+
+`public static function asciiToLower(string $string): string`
+
+Converts ASCII uppercase letters in a string to lowercase.
+
+Unlike `strtolower()`, which honors `LC_CTYPE` before PHP 8.2, the conversion is
+locale-independent and leaves every non-ASCII byte unchanged, as HTTP protocol
+elements require.
+
+## `GuzzleHttp\Psr7\Utils::asciiToUpper`
+
+`public static function asciiToUpper(string $string): string`
+
+Converts ASCII lowercase letters in a string to uppercase.
+
+Unlike `strtoupper()`, which honors `LC_CTYPE` before PHP 8.2, the conversion is
+locale-independent and leaves every non-ASCII byte unchanged, as HTTP protocol
+elements require.
+
+## `GuzzleHttp\Psr7\Utils::caselessContains`
+
+`public static function caselessContains(string $haystack, string $needle): bool`
+
+Checks whether the haystack contains the needle, comparing ASCII letters
+case-insensitively and without locale sensitivity.
+
+## `GuzzleHttp\Psr7\Utils::caselessEquals`
+
+`public static function caselessEquals(string $left, string $right): bool`
+
+Checks whether two strings are equal, comparing ASCII letters case-insensitively
+and without locale sensitivity.
+
 ## `GuzzleHttp\Psr7\Utils::caselessRemove`
 
 `public static function caselessRemove(array $keys, array $data): array`

--- a/src/Message.php
+++ b/src/Message.php
@@ -53,7 +53,7 @@ final class Message
         }
 
         foreach ($message->getHeaders() as $name => $values) {
-            if (is_string($name) && strtolower($name) === 'set-cookie') {
+            if (is_string($name) && Utils::asciiToLower($name) === 'set-cookie') {
                 foreach ($values as $value) {
                     $msg .= "\r\n{$name}: ".$value;
                 }
@@ -386,7 +386,7 @@ final class Message
         $found = false;
 
         foreach ($headers as $name => $values) {
-            if (strtolower((string) $name) !== 'host') {
+            if (Utils::asciiToLower((string) $name) !== 'host') {
                 continue;
             }
 

--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -51,12 +51,12 @@ trait MessageTrait
 
     public function hasHeader(string $name): bool
     {
-        return isset($this->headerNames[strtolower($name)]);
+        return isset($this->headerNames[Utils::asciiToLower($name)]);
     }
 
     public function getHeader(string $name): array
     {
-        $header = strtolower($name);
+        $header = Utils::asciiToLower($name);
 
         if (!isset($this->headerNames[$header])) {
             return [];
@@ -79,7 +79,7 @@ trait MessageTrait
     {
         $this->assertHeader($name);
         $value = $this->normalizeHeaderValue($value);
-        $normalized = strtolower($name);
+        $normalized = Utils::asciiToLower($name);
 
         $new = clone $this;
         if (isset($new->headerNames[$normalized])) {
@@ -98,7 +98,7 @@ trait MessageTrait
     {
         $this->assertHeader($name);
         $value = $this->normalizeHeaderValue($value);
-        $normalized = strtolower($name);
+        $normalized = Utils::asciiToLower($name);
 
         $new = clone $this;
         if (isset($new->headerNames[$normalized])) {
@@ -117,7 +117,7 @@ trait MessageTrait
      */
     public function withoutHeader(string $name): MessageInterface
     {
-        $normalized = strtolower($name);
+        $normalized = Utils::asciiToLower($name);
 
         if (!isset($this->headerNames[$normalized])) {
             return $this;
@@ -167,7 +167,7 @@ trait MessageTrait
 
             $this->assertHeader($header);
             $value = $this->normalizeHeaderValue($value);
-            $normalized = strtolower($header);
+            $normalized = Utils::asciiToLower($header);
             if (isset($this->headerNames[$normalized])) {
                 $header = $this->headerNames[$normalized];
                 $this->headers[$header] = array_merge($this->headers[$header], $value);

--- a/src/MimeType.php
+++ b/src/MimeType.php
@@ -1304,6 +1304,6 @@ final class MimeType
      */
     public static function fromExtension(string $extension): ?string
     {
-        return self::MIME_TYPES[strtolower($extension)] ?? null;
+        return self::MIME_TYPES[Utils::asciiToLower($extension)] ?? null;
     }
 }

--- a/src/MultipartStream.php
+++ b/src/MultipartStream.php
@@ -211,9 +211,9 @@ final class MultipartStream implements StreamInterface
      */
     private static function getHeader(array $headers, string $key): ?string
     {
-        $lowercaseHeader = strtolower($key);
+        $lowercaseHeader = Utils::asciiToLower($key);
         foreach ($headers as $k => $v) {
-            if (strtolower((string) $k) === $lowercaseHeader) {
+            if (Utils::asciiToLower((string) $k) === $lowercaseHeader) {
                 return $v;
             }
         }

--- a/src/ServerRequestGlobalsFactory.php
+++ b/src/ServerRequestGlobalsFactory.php
@@ -123,7 +123,13 @@ final class ServerRequestGlobalsFactory
                     continue;
                 }
 
-                $header = str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', $header))));
+                $parts = explode(' ', Utils::asciiToLower(str_replace('_', ' ', $header)));
+                foreach ($parts as $i => $part) {
+                    if ($part !== '') {
+                        $parts[$i] = Utils::asciiToUpper($part[0]).substr($part, 1);
+                    }
+                }
+                $header = implode('-', $parts);
                 $headers[$header] = $value;
 
                 continue;
@@ -159,7 +165,7 @@ final class ServerRequestGlobalsFactory
     private static function removeInvalidHostHeader(array $headers): array
     {
         foreach ($headers as $name => $value) {
-            if (strtolower((string) $name) !== 'host') {
+            if (Utils::asciiToLower((string) $name) !== 'host') {
                 continue;
             }
 
@@ -185,7 +191,7 @@ final class ServerRequestGlobalsFactory
      */
     private static function getRequestMethodFromServer(array $server): string
     {
-        return strtoupper(self::getServerParam($server, 'REQUEST_METHOD') ?? 'GET');
+        return Utils::asciiToUpper(self::getServerParam($server, 'REQUEST_METHOD') ?? 'GET');
     }
 
     /**

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -725,7 +725,7 @@ class Uri implements UriInterface, \JsonSerializable
      */
     private function filterScheme(string $scheme): string
     {
-        $scheme = \strtr($scheme, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz');
+        $scheme = Utils::asciiToLower($scheme);
 
         if (!Rfc3986::isValidScheme($scheme)) {
             throw new \InvalidArgumentException(sprintf('Invalid scheme: "%s"', $scheme));
@@ -751,9 +751,9 @@ class Uri implements UriInterface, \JsonSerializable
      */
     private function filterHost(string $host): string
     {
-        $host = \strtr($host, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz');
+        $host = Utils::asciiToLower($host);
         $filtered = \preg_replace_callback('/%'.Rfc3986::HEX_OCTET.'/', static function (array $m): string {
-            return \strtoupper($m[0]);
+            return Utils::asciiToUpper($m[0]);
         }, $host);
         if ($filtered === null) {
             throw new \RuntimeException('Unable to normalize URI host percent-encoding: '.\preg_last_error_msg());

--- a/src/UriComparator.php
+++ b/src/UriComparator.php
@@ -28,7 +28,7 @@ final class UriComparator
      */
     public static function isCrossOrigin(UriInterface $original, UriInterface $modified): bool
     {
-        if (\strcasecmp($original->getHost(), $modified->getHost()) !== 0) {
+        if (!Utils::caselessEquals($original->getHost(), $modified->getHost())) {
             return true;
         }
 

--- a/src/UriNormalizer.php
+++ b/src/UriNormalizer.php
@@ -212,7 +212,7 @@ final class UriNormalizer
         $regex = '/(?:%'.Rfc3986::HEX_OCTET.')++/';
 
         $callback = function (array $match): string {
-            return strtoupper($match[0]);
+            return Utils::asciiToUpper($match[0]);
         };
 
         return $uri

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -16,6 +16,48 @@ final class Utils
     }
 
     /**
+     * Converts ASCII uppercase letters in a string to lowercase.
+     *
+     * Unlike strtolower(), which honors LC_CTYPE before PHP 8.2, the
+     * conversion is locale-independent and leaves every non-ASCII byte
+     * unchanged, as HTTP protocol elements require.
+     */
+    public static function asciiToLower(string $string): string
+    {
+        return strtr($string, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz');
+    }
+
+    /**
+     * Converts ASCII lowercase letters in a string to uppercase.
+     *
+     * Unlike strtoupper(), which honors LC_CTYPE before PHP 8.2, the
+     * conversion is locale-independent and leaves every non-ASCII byte
+     * unchanged, as HTTP protocol elements require.
+     */
+    public static function asciiToUpper(string $string): string
+    {
+        return strtr($string, 'abcdefghijklmnopqrstuvwxyz', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ');
+    }
+
+    /**
+     * Checks whether the haystack contains the needle, comparing ASCII
+     * letters case-insensitively and without locale sensitivity.
+     */
+    public static function caselessContains(string $haystack, string $needle): bool
+    {
+        return str_contains(self::asciiToLower($haystack), self::asciiToLower($needle));
+    }
+
+    /**
+     * Checks whether two strings are equal, comparing ASCII letters
+     * case-insensitively and without locale sensitivity.
+     */
+    public static function caselessEquals(string $left, string $right): bool
+    {
+        return self::asciiToLower($left) === self::asciiToLower($right);
+    }
+
+    /**
      * Remove the items given by the keys from the data, case-insensitively.
      *
      * @param array<array-key, string|int> $keys
@@ -25,11 +67,11 @@ final class Utils
         $result = [];
 
         foreach ($keys as &$key) {
-            $key = strtolower((string) $key);
+            $key = self::asciiToLower((string) $key);
         }
 
         foreach ($data as $k => $v) {
-            if (!in_array(strtolower((string) $k), $keys)) {
+            if (!in_array(self::asciiToLower((string) $k), $keys)) {
                 $result[$k] = $v;
             }
         }
@@ -254,7 +296,7 @@ final class Utils
 
                 if (isset($changes['set_headers']) && is_array($changes['set_headers'])) {
                     foreach (array_keys($changes['set_headers']) as $header) {
-                        if (strtolower((string) $header) === 'host') {
+                        if (self::asciiToLower((string) $header) === 'host') {
                             throw new \InvalidArgumentException(
                                 'Cannot modify request with both a URI containing a host and an explicit Host header.'
                             );
@@ -290,7 +332,7 @@ final class Utils
 
         $hasHost = false;
         foreach (array_keys($headers) as $header) {
-            if (strtolower((string) $header) === 'host') {
+            if (self::asciiToLower((string) $header) === 'host') {
                 $hasHost = true;
                 break;
             }
@@ -327,7 +369,7 @@ final class Utils
             $addedHeaders = [];
             foreach ($headers as $header => $value) {
                 $header = (string) $header;
-                $normalized = strtolower($header);
+                $normalized = self::asciiToLower($header);
 
                 if (isset($addedHeaders[$normalized])) {
                     /** @var RequestInterface */

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -18,6 +18,40 @@ class UtilsTest extends TestCase
         PhpStreamMock::reset();
     }
 
+    public function testAsciiToLower(): void
+    {
+        self::assertSame('abcdefghijklmnopqrstuvwxyz', Psr7\Utils::asciiToLower('ABCDEFGHIJKLMNOPQRSTUVWXYZ'));
+        self::assertSame('x-checksum', Psr7\Utils::asciiToLower('X-Checksum'));
+        self::assertSame('0123456789 !#$%&*+-.^_`|~', Psr7\Utils::asciiToLower('0123456789 !#$%&*+-.^_`|~'));
+        self::assertSame("\xC4\xB0i", Psr7\Utils::asciiToLower("\xC4\xB0I"));
+        self::assertSame('', Psr7\Utils::asciiToLower(''));
+    }
+
+    public function testAsciiToUpper(): void
+    {
+        self::assertSame('ABCDEFGHIJKLMNOPQRSTUVWXYZ', Psr7\Utils::asciiToUpper('abcdefghijklmnopqrstuvwxyz'));
+        self::assertSame('X-CHECKSUM', Psr7\Utils::asciiToUpper('x-Checksum'));
+        self::assertSame('0123456789 !#$%&*+-.^_`|~', Psr7\Utils::asciiToUpper('0123456789 !#$%&*+-.^_`|~'));
+        self::assertSame("\xC4\xB1I", Psr7\Utils::asciiToUpper("\xC4\xB1i"));
+        self::assertSame('', Psr7\Utils::asciiToUpper(''));
+    }
+
+    public function testCaselessContains(): void
+    {
+        self::assertTrue(Psr7\Utils::caselessContains('Connection TIMEOUT after', 'timeout'));
+        self::assertFalse(Psr7\Utils::caselessContains('Connection reset', 'timeout'));
+        self::assertTrue(Psr7\Utils::caselessContains('Connection timeout after', 'timeout'));
+        self::assertTrue(Psr7\Utils::caselessContains('Connection reset', ''));
+    }
+
+    public function testCaselessEquals(): void
+    {
+        self::assertTrue(Psr7\Utils::caselessEquals('HOST', 'host'));
+        self::assertFalse(Psr7\Utils::caselessEquals('host', 'hosts'));
+        self::assertTrue(Psr7\Utils::caselessEquals('', ''));
+        self::assertFalse(Psr7\Utils::caselessEquals("\xC4\xB0", 'i'));
+    }
+
     public function testCopiesToString(): void
     {
         $s = Psr7\Utils::streamFor('foobaz');


### PR DESCRIPTION
This mirrors #850 for 3.0 and completes it, carrying all the code changes since only the changelog is merged up. Beyond `Utils::asciiToLower()` and `asciiToUpper()`, two more helpers cover the shapes the wider audit found: `caselessEquals()` replaces `strcasecmp()` comparisons and `caselessContains()` replaces `stripos()` containment checks, both named after the existing `caselessRemove()`. Every locale-sensitive site is converted, including `UriComparator`'s host comparison and `ServerRequestGlobalsFactory`'s header-name reconstruction, whose `ucwords()` call — locale-sensitive before PHP 8.2 like the rest of the family, and capable of corrupting header names such as `Authorization` under Turkish locales — is replaced with an ASCII-safe equivalent. The helpers are unit-tested and documented in `docs/header-and-query-helpers.md` with PHPDoc-synced prose, and `AGENTS.md` gains a bullet mandating them.