### PR TITLE
Add tests locking in no-file upload handling

### DIFF
--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -17,6 +17,10 @@ class ServerRequestTest extends TestCase
     public static function dataNormalizeFiles(): iterable
     {
         return [
+            'No files' => [
+                [],
+                [],
+            ],
             'Single file' => [
                 [
                     'file' => [
@@ -1521,6 +1525,38 @@ class ServerRequestTest extends TestCase
                 UPLOAD_ERR_OK,
                 'MyFile.txt',
                 'text/plain'
+            ),
+        ];
+
+        self::assertEquals($expectedFiles, $server->getUploadedFiles());
+    }
+
+    public function testFromGlobalsRepresentsEmptyFileInputAsNoFileUpload(): void
+    {
+        $_SERVER = [
+            'REQUEST_METHOD' => 'POST',
+            'HTTP_HOST' => 'www.example.org',
+        ];
+
+        $_FILES = [
+            'test_file' => [
+                'name' => '',
+                'type' => '',
+                'tmp_name' => '',
+                'error' => UPLOAD_ERR_NO_FILE,
+                'size' => 0,
+            ],
+        ];
+
+        $server = ServerRequest::fromGlobals();
+
+        $expectedFiles = [
+            'test_file' => new UploadedFile(
+                '',
+                0,
+                UPLOAD_ERR_NO_FILE,
+                '',
+                ''
             ),
         ];
 


### PR DESCRIPTION
guzzle/guzzle#3873 argued that `getUploadedFiles()` should return an empty array when a form is submitted with an unselected file input. That behaviour is intentional: PSR-7's "an empty array MUST be returned if no data is present" wording covers requests carrying no upload data at all, while an unselected file input produces a full `$_FILES` entry with `UPLOAD_ERR_NO_FILE` that the spec expects to be represented as an `UploadedFileInterface` leaf, matching laminas-diactoros, nyholm/psr7-server, slim/psr7, httpsoft, and Symfony's PSR-7 bridge. This adds a `normalizeFiles([])` data provider case and an end-to-end `fromGlobals()` test for the unselected input scenario, mirroring #856 on the 2.13 branch.