### PR TITLE
Add a locale-independent asciiUcFirst helper

### DIFF
--- a/docs/header-and-query-helpers.md
+++ b/docs/header-and-query-helpers.md
@@ -69,6 +69,17 @@ Unlike `strtoupper()`, which honors `LC_CTYPE` before PHP 8.2, the conversion is
 locale-independent and leaves every non-ASCII byte unchanged, as HTTP protocol
 elements require.
 
+## `GuzzleHttp\Psr7\Utils::asciiUcFirst`
+
+`public static function asciiUcFirst(string $string): string`
+
+Converts the first character of a string to uppercase when it is an ASCII
+lowercase letter.
+
+Unlike `ucfirst()`, which honors `LC_CTYPE` before PHP 8.2, the conversion is
+locale-independent and leaves every non-ASCII byte unchanged, as HTTP protocol
+elements require.
+
 ## `GuzzleHttp\Psr7\Utils::caselessContains`
 
 `public static function caselessContains(string $haystack, string $needle): bool`

--- a/src/ServerRequestGlobalsFactory.php
+++ b/src/ServerRequestGlobalsFactory.php
@@ -125,9 +125,7 @@ final class ServerRequestGlobalsFactory
 
                 $parts = explode(' ', Utils::asciiToLower(str_replace('_', ' ', $header)));
                 foreach ($parts as $i => $part) {
-                    if ($part !== '') {
-                        $parts[$i] = Utils::asciiToUpper($part[0]).substr($part, 1);
-                    }
+                    $parts[$i] = Utils::asciiUcFirst($part);
                 }
                 $header = implode('-', $parts);
                 $headers[$header] = $value;

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -40,6 +40,23 @@ final class Utils
     }
 
     /**
+     * Converts the first character of a string to uppercase when it is an
+     * ASCII lowercase letter.
+     *
+     * Unlike ucfirst(), which honors LC_CTYPE before PHP 8.2, the conversion
+     * is locale-independent and leaves every non-ASCII byte unchanged, as
+     * HTTP protocol elements require.
+     */
+    public static function asciiUcFirst(string $string): string
+    {
+        if ($string === '') {
+            return '';
+        }
+
+        return self::asciiToUpper($string[0]).substr($string, 1);
+    }
+
+    /**
      * Checks whether the haystack contains the needle, comparing ASCII
      * letters case-insensitively and without locale sensitivity.
      */

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -36,6 +36,16 @@ class UtilsTest extends TestCase
         self::assertSame('', Psr7\Utils::asciiToUpper(''));
     }
 
+    public function testAsciiUcFirst(): void
+    {
+        self::assertSame('Index', Psr7\Utils::asciiUcFirst('index'));
+        self::assertSame('Index', Psr7\Utils::asciiUcFirst('Index'));
+        self::assertSame('X-a', Psr7\Utils::asciiUcFirst('x-a'));
+        self::assertSame('0abc', Psr7\Utils::asciiUcFirst('0abc'));
+        self::assertSame("\xC4\xB1i", Psr7\Utils::asciiUcFirst("\xC4\xB1i"));
+        self::assertSame('', Psr7\Utils::asciiUcFirst(''));
+    }
+
     public function testCaselessContains(): void
     {
         self::assertTrue(Psr7\Utils::caselessContains('Connection TIMEOUT after', 'timeout'));


### PR DESCRIPTION
This adds `Utils::asciiUcFirst()`, completing the case-folding helper set with the first-character capitalization shape: `ucfirst()` honors `LC_CTYPE` before PHP 8.2 like the rest of the family, and the hand-rolled composition needs an empty-string guard that is easy to forget, so the guard now lives inside the helper. The header-name reconstruction in `ServerRequestGlobalsFactory` adopts it, simplifying its per-word loop. Documented in `docs/header-and-query-helpers.md` with PHPDoc-synced prose and unit-tested including non-ASCII first-byte passthrough; the changelog entry lands with the 2.13 parity PR and merges up.