### PR TITLE
Add caseless comparison and asciiUcFirst helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add locale-independent Utils::asciiToLower and Utils::asciiToUpper helpers
+- Add locale-independent Utils::asciiUcFirst, caselessEquals, and caselessContains helpers
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -477,6 +477,34 @@ locale-independent and leaves every non-ASCII byte unchanged, as HTTP protocol
 elements require.
 
 
+## `GuzzleHttp\Psr7\Utils::asciiUcFirst`
+
+`public static function asciiUcFirst(string $string): string`
+
+Converts the first character of a string to uppercase when it is an ASCII
+lowercase letter.
+
+Unlike ucfirst(), which honors LC_CTYPE before PHP 8.2, the conversion is
+locale-independent and leaves every non-ASCII byte unchanged, as HTTP protocol
+elements require.
+
+
+## `GuzzleHttp\Psr7\Utils::caselessContains`
+
+`public static function caselessContains(string $haystack, string $needle): bool`
+
+Checks whether the haystack contains the needle, comparing ASCII letters
+case-insensitively and without locale sensitivity.
+
+
+## `GuzzleHttp\Psr7\Utils::caselessEquals`
+
+`public static function caselessEquals(string $left, string $right): bool`
+
+Checks whether two strings are equal, comparing ASCII letters
+case-insensitively and without locale sensitivity.
+
+
 ## `GuzzleHttp\Psr7\Utils::caselessRemove`
 
 `public static function caselessRemove(iterable<string> $keys, $keys, array $data): array`

--- a/src/UriComparator.php
+++ b/src/UriComparator.php
@@ -19,10 +19,7 @@ final class UriComparator
      */
     public static function isCrossOrigin(UriInterface $original, UriInterface $modified): bool
     {
-        $originalHost = \strtr($original->getHost(), 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz');
-        $modifiedHost = \strtr($modified->getHost(), 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz');
-
-        if ($originalHost !== $modifiedHost) {
+        if (!Utils::caselessEquals($original->getHost(), $modified->getHost())) {
             return true;
         }
 

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -35,6 +35,41 @@ final class Utils
     }
 
     /**
+     * Converts the first character of a string to uppercase when it is an
+     * ASCII lowercase letter.
+     *
+     * Unlike ucfirst(), which honors LC_CTYPE before PHP 8.2, the conversion
+     * is locale-independent and leaves every non-ASCII byte unchanged, as
+     * HTTP protocol elements require.
+     */
+    public static function asciiUcFirst(string $string): string
+    {
+        if ($string === '') {
+            return '';
+        }
+
+        return self::asciiToUpper($string[0]).substr($string, 1);
+    }
+
+    /**
+     * Checks whether the haystack contains the needle, comparing ASCII
+     * letters case-insensitively and without locale sensitivity.
+     */
+    public static function caselessContains(string $haystack, string $needle): bool
+    {
+        return str_contains(self::asciiToLower($haystack), self::asciiToLower($needle));
+    }
+
+    /**
+     * Checks whether two strings are equal, comparing ASCII letters
+     * case-insensitively and without locale sensitivity.
+     */
+    public static function caselessEquals(string $left, string $right): bool
+    {
+        return self::asciiToLower($left) === self::asciiToLower($right);
+    }
+
+    /**
      * Remove the items given by the keys, case insensitively from the data.
      *
      * @param (string|int)[] $keys

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -31,6 +31,32 @@ class UtilsTest extends TestCase
         self::assertSame('', Psr7\Utils::asciiToUpper(''));
     }
 
+    public function testAsciiUcFirst(): void
+    {
+        self::assertSame('Index', Psr7\Utils::asciiUcFirst('index'));
+        self::assertSame('Index', Psr7\Utils::asciiUcFirst('Index'));
+        self::assertSame('X-a', Psr7\Utils::asciiUcFirst('x-a'));
+        self::assertSame('0abc', Psr7\Utils::asciiUcFirst('0abc'));
+        self::assertSame("\xC4\xB1i", Psr7\Utils::asciiUcFirst("\xC4\xB1i"));
+        self::assertSame('', Psr7\Utils::asciiUcFirst(''));
+    }
+
+    public function testCaselessContains(): void
+    {
+        self::assertTrue(Psr7\Utils::caselessContains('Connection TIMEOUT after', 'timeout'));
+        self::assertTrue(Psr7\Utils::caselessContains('timeout', 'timeout'));
+        self::assertTrue(Psr7\Utils::caselessContains('timeout', ''));
+        self::assertFalse(Psr7\Utils::caselessContains('Connection reset', 'timeout'));
+    }
+
+    public function testCaselessEquals(): void
+    {
+        self::assertTrue(Psr7\Utils::caselessEquals('HOST', 'host'));
+        self::assertTrue(Psr7\Utils::caselessEquals('', ''));
+        self::assertFalse(Psr7\Utils::caselessEquals('host', 'hosts'));
+        self::assertFalse(Psr7\Utils::caselessEquals("\xC4\xB0", 'i'));
+    }
+
     public function testCopiesToString(): void
     {
         $s = Psr7\Utils::streamFor('foobaz');


### PR DESCRIPTION
This brings 2.13 to API parity with the 3.0 helper set: `Utils::caselessEquals()` replaces `strcasecmp()` comparisons, `Utils::caselessContains()` replaces `stripos()` containment checks, and `Utils::asciiUcFirst()` owns the first-character capitalization shape including its empty-string guard. The implementations are byte-for-byte identical to 3.0's, with `str_contains` supplied on PHP 7.x by the `symfony/polyfill-php80` dependency the branch already requires. `UriComparator`'s host comparison adopts `caselessEquals()`, replacing the merged-up 2.12.5 inline fold. All three are unit-tested and documented in the README, with a 2.13.0 changelog entry. These functions share Zend's locale-backed case tables before PHP 8.2, which is the defect family the helpers exist to avoid.