### PR TITLE
Canonicalize IPv6 URI hosts to their RFC 5952 form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `GuzzleHttp\Psr7\Exception\TimeoutException` for timed-out stream operations
 - Add `GuzzleHttp\Psr7\Utils::redactUserInfoInString()` to redact the userinfo of a raw URI string within text
-- Promote `GuzzleHttp\Psr7\Rfc3986` to public API with `isValidScheme()`, `isValidHost()`, and `isValidPort()`
+- Promote `GuzzleHttp\Psr7\Rfc3986` to public API with `isValid*()` predicates and `canonicalizeIpv6()`
+- Add `GuzzleHttp\Psr7\UriNormalizer::CANONICALIZE_IPV6_HOST` to `PRESERVING_NORMALIZATIONS`
 
 ### Changed
 
@@ -86,6 +87,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Percent-encode raw control bytes in userinfo before bracketed IP-literal hosts instead of parsing mutated values
 - Reject invalid UTF-8 and preserve percent-sequences in userinfo before bracketed IP-literal hosts
 - Normalize percent-encoded octets in the URI host to uppercase hex
+- Canonicalize IPv6 hosts to RFC 5952 form in `Uri` construction, `fromParts()`, and `withHost()`
+- Canonicalize bracketed IPv6 hosts in `UriComparator::isCrossOrigin()`
 - Reject malformed percent-sequences and percent-encoded bytes forbidden by the URI host policy
 - Trim header list elements with only spaces, horizontal tabs, and line terminators in `Header::splitList()`
 - Report header parameter PCRE failures explicitly in `Header::parse()`

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -307,6 +307,43 @@ curl rejects them too, except encoded DEL (`%7F`), which it decodes and forwards
 to name resolution. Other percent-encoded octets, including UTF-8 data such as
 `a%C3%A9b`, remain accepted and are normalized to uppercase hex.
 
+IPv6 hosts are now canonicalized to their RFC 5952 form when a URI is
+constructed, so `getHost()`, `getAuthority()`, and `(string) $uri` return the
+canonical spelling and synthesized `Host` headers use it. Leading zeros are
+suppressed, hexadecimal fields are lowercase, and the longest run of two or
+more zero fields is collapsed with `::`. Embedded dotted-decimal notation
+follows the rendering policy of BIND-derived `inet_ntop()` implementations and
+curl 8.11 and newer: exactly the IPv4-mapped (`::ffff:0:0/96`) and deprecated
+IPv4-compatible (`::/96`) layouts use it, while other embedded-IPv4 forms,
+including translated (NAT64) well-known prefixes such as `64:ff9b::/96`
+(RFC 6052), serialize in pure hexadecimal fields.
+
+```php
+// 2.x preserved the spelling as given
+(string) new Uri('http://[0:0:0:0:0:0:0:1]/'); // http://[0:0:0:0:0:0:0:1]/
+
+// 3.0
+(string) new Uri('http://[0:0:0:0:0:0:0:1]/');          // http://[::1]/
+(string) new Uri('http://[::FFFF:7F00:1]/');            // http://[::ffff:127.0.0.1]/
+(string) new Uri('http://[2001:db8:3:4::192.0.2.33]/'); // http://[2001:db8:3:4::c000:221]/
+```
+
+Applications that persist URI strings, for example as cache keys, will observe
+the new canonical form for previously non-canonical IPv6 spellings. Equivalent
+spellings of the same address now compare as same-origin in
+`UriComparator::isCrossOrigin()`, which canonicalizes bracketed IPv6 literals
+from any PSR-7 implementation before comparing hosts, and as equivalent in
+`UriNormalizer::isEquivalent()`. The new
+`UriNormalizer::CANONICALIZE_IPV6_HOST` flag, included in the default
+`UriNormalizer::PRESERVING_NORMALIZATIONS`, requests the canonical host from
+other PSR-7 implementations through `withHost()` and keeps the result only
+when the returned `getHost()` exactly matches the requested spelling; a
+nonexact result leaves that step unchanged while other selected normalizations
+still apply, and setter exceptions propagate. `UriComparator` does not share
+this limitation, since it canonicalizes the extracted host text directly. The
+public helper `Rfc3986::canonicalizeIpv6()` exposes the underlying
+transformation.
+
 #### Request Host Synchronization
 
 `Request::withUri()` now applies PSR-7 Host header synchronization before using

--- a/docs/uri-helpers.md
+++ b/docs/uri-helpers.md
@@ -60,8 +60,8 @@ is considered a same-document reference.
 
 ## URI Syntax Validation
 
-`GuzzleHttp\Psr7\Rfc3986` provides static methods for validating individual URI
-components against the grammar defined by
+`GuzzleHttp\Psr7\Rfc3986` provides static methods for validating and
+canonicalizing individual URI components against the grammar defined by
 [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986). They operate on raw
 component strings rather than on `Psr\Http\Message\UriInterface` instances.
 
@@ -111,6 +111,39 @@ Whether the string is a valid port number. RFC 3986 defines the port as
 the stricter policy used throughout the library instead, accepting a non-empty
 run of digits (leading zeros are accepted and normalized) that resolves to a
 value in the range 0-65535.
+
+### `GuzzleHttp\Psr7\Rfc3986::canonicalizeIpv6`
+
+`public static function canonicalizeIpv6(string $address): string`
+
+Returns the [RFC 5952](https://datatracker.ietf.org/doc/html/rfc5952#section-4)
+canonical form of a valid IPv6 address. The address must be a valid textual
+IPv6 address without brackets and without a zone identifier, such as the
+inside of an IP-literal accepted by `isValidHost()`. Canonicalization
+lowercases the hexadecimal fields, suppresses leading zeros, and collapses the
+longest run of two or more zero fields (the leftmost on a tie) with `::`.
+Embedded dotted-decimal notation follows the rendering policy of BIND-derived
+`inet_ntop()` implementations and curl: exactly the IPv4-mapped
+(`::ffff:0:0/96`) and deprecated IPv4-compatible (`::/96`) layouts use it,
+while other embedded-IPv4 forms, including translated (NAT64) well-known
+prefixes such as `64:ff9b::/96` (RFC 6052), serialize in pure hexadecimal
+fields. An `\InvalidArgumentException` is thrown if the address cannot be
+parsed.
+
+Validation is strict and platform-independent: the address is checked against
+the RFC 3986 `IPv6address` grammar with PHP's `FILTER_VALIDATE_IP` filter and
+parsed in pure PHP, so spellings that only some platform parsers accept, such as
+the zero-padded dotted octets in `::ffff:192.168.001.001`, are rejected
+everywhere.
+
+Emitting dotted-decimal notation for these two selected layouts is the
+BIND-derived `inet_ntop()` and curl compatibility policy used here.
+[RFC 5952 Section 5](https://datatracker.ietf.org/doc/html/rfc5952#section-5)
+permits mixed notation for recognizable embedded-IPv4 prefixes but does not
+limit that category to these layouts; RFC 6052, for example, defines
+`64:ff9b::/96` as a Well-Known Prefix, which this implementation renders in
+pure hexadecimal. The WHATWG URL Standard always emits pure hexadecimal
+fields.
 
 ## URI Components
 
@@ -190,8 +223,13 @@ Determines if a modified URI should be considered cross-origin with respect to
 an original URI.
 
 Two URIs are cross-origin when their scheme, host, or effective port differ.
-Host comparison is case-insensitive, and missing ports use the default port for
-`http` or `https`. Other schemes do not receive implicit default ports.
+Host comparison is case-insensitive, and bracketed IPv6 literals are
+canonicalized to their RFC 5952 form from any PSR-7 implementation before
+comparison, so equivalent spellings of the same address are same-origin.
+IPvFuture literals and bracketed values that cannot be parsed as an IPv6
+address, such as those carrying zone identifiers, still compare as
+case-insensitive text. Missing ports use the default port for `http` or
+`https`. Other schemes do not receive implicit default ports.
 
 This helper only compares URI origins. It does not implement redirect handling
 or credential policy.
@@ -343,6 +381,21 @@ The following normalizations are available:
     the URI.
 
     Example: `?lang=en&article=fred` → `?article=fred&lang=en`
+
+- `UriNormalizer::CANONICALIZE_IPV6_HOST`
+
+    Canonicalizes IPv6 hosts to their RFC 5952 form. IPv6 addresses allow
+    leading zeros and multiple placements of the `::` elision, so the same
+    address has many textual spellings. The canonical form is required for
+    IPv6 literals in URIs by RFC 5952 Section 6 and never changes what the URI
+    refers to. Native `Uri` instances already guarantee canonical output; for
+    other implementations, the canonical host is requested through
+    `withHost()` and the result is kept only when the returned `getHost()`
+    exactly matches the requested spelling, otherwise this step leaves the URI
+    unchanged while other selected normalizations still apply, and setter
+    exceptions propagate.
+
+    Example: `http://[::0:0a]/` → `http://[::a]/`
 
 ### `GuzzleHttp\Psr7\UriNormalizer::isEquivalent`
 

--- a/src/Rfc3986.php
+++ b/src/Rfc3986.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace GuzzleHttp\Psr7;
 
 /**
- * Syntax predicates for the URI grammar defined by RFC 3986.
+ * Syntax predicates and canonicalization helpers for the URI grammar defined
+ * by RFC 3986.
  */
 final class Rfc3986
 {
@@ -118,6 +119,115 @@ final class Rfc3986
         return strlen($normalized) <= 5 && (int) $normalized <= 0xFFFF;
     }
 
+    /**
+     * Returns the RFC 5952 canonical form of a valid IPv6 address.
+     *
+     * The address must be a valid textual IPv6 address without brackets and
+     * without a zone identifier, such as the inside of an IP-literal accepted
+     * by `isValidHost()`. Canonicalization lowercases the hexadecimal fields,
+     * suppresses leading zeros, and collapses the longest run of two or more
+     * zero fields (the leftmost on a tie) with `::`. Embedded dotted-decimal
+     * notation follows the rendering policy of BIND-derived `inet_ntop()`
+     * implementations and curl: exactly the IPv4-mapped (`::ffff:0:0/96`) and
+     * deprecated IPv4-compatible (`::/96`) layouts use it, while other
+     * embedded-IPv4 forms, including translated (NAT64) well-known prefixes
+     * such as `64:ff9b::/96` (RFC 6052), serialize in pure hexadecimal fields.
+     *
+     * Validation is strict and platform-independent: the address is checked
+     * against the RFC 3986 `IPv6address` grammar with PHP's
+     * `FILTER_VALIDATE_IP` filter and parsed in pure PHP, so spellings that
+     * only some platform parsers accept, such as the zero-padded dotted octets
+     * in `::ffff:192.168.001.001`, are rejected everywhere.
+     *
+     * @throws \InvalidArgumentException If the address cannot be parsed.
+     *
+     * @see https://datatracker.ietf.org/doc/html/rfc5952#section-4
+     */
+    public static function canonicalizeIpv6(string $address): string
+    {
+        $canonical = self::tryCanonicalizeIpv6($address);
+        if ($canonical === null) {
+            throw new \InvalidArgumentException('Invalid IPv6 address');
+        }
+
+        return $canonical;
+    }
+
+    /**
+     * Returns the RFC 5952 canonical form of a valid IPv6 address, or null
+     * when the address cannot be parsed.
+     *
+     * @internal
+     */
+    public static function tryCanonicalizeIpv6(string $address): ?string
+    {
+        // Platform parsers disagree on which spellings are valid: Apple libc
+        // and OpenBSD inet_pton() accept zero-padded dotted octets such as
+        // "::ffff:192.168.001.001", and macOS additionally accepts and silently
+        // strips zone IDs ("fe80::1%eth0"), while glibc, musl, and PHP's own
+        // filter reject both. Origin classification built on this helper must
+        // fail closed and must not vary by operating system, so the address is
+        // validated with the platform-independent FILTER_VALIDATE_IP filter and
+        // parsed in pure PHP; no OS parser is consulted.
+        if (\filter_var($address, \FILTER_VALIDATE_IP, \FILTER_FLAG_IPV6) === false) {
+            return null;
+        }
+
+        $words = self::parseIpv6Words($address);
+        if ($words === null) {
+            return null;
+        }
+
+        // Find the longest run of two or more zero fields; ties keep the
+        // leftmost run per RFC 5952 section 4.2.3.
+        $bestStart = 0;
+        $bestLen = 0;
+        $start = -1;
+        foreach ($words as $i => $word) {
+            if ($word !== 0) {
+                $start = -1;
+                continue;
+            }
+            if ($start === -1) {
+                $start = $i;
+            }
+            if ($i - $start + 1 > $bestLen) {
+                $bestStart = $start;
+                $bestLen = $i - $start + 1;
+            }
+        }
+        if ($bestLen < 2) {
+            $bestLen = 0;
+        }
+
+        // RFC 5952 section 5: embedded IPv4 notation for IPv4-mapped
+        // (::ffff:0:0/96) and IPv4-compatible (::/96) addresses, the same
+        // condition BIND-derived inet_ntop() and curl use. bestStart must be
+        // zero: a five or six field zero run elsewhere is not an IPv4 prefix.
+        $mixed = $bestStart === 0
+            && ($bestLen === 6 || ($bestLen === 5 && $words[5] === 0xFFFF));
+
+        $groups = [];
+        for ($i = 0, $n = $mixed ? 6 : 8; $i < $n; ++$i) {
+            $groups[] = dechex($words[$i]);
+        }
+        if ($mixed) {
+            $groups[] = sprintf(
+                '%d.%d.%d.%d',
+                $words[6] >> 8,
+                $words[6] & 0xFF,
+                $words[7] >> 8,
+                $words[7] & 0xFF
+            );
+        }
+
+        if ($bestLen === 0) {
+            return implode(':', $groups);
+        }
+
+        return implode(':', array_slice($groups, 0, $bestStart)).'::'.implode(':', array_slice($groups, $bestStart + $bestLen));
+    }
+
     private static function hasValidHostPercentEncoding(string $host): bool
     {
         // Mirror of the raw reg-name policy above for percent-encoded octets:
@@ -148,5 +258,104 @@ final class Rfc3986
         // RFC 6874 IPv6 zone identifiers are intentionally not supported here.
         // Bracketed hosts are validated as IPv6 or IPvFuture only.
         return preg_match('/^v[0-9a-f]+\.['.self::CHAR_UNRESERVED.self::CHAR_SUB_DELIMS.':]+$/iD', $address) === 1;
+    }
+
+    /**
+     * Parses a textual IPv6 address into its eight 16-bit words, or null
+     * when the text is not a structurally valid address.
+     *
+     * The grammar enforced here is the RFC 3986 `IPv6address` rule: one to four
+     * hexadecimal digits per field, at most one `::` eliding one or more zero
+     * fields, and an optional dotted-decimal tail of four octets (0-255, no
+     * leading zeros) as the final 32 bits. FILTER_VALIDATE_IP accepts exactly
+     * this grammar, so the filter guard in tryCanonicalizeIpv6() and this
+     * parser always agree and the null paths here can only fail closed.
+     *
+     * @return list<int>|null
+     */
+    private static function parseIpv6Words(string $address): ?array
+    {
+        // A dotted-decimal tail is only valid as the final 32 bits, after the
+        // final colon. Rewrite it into its two hexadecimal fields so the
+        // remainder of the parse handles hexadecimal fields only.
+        $dot = strpos($address, '.');
+        if ($dot !== false) {
+            $colon = strrpos($address, ':');
+            if ($colon === false || $colon > $dot) {
+                return null;
+            }
+            $octets = explode('.', substr($address, $colon + 1));
+            if (count($octets) !== 4) {
+                return null;
+            }
+            $bytes = [];
+            foreach ($octets as $octet) {
+                if ($octet === '' || strlen($octet) > 3 || !ctype_digit($octet)) {
+                    return null;
+                }
+                if ($octet[0] === '0' && $octet !== '0') {
+                    return null;
+                }
+                $byte = (int) $octet;
+                if ($byte > 255) {
+                    return null;
+                }
+                $bytes[] = $byte;
+            }
+            $address = substr($address, 0, $colon + 1)
+                .dechex(($bytes[0] << 8) | $bytes[1])
+                .':'
+                .dechex(($bytes[2] << 8) | $bytes[3]);
+        }
+
+        $halves = explode('::', $address);
+        if (count($halves) > 2) {
+            return null;
+        }
+
+        $head = self::parseHexFields($halves[0]);
+        if ($head === null) {
+            return null;
+        }
+
+        if (count($halves) === 1) {
+            return count($head) === 8 ? $head : null;
+        }
+
+        $tail = self::parseHexFields($halves[1]);
+        if ($tail === null) {
+            return null;
+        }
+
+        // The "::" must elide at least one zero field.
+        $elided = 8 - count($head) - count($tail);
+        if ($elided < 1) {
+            return null;
+        }
+
+        return array_merge($head, array_fill(0, $elided, 0), $tail);
+    }
+
+    /**
+     * Parses a colon-separated run of 16-bit hexadecimal fields, or null
+     * when a field is empty, longer than four digits, or not hexadecimal.
+     *
+     * @return list<int>|null
+     */
+    private static function parseHexFields(string $fields): ?array
+    {
+        if ($fields === '') {
+            return [];
+        }
+
+        $words = [];
+        foreach (explode(':', $fields) as $field) {
+            if ($field === '' || strlen($field) > 4 || !ctype_xdigit($field)) {
+                return null;
+            }
+            $words[] = intval($field, 16);
+        }
+
+        return $words;
     }
 }

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -760,6 +760,17 @@ class Uri implements UriInterface, \JsonSerializable
         }
         self::assertValidHost($filtered);
 
+        if (str_starts_with($filtered, '[') && !str_starts_with($filtered, '[v')) {
+            // assertValidHost() accepted this bracketed value with the same
+            // filter_var() predicate tryCanonicalizeIpv6() validates with, and
+            // its pure-PHP parse cannot fail on filter-accepted text, so the
+            // null guard is defense in depth only.
+            $canonical = Rfc3986::tryCanonicalizeIpv6(substr($filtered, 1, -1));
+            if ($canonical !== null) {
+                $filtered = '['.$canonical.']';
+            }
+        }
+
         return $filtered;
     }
 

--- a/src/UriComparator.php
+++ b/src/UriComparator.php
@@ -19,8 +19,13 @@ final class UriComparator
      * respect to an original URI.
      *
      * Two URIs are cross-origin when their scheme, host, or effective port
-     * differ. Host comparison is case-insensitive, and missing ports use the
-     * default port for `http` or `https`. Other schemes do not receive implicit
+     * differ. Host comparison is case-insensitive, and bracketed IPv6 literals
+     * are canonicalized to their RFC 5952 form from any PSR-7 implementation
+     * before comparison, so equivalent spellings of the same address are
+     * same-origin. IPvFuture literals and bracketed values that cannot be
+     * parsed as an IPv6 address, such as those carrying zone identifiers,
+     * still compare as case-insensitive text. Missing ports use the default
+     * port for `http` or `https`. Other schemes do not receive implicit
      * default ports.
      *
      * This helper only compares URI origins. It does not implement redirect
@@ -28,7 +33,7 @@ final class UriComparator
      */
     public static function isCrossOrigin(UriInterface $original, UriInterface $modified): bool
     {
-        if (!Utils::caselessEquals($original->getHost(), $modified->getHost())) {
+        if (!Utils::caselessEquals(self::normalizeHost($original), self::normalizeHost($modified))) {
             return true;
         }
 
@@ -41,6 +46,28 @@ final class UriComparator
         }
 
         return false;
+    }
+
+    private static function normalizeHost(UriInterface $uri): string
+    {
+        $host = $uri->getHost();
+        if (!str_starts_with($host, '[') || !str_ends_with($host, ']')) {
+            return $host;
+        }
+
+        // Foreign UriInterface implementations may carry non-canonical IPv6
+        // spellings; canonicalize what is unambiguously an IPv6 address so
+        // equivalent literals compare as same-origin, and leave IPvFuture,
+        // zone-identifier, and invalid text to the caseless textual
+        // comparison. Validation is platform-independent, so a spelling only
+        // some OS parsers accept, such as zero-padded dotted octets, is
+        // cross-origin everywhere instead of same-origin on some systems.
+        $canonical = Rfc3986::tryCanonicalizeIpv6(substr($host, 1, -1));
+        if ($canonical === null) {
+            return $host;
+        }
+
+        return '['.$canonical.']';
     }
 
     private static function computePort(UriInterface $uri): ?int

--- a/src/UriNormalizer.php
+++ b/src/UriNormalizer.php
@@ -25,7 +25,8 @@ final class UriNormalizer
         self::CONVERT_EMPTY_PATH |
         self::REMOVE_DEFAULT_HOST |
         self::REMOVE_DEFAULT_PORT |
-        self::REMOVE_DOT_SEGMENTS;
+        self::REMOVE_DOT_SEGMENTS |
+        self::CANONICALIZE_IPV6_HOST;
 
     /**
      * All letters within a percent-encoding triplet (e.g., "%3A") are
@@ -114,6 +115,23 @@ final class UriNormalizer
     public const SORT_QUERY_PARAMETERS = 128;
 
     /**
+     * Canonicalizes IPv6 hosts to their RFC 5952 form.
+     *
+     * IPv6 addresses allow leading zeros and multiple placements of the `::`
+     * elision, so the same address has many textual spellings. The canonical
+     * form is required for IPv6 literals in URIs by RFC 5952 Section 6 and
+     * never changes what the URI refers to. Native `Uri` instances already
+     * guarantee canonical output; for other implementations, the canonical
+     * host is requested through `withHost()` and the result is kept only when
+     * the returned `getHost()` exactly matches the requested spelling,
+     * otherwise this step leaves the URI unchanged while other selected
+     * normalizations still apply, and setter exceptions propagate.
+     *
+     * Example: http://[::0:0a]/ → http://[::a]/
+     */
+    public const CANONICALIZE_IPV6_HOST = 256;
+
+    /**
      * Returns a normalized URI.
      *
      * The scheme and host component are already normalized to lowercase per
@@ -183,6 +201,10 @@ final class UriNormalizer
             $uri = $uri->withQuery(implode('&', $queryKeyValues));
         }
 
+        if ($flags & self::CANONICALIZE_IPV6_HOST) {
+            $uri = self::canonicalizeIpv6Host($uri);
+        }
+
         return $uri;
     }
 
@@ -247,6 +269,32 @@ final class UriNormalizer
         }
 
         return $normalized;
+    }
+
+    private static function canonicalizeIpv6Host(UriInterface $uri): UriInterface
+    {
+        $host = $uri->getHost();
+        if (!str_starts_with($host, '[') || !str_ends_with($host, ']')) {
+            return $uri;
+        }
+
+        // Foreign UriInterface implementations may carry IPvFuture literals,
+        // IPv6 zone identifiers, uppercase text, or invalid spellings;
+        // tryCanonicalizeIpv6() canonicalizes only what is unambiguously an
+        // IPv6 address and leaves everything else untouched.
+        $canonical = Rfc3986::tryCanonicalizeIpv6(substr($host, 1, -1));
+        if ($canonical === null || '['.$canonical.']' === $host) {
+            return $uri;
+        }
+
+        $candidate = $uri->withHost('['.$canonical.']');
+        // Normalization must never corrupt a component, so keep the original
+        // host when the implementation does not retain the canonical form.
+        if ($candidate->getHost() !== '['.$canonical.']') {
+            return $uri;
+        }
+
+        return $candidate;
     }
 
     private function __construct()

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -459,6 +459,15 @@ class MessageTest extends TestCase
         self::assertSame('https://[::1]', (string) $request->getUri());
     }
 
+    public function testParsesOptionsAsteriskFormRequestTargetWithNonCanonicalIpv6Host(): void
+    {
+        $request = Psr7\Message::parseRequest("OPTIONS * HTTP/1.1\r\nHost: [0:0::1]:443\r\n\r\n");
+
+        self::assertSame('*', $request->getRequestTarget());
+        self::assertSame('[0:0::1]:443', $request->getHeaderLine('Host'));
+        self::assertSame('https://[::1]', (string) $request->getUri());
+    }
+
     public function testParsesOptionsAsteriskFormRequestTargetWithoutHost(): void
     {
         $req = "OPTIONS * HTTP/1.1\r\n\r\n";

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -577,6 +577,12 @@ class RequestTest extends TestCase
         self::assertSame('foo.com:8125', $r->getHeaderLine('host'));
     }
 
+    public function testAddsCanonicalIpv6HostAndPortToHeader(): void
+    {
+        $r = new Request('GET', 'http://[0:0::1]:8080/bar');
+        self::assertSame('[::1]:8080', $r->getHeaderLine('host'));
+    }
+
     public function testGeneratedHostHeaderRejectsInvalidUriHostFromCustomUri(): void
     {
         $uri = $this->createMock(UriInterface::class);

--- a/tests/Rfc3986Test.php
+++ b/tests/Rfc3986Test.php
@@ -157,6 +157,7 @@ class Rfc3986Test extends TestCase
         yield 'IPv6 uncompressed' => ['[2001:db8:0:0:0:0:0:1]', true];
         yield 'IPv4-mapped IPv6 literal' => ['[::ffff:192.0.2.1]', true];
         yield 'IPv6 with general ls32 IPv4 form' => ['[2001:db8::192.168.0.1]', true];
+        yield 'IPv6 v4-mapped tail with zero-padded octets' => ['[::ffff:192.168.001.001]', false];
         yield 'IPv6 with percent-encoded zone id' => ['[fe80::1%25eth0]', false];
         yield 'IPv6 with raw zone id' => ['[fe80::1%eth0]', false];
         yield 'IPv6 with trailing garbage inside brackets' => ['[::1extra]', false];
@@ -243,5 +244,84 @@ class Rfc3986Test extends TestCase
         yield 'utf8 e-acute' => ["\xC3\xA9", false];
         yield 'arabic-indic digits' => ["\xD9\xA8\xD9\xA0", false];
         yield 'fullwidth digits' => ["\xEF\xBC\x91\xEF\xBC\x92\xEF\xBC\x93", false];
+    }
+
+    /**
+     * @dataProvider canonicalIpv6Provider
+     */
+    public function testCanonicalizeIpv6(string $address, string $expected): void
+    {
+        self::assertSame($expected, Rfc3986::canonicalizeIpv6($address));
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: string}>
+     */
+    public static function canonicalIpv6Provider(): iterable
+    {
+        // RFC 5952 section 4.1: leading zeros are suppressed; section 4.3:
+        // hexadecimal digits are lowercase.
+        yield 'leading zeros and uppercase hex' => ['::0:0A', '::a'];
+        yield 'already canonical loopback' => ['::1', '::1'];
+        yield 'unspecified address' => ['::', '::'];
+
+        // RFC 5952 section 4.2: the longest run of two or more zero fields is
+        // collapsed with "::"; the leftmost run wins a tie; a single zero
+        // field is never collapsed.
+        yield 'full form collapses to loopback' => ['0:0:0:0:0:0:0:1', '::1'];
+        yield 'longest zero run wins' => ['1:0:0:1:0:0:0:1', '1:0:0:1::1'];
+        yield 'leftmost zero run wins a tie' => ['1:0:0:1:0:0:1:1', '1::1:0:0:1:1'];
+        yield 'single zero field is not collapsed' => ['1:0:1:1:1:1:1:1', '1:0:1:1:1:1:1:1'];
+
+        // RFC 5952 section 5: IPv4-mapped and IPv4-compatible addresses use
+        // embedded dotted-decimal notation; other embedded IPv4 text is
+        // rewritten to hexadecimal fields.
+        yield 'v4-mapped from pure hex' => ['::ffff:7f00:1', '::ffff:127.0.0.1'];
+        yield 'v4-mapped stays dotted' => ['::ffff:127.0.0.1', '::ffff:127.0.0.1'];
+        yield 'v4-compatible from pure hex' => ['::102:304', '::1.2.3.4'];
+        yield 'v4-compatible low bytes collapse' => ['::0.0.0.7', '::7'];
+        yield 'embedded v4 after hextets becomes hex' => ['2001:db8:3:4::192.0.2.33', '2001:db8:3:4::c000:221'];
+        yield 'full form with dotted tail becomes hex' => ['1:2:3:4:5:6:1.2.3.4', '1:2:3:4:5:6:102:304'];
+        yield 'compression covering a single field' => ['1:2:3:4:5:6:7::', '1:2:3:4:5:6:7:0'];
+    }
+
+    /**
+     * @dataProvider invalidIpv6Provider
+     */
+    public function testCanonicalizeIpv6RejectsInvalidAddresses(string $address): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        Rfc3986::canonicalizeIpv6($address);
+    }
+
+    /**
+     * @return iterable<string, array{0: string}>
+     */
+    public static function invalidIpv6Provider(): iterable
+    {
+        yield 'empty' => [''];
+        yield 'colons only' => [':::'];
+        yield 'plain IPv4 address' => ['1.2.3.4'];
+        yield 'bracketed address' => ['[::1]'];
+        yield 'reg-name' => ['example.com'];
+        yield 'percent-encoded zone id' => ['fe80::1%25eth0'];
+        yield 'raw zone id' => ['fe80::1%eth0'];
+        yield 'too many groups' => ['1:2:3:4:5:6:7:8:9'];
+        yield 'trailing space' => ['::1 '];
+        yield 'trailing newline' => ["::1\n"];
+
+        // Platform inet_pton() implementations disagree on these spellings
+        // (Apple libc and OpenBSD accept them, glibc and musl reject them); the
+        // platform-independent validation rejects them everywhere.
+        yield 'v4-mapped tail with zero-padded octets' => ['::ffff:192.168.001.001'];
+        yield 'v4-compatible tail with zero-padded octets' => ['::192.168.001.001'];
+        yield 'general dotted tail with zero-padded octet' => ['2001:db8::192.168.0.001'];
+        yield 'dotted tail with zero-padded first octet' => ['::01.2.3.4'];
+        yield 'dotted tail with zero-padded last octet' => ['::1.2.3.04'];
+
+        yield 'dotted tail not in final position' => ['::1.2.3.4:5'];
+        yield 'dotted tail overflowing eight fields' => ['1:2:3:4:5:6:7:1.2.3.4'];
+        yield 'compression covering zero fields' => ['1:2:3:4:5:6:7:8::'];
     }
 }

--- a/tests/ServerRequestTest.php
+++ b/tests/ServerRequestTest.php
@@ -489,6 +489,10 @@ class ServerRequestTest extends TestCase
                 'https://[::1]:8000/blog/article.php?id=10&user=foo',
                 array_merge($server, ['HTTP_HOST' => '[::1]:8000']),
             ],
+            'IPv6 host with non-canonical spelling' => [
+                'https://[::1]:8000/blog/article.php?id=10&user=foo',
+                array_merge($server, ['HTTP_HOST' => '[::0:1]:8000']),
+            ],
             'Invalid host' => [
                 'https://www.example.org/blog/article.php?id=10&user=foo',
                 array_merge($server, ['HTTP_HOST' => 'a:b']),

--- a/tests/UriComparatorTest.php
+++ b/tests/UriComparatorTest.php
@@ -41,12 +41,71 @@ class UriComparatorTest extends TestCase
             ['https://example.com/123', 'https://www.example.com/', true],
             ['https://example.com/123', 'https://example.com:444/', true],
             ['https://example.com:443/123', 'https://example.com:444/', true],
+            ['http://[::1]/123', 'http://[0:0:0:0:0:0:0:1]/', false],
+            ['http://[::1]/123', 'http://[::2]/', true],
             ['custom://example.com/', 'custom://example.com:80/', true],
             ['custom://example.com/', 'custom://example.com/other', false],
             ['ftp://example.com/', 'ftp://example.com:80/', true],
             ['ws://example.com/', 'ws://example.com:80/', true],
             ['wss://example.com/', 'wss://example.com:443/', true],
         ];
+    }
+
+    public function testForeignNonCanonicalIpv6HostIsSameOrigin(): void
+    {
+        $foreign = $this->createMock(UriInterface::class);
+        $foreign->method('getHost')->willReturn('[0:0:0:0:0:0:0:1]');
+        $foreign->method('getScheme')->willReturn('http');
+        $foreign->method('getPort')->willReturn(null);
+
+        self::assertFalse(UriComparator::isCrossOrigin($foreign, new Uri('http://[::1]/')));
+        self::assertFalse(UriComparator::isCrossOrigin(new Uri('http://[::1]/'), $foreign));
+    }
+
+    public function testForeignUppercaseIpv6HostIsSameOrigin(): void
+    {
+        $foreign = $this->createMock(UriInterface::class);
+        $foreign->method('getHost')->willReturn('[FE80::1]');
+        $foreign->method('getScheme')->willReturn('http');
+        $foreign->method('getPort')->willReturn(null);
+
+        self::assertFalse(UriComparator::isCrossOrigin($foreign, new Uri('http://[fe80::1]/')));
+    }
+
+    public function testForeignIpv6HostWithZoneIdComparesTextually(): void
+    {
+        $foreign = $this->createMock(UriInterface::class);
+        $foreign->method('getHost')->willReturn('[fe80::1%25eth0]');
+        $foreign->method('getScheme')->willReturn('http');
+        $foreign->method('getPort')->willReturn(null);
+
+        self::assertTrue(UriComparator::isCrossOrigin($foreign, new Uri('http://[fe80::1]/')));
+    }
+
+    public function testForeignIpv6HostWithZeroPaddedDottedOctetsComparesTextually(): void
+    {
+        $foreign = $this->createMock(UriInterface::class);
+        $foreign->method('getHost')->willReturn('[::ffff:192.168.001.001]');
+        $foreign->method('getScheme')->willReturn('http');
+        $foreign->method('getPort')->willReturn(null);
+
+        self::assertTrue(UriComparator::isCrossOrigin($foreign, new Uri('http://[::ffff:192.168.1.1]/')));
+        self::assertTrue(UriComparator::isCrossOrigin(new Uri('http://[::ffff:192.168.1.1]/'), $foreign));
+    }
+
+    public function testForeignIpvFutureHostsCompareCaselessly(): void
+    {
+        $original = $this->createMock(UriInterface::class);
+        $original->method('getHost')->willReturn('[v1.ab]');
+        $original->method('getScheme')->willReturn('http');
+        $original->method('getPort')->willReturn(null);
+
+        $modified = $this->createMock(UriInterface::class);
+        $modified->method('getHost')->willReturn('[V1.AB]');
+        $modified->method('getScheme')->willReturn('http');
+        $modified->method('getPort')->willReturn(null);
+
+        self::assertFalse(UriComparator::isCrossOrigin($original, $modified));
     }
 
     public function testNonHttpSchemeMissingPortDoesNotUseSchemeDefault(): void

--- a/tests/UriNormalizerTest.php
+++ b/tests/UriNormalizerTest.php
@@ -245,6 +245,119 @@ class UriNormalizerTest extends TestCase
         self::assertSame('?a&a=a&a=b&a=c&a=d&b=a&b=b&b=c', (string) $normalizedUri);
     }
 
+    public function testCanonicalizeIpv6Host(): void
+    {
+        $uri = $this->createMock(UriInterface::class);
+        $uri->expects(self::any())->method('getHost')->willReturn('[::0:0A]');
+        $uri->expects(self::once())->method('withHost')->with('[::a]')->willReturn(new Uri('http://[::a]'));
+
+        $normalizedUri = UriNormalizer::normalize($uri, UriNormalizer::CANONICALIZE_IPV6_HOST);
+
+        self::assertInstanceOf(UriInterface::class, $normalizedUri);
+        self::assertSame('[::a]', $normalizedUri->getHost());
+    }
+
+    public function testCanonicalizeIpv6HostLowercasesForeignHosts(): void
+    {
+        $uri = $this->createMock(UriInterface::class);
+        $uri->expects(self::any())->method('getHost')->willReturn('[FE80::1]');
+        $uri->expects(self::once())->method('withHost')->with('[fe80::1]')->willReturn(new Uri('http://[fe80::1]'));
+
+        $normalizedUri = UriNormalizer::normalize($uri, UriNormalizer::CANONICALIZE_IPV6_HOST);
+
+        self::assertInstanceOf(UriInterface::class, $normalizedUri);
+        self::assertSame('[fe80::1]', $normalizedUri->getHost());
+    }
+
+    public function testCanonicalizeIpv6HostKeepsHostsTheImplementationCannotRetain(): void
+    {
+        $result = $this->createMock(UriInterface::class);
+        $result->expects(self::any())->method('getHost')->willReturn('[::0:0a]');
+
+        $uri = $this->createMock(UriInterface::class);
+        $uri->expects(self::any())->method('getHost')->willReturn('[::0:0A]');
+        $uri->expects(self::once())->method('withHost')->with('[::a]')->willReturn($result);
+
+        $normalizedUri = UriNormalizer::normalize($uri, UriNormalizer::CANONICALIZE_IPV6_HOST);
+
+        self::assertSame($uri, $normalizedUri);
+    }
+
+    public function testCanonicalizeIpv6HostDiscardsUnrelatedSetterResults(): void
+    {
+        $result = $this->createMock(UriInterface::class);
+        $result->expects(self::any())->method('getHost')->willReturn('attacker.example');
+
+        $uri = $this->createMock(UriInterface::class);
+        $uri->expects(self::any())->method('getHost')->willReturn('[::0:0A]');
+        $uri->expects(self::once())->method('withHost')->with('[::a]')->willReturn($result);
+
+        $normalizedUri = UriNormalizer::normalize($uri, UriNormalizer::CANONICALIZE_IPV6_HOST);
+
+        self::assertSame($uri, $normalizedUri);
+    }
+
+    public function testCanonicalizeIpv6HostPropagatesSetterExceptions(): void
+    {
+        $uri = $this->createMock(UriInterface::class);
+        $uri->expects(self::any())->method('getHost')->willReturn('[::0:0A]');
+        $uri->expects(self::once())->method('withHost')->with('[::a]')->willThrowException(new \RuntimeException('setter failed'));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('setter failed');
+
+        UriNormalizer::normalize($uri, UriNormalizer::CANONICALIZE_IPV6_HOST);
+    }
+
+    public function testCanonicalizeIpv6HostFallbackPreservesEarlierNormalizations(): void
+    {
+        // CONVERT_EMPTY_PATH succeeds first; the host step is then discarded
+        // because the implementation does not retain the canonical spelling.
+        $withPath = $this->createMock(UriInterface::class);
+        $withPath->expects(self::any())->method('getScheme')->willReturn('http');
+        $withPath->expects(self::any())->method('getPath')->willReturn('/');
+        $withPath->expects(self::any())->method('getHost')->willReturn('[::0:0A]');
+        $withPath->expects(self::once())->method('withHost')->with('[::a]')->willReturnSelf();
+
+        $uri = $this->createMock(UriInterface::class);
+        $uri->expects(self::any())->method('getScheme')->willReturn('http');
+        $uri->expects(self::any())->method('getPath')->willReturn('');
+        $uri->expects(self::once())->method('withPath')->with('/')->willReturn($withPath);
+
+        $normalizedUri = UriNormalizer::normalize($uri, UriNormalizer::CONVERT_EMPTY_PATH | UriNormalizer::CANONICALIZE_IPV6_HOST);
+
+        self::assertSame($withPath, $normalizedUri);
+        self::assertSame('/', $normalizedUri->getPath());
+        self::assertSame('[::0:0A]', $normalizedUri->getHost());
+    }
+
+    /**
+     * @dataProvider getNonCanonicalizableHosts
+     */
+    public function testCanonicalizeIpv6HostLeavesOtherHostsUntouched(string $host): void
+    {
+        $uri = $this->createMock(UriInterface::class);
+        $uri->expects(self::any())->method('getHost')->willReturn($host);
+        $uri->expects(self::never())->method('withHost');
+
+        $normalizedUri = UriNormalizer::normalize($uri, UriNormalizer::CANONICALIZE_IPV6_HOST);
+
+        self::assertSame($uri, $normalizedUri);
+    }
+
+    public static function getNonCanonicalizableHosts(): iterable
+    {
+        return [
+            ['example.com'],
+            ['[::1]'],
+            ['[v1.fe]'],
+            ['[fe80::1%25eth0]'],
+            ['::0:1'],
+            ['[gggg::1]'],
+            ['[::ffff:192.168.001.001]'],
+        ];
+    }
+
     /**
      * @dataProvider getEquivalentTestCases
      */
@@ -268,6 +381,9 @@ class UriNormalizerTest extends TestCase
             ['urn:/..//x', 'urn:/.//x', true],
             ['http:/a/..//b', 'http:/%61/..//b', true],
             ['http://example.org/path#fr%61g%c2%b1', 'http://example.org/path#frag%C2%B1', true],
+            ['http://[::0:1]/', 'http://[::1]/', true],
+            ['http://[0:0:0:0:0:0:0:1]/', 'http://[::1]/', true],
+            ['http://[::1]/', 'http://[::2]/', false],
             ['https://example.org/', 'http://example.org/', false],
             ['https://example.org/', '//example.org/', false],
             ['//example.org/', '//example.org/', true],

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -488,6 +488,7 @@ class UriTest extends TestCase
         yield 'underscore' => ['foo_bar.example', 'foo_bar.example'];
         yield 'sub-delims' => ['foo!$&\'()*+,;=.example', 'foo!$&\'()*+,;=.example'];
         yield 'ipv6 literal' => ['[::1]', '[::1]'];
+        yield 'ipv6 uncompressed' => ['[2001:db8:0:0:0:0:0:1]', '[2001:db8::1]'];
         yield 'ipvfuture literal' => ['[v7.a:b]', '[v7.a:b]'];
     }
 
@@ -1544,8 +1545,8 @@ class UriTest extends TestCase
 
         yield 'embedded ipv4 after hextets' => [
             'http://[2001:db8:3:4::192.0.2.33]/',
-            'http://[2001:db8:3:4::192.0.2.33]/',
-            '[2001:db8:3:4::192.0.2.33]',
+            'http://[2001:db8:3:4::c000:221]/',
+            '[2001:db8:3:4::c000:221]',
             null,
         ];
 
@@ -1576,6 +1577,47 @@ class UriTest extends TestCase
             '[::ffff:192.0.2.128]',
             null,
         ];
+    }
+
+    /**
+     * @dataProvider getIpv6CanonicalizationTestCases
+     */
+    public function testCanonicalizesIpv6Hosts(string $input, string $expectedHost, string $expectedUri): void
+    {
+        $uri = new Uri($input);
+
+        self::assertSame($expectedHost, $uri->getHost());
+        self::assertSame($expectedUri, (string) $uri);
+    }
+
+    public static function getIpv6CanonicalizationTestCases(): iterable
+    {
+        yield 'leading zeros and case' => ['http://[::0:0A]/', '[::a]', 'http://[::a]/'];
+        yield 'full form' => ['http://[0:0:0:0:0:0:0:1]/', '[::1]', 'http://[::1]/'];
+        yield 'longest zero run wins' => ['http://[1:0:0:1:0:0:0:1]/', '[1:0:0:1::1]', 'http://[1:0:0:1::1]/'];
+        yield 'leftmost zero run wins a tie' => ['http://[1:0:0:1:0:0:1:1]/', '[1::1:0:0:1:1]', 'http://[1::1:0:0:1:1]/'];
+        yield 'single zero field is not collapsed' => ['http://[1:0:1:1:1:1:1:1]/', '[1:0:1:1:1:1:1:1]', 'http://[1:0:1:1:1:1:1:1]/'];
+        yield 'unspecified address' => ['http://[::]/', '[::]', 'http://[::]/'];
+        yield 'v4-mapped from pure hex' => ['http://[::FFFF:7F00:1]/', '[::ffff:127.0.0.1]', 'http://[::ffff:127.0.0.1]/'];
+        yield 'v4-mapped stays dotted' => ['http://[::ffff:127.0.0.1]/', '[::ffff:127.0.0.1]', 'http://[::ffff:127.0.0.1]/'];
+        yield 'v4-compatible from pure hex' => ['http://[::102:304]/', '[::1.2.3.4]', 'http://[::1.2.3.4]/'];
+        yield 'embedded v4 after hextets becomes hex' => ['http://[2001:db8:3:4::192.0.2.33]/', '[2001:db8:3:4::c000:221]', 'http://[2001:db8:3:4::c000:221]/'];
+        yield 'ipvfuture untouched' => ['http://[v1.fe]/', '[v1.fe]', 'http://[v1.fe]/'];
+        yield 'with port' => ['http://[::0:1]:8080/', '[::1]', 'http://[::1]:8080/'];
+    }
+
+    public function testCanonicalizesIpv6HostsFromAllConstructionPaths(): void
+    {
+        $uri = new Uri('http://[0:0::1]/');
+        self::assertSame('[::1]', $uri->getHost());
+        self::assertSame('http://[::1]/', (string) $uri);
+        self::assertSame((string) $uri, (string) new Uri((string) $uri));
+
+        $uri = (new Uri())->withHost('[0:0::1]');
+        self::assertSame('[::1]', $uri->getHost());
+
+        $uri = Uri::fromParts(['scheme' => 'http', 'host' => '[0:0::1]']);
+        self::assertSame('[::1]', $uri->getHost());
     }
 
     /**


### PR DESCRIPTION
The same IPv6 address can be written many ways, and RFC 5952 section 6 requires the canonical text form for IPv6 literals in URIs, so today textual comparisons such as UriNormalizer::isEquivalent() and UriComparator::isCrossOrigin() report false negatives for hosts like [::0:0a] and [::a] that curl happily treats as one destination. This adds a public Rfc3986::canonicalizeIpv6() helper and applies it during host filtering, so getHost() and string output always carry the RFC 5952 form, keeping the section 5 mixed notation for the IPv4-mapped and deprecated IPv4-compatible layouts to match BIND-derived inet_ntop() and the parse-time normalization curl itself performs since 8.11.0, while other embedded forms serialize in pure hexadecimal. A new UriNormalizer::CANONICALIZE_IPV6_HOST flag, included in PRESERVING_NORMALIZATIONS, requests the canonical host from other PSR-7 implementations through withHost() and keeps the result only when the implementation retains the exact spelling, while UriComparator::isCrossOrigin() canonicalizes extracted host text directly, so origin checks give the same answer however an implementation spells the address. IPvFuture literals are untouched, the helper rejects zone identifiers deterministically on every platform, and the behavior change is covered in the changelog and upgrading guide.