### PR TITLE
Fold cross-origin host comparison without locale sensitivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 2.12.5 - Upcoming
 
-### Changed
+### Fixed
 
 - Compare header names and hosts with locale-independent ASCII lowercasing
+- Compare hosts without locale sensitivity when detecting cross-origin redirects
 
 ## 2.12.4 - 2026-07-08
 

--- a/src/UriComparator.php
+++ b/src/UriComparator.php
@@ -19,7 +19,10 @@ final class UriComparator
      */
     public static function isCrossOrigin(UriInterface $original, UriInterface $modified): bool
     {
-        if (\strcasecmp($original->getHost(), $modified->getHost()) !== 0) {
+        $originalHost = \strtr($original->getHost(), 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz');
+        $modifiedHost = \strtr($modified->getHost(), 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz');
+
+        if ($originalHost !== $modifiedHost) {
             return true;
         }
 


### PR DESCRIPTION
`UriComparator::isCrossOrigin()` compared hosts with `strcasecmp()`, which shares Zend's locale-backed case tables before PHP 8.2, so a host containing `I` can fail to compare equal to its lowercase form under single-byte locales such as Turkish. Because this comparison feeds Guzzle's redirect middleware decision to strip credentials, a misfold makes a same-origin redirect look cross-origin and silently drops authentication. Both hosts are now folded with the locale-independent inline `strtr()` ASCII map before comparing, matching the 2.12.5 treatment of the other host and header comparisons.