### PR TITLE
Apply percent-encoding normalization to URI userinfo and host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Canonicalize IPv6 hosts to RFC 5952 form in `Uri` construction, `fromParts()`, and `withHost()`
 - Canonicalize bracketed IPv6 hosts in `UriComparator::isCrossOrigin()`
 - Reject malformed percent-sequences and percent-encoded bytes forbidden by the URI host policy
+- Extend `CAPITALIZE_PERCENT_ENCODING` and `DECODE_UNRESERVED_CHARACTERS` to userinfo and host
 - Trim header list elements with only spaces, horizontal tabs, and line terminators in `Header::splitList()`
 - Report header parameter PCRE failures explicitly in `Header::parse()`
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -787,6 +787,40 @@ Guzzle PSR-7 stream implementations no longer support native PHP `serialize()`
 or `unserialize()`. Persist stream contents explicitly and recreate streams with
 `Utils::streamFor()` when needed.
 
+#### URI Normalization of Userinfo and Host
+
+`UriNormalizer::CAPITALIZE_PERCENT_ENCODING` and
+`UriNormalizer::DECODE_UNRESERVED_CHARACTERS` now also apply to the userinfo and
+host components. In 2.x, these normalizations only rewrote the path, query, and
+fragment.
+
+Since the host is case-insensitive and PSR-7 requires it to be lowercase, octets
+decoded in the host are lowercased. Reserved percent-encoded octets such as
+`%3A` are never decoded, so component boundaries cannot change, and these two
+flags never modify bracketed IP-literal hosts, which only the separate
+`UriNormalizer::CANONICALIZE_IPV6_HOST` normalization may canonicalize. Both
+flags are part of `UriNormalizer::PRESERVING_NORMALIZATIONS`, so the output of
+`UriNormalizer::normalize()` and the result of `UriNormalizer::isEquivalent()`
+can change for URIs whose userinfo or host contains percent-encoded octets.
+Custom `UriInterface` implementations now receive `withUserInfo()` or
+`withHost()` calls from the normalizer when a normalization changes those
+components; unchanged components are never rewritten. The rewrite is kept only
+when the value returned by the implementation matches the normalized form, and
+a userinfo with an empty user segment is never rewritten. If a setter returns a
+different representation, that rewrite is discarded, while other selected
+normalizations still apply, and setter exceptions propagate. No percent-encoding
+normalization is applied to a component with malformed percent syntax, such as a
+`%` not followed by two hexadecimal digits.
+
+```php
+use GuzzleHttp\Psr7\Uri;
+use GuzzleHttp\Psr7\UriNormalizer;
+
+// 2.x: http://%75ser@ex%61mple.com/
+// 3.0: http://user@example.com/
+(string) UriNormalizer::normalize(new Uri('http://%75ser@ex%61mple.com/'));
+```
+
 1.x to 2.0
 ----------
 

--- a/docs/uri-helpers.md
+++ b/docs/uri-helpers.md
@@ -322,7 +322,16 @@ The following normalizations are available:
 - `UriNormalizer::CAPITALIZE_PERCENT_ENCODING`
 
     All letters within a percent-encoding triplet (e.g., "%3A") are
-    case-insensitive, and should be capitalized.
+    case-insensitive, and should be capitalized. This applies to the userinfo,
+    host, path, query, and fragment components. Bracketed IP-literal hosts are
+    skipped as a legacy tolerance for nonstandard values other implementations
+    may carry; zone-identifier text was briefly valid URI syntax under RFC 6874,
+    which RFC 9844 obsoleted and reverted. The userinfo and host are only
+    rewritten when the value returned by the implementation matches the
+    normalized form, and a userinfo with an empty user segment is never
+    rewritten. No percent-encoding normalization is applied to a component that
+    contains malformed percent syntax, such as a `%` not followed by two
+    hexadecimal digits.
 
     Example: `http://example.org/a%c2%b1b` → `http://example.org/a%C2%B1b`
 
@@ -333,6 +342,17 @@ The following normalizations are available:
     (%30–%39), hyphen (%2D), period (%2E), underscore (%5F), or tilde (%7E)
     should not be created by URI producers and, when found in a URI, should be
     decoded to their corresponding unreserved characters by URI normalizers.
+    This applies to the userinfo, host, path, query, and fragment components.
+    Since the host is case-insensitive and PSR-7 requires it to be lowercase,
+    octets decoded in the host are lowercased (e.g., "%41" becomes "a").
+    Bracketed IP-literal hosts are skipped as a legacy tolerance for nonstandard
+    values other implementations may carry; zone-identifier text was briefly
+    valid URI syntax under RFC 6874, which RFC 9844 obsoleted and reverted. The
+    userinfo and host are only rewritten when the value returned by the
+    implementation matches the normalized form, and a userinfo with an empty
+    user segment is never rewritten. No percent-encoding normalization is
+    applied to a component that contains malformed percent syntax, such as a `%`
+    not followed by two hexadecimal digits.
 
     Example: `http://example.org/%7Eusern%61me/` → `http://example.org/~username/`
 

--- a/src/UriNormalizer.php
+++ b/src/UriNormalizer.php
@@ -30,7 +30,16 @@ final class UriNormalizer
 
     /**
      * All letters within a percent-encoding triplet (e.g., "%3A") are
-     * case-insensitive, and should be capitalized.
+     * case-insensitive, and should be capitalized. This applies to the
+     * userinfo, host, path, query, and fragment components. Bracketed
+     * IP-literal hosts are skipped as a legacy tolerance for nonstandard values
+     * other implementations may carry; zone-identifier text was briefly valid
+     * URI syntax under RFC 6874, which RFC 9844 obsoleted and reverted. The
+     * userinfo and host are only rewritten when the value returned by the
+     * implementation matches the normalized form, and a userinfo with an empty
+     * user segment is never rewritten. No percent-encoding normalization is
+     * applied to a component that contains malformed percent syntax, such as a
+     * `%` not followed by two hexadecimal digits.
      *
      * Example: http://example.org/a%c2%b1b → http://example.org/a%C2%B1b
      */
@@ -43,7 +52,18 @@ final class UriNormalizer
      * and %61–%7A), DIGIT (%30–%39), hyphen (%2D), period (%2E), underscore
      * (%5F), or tilde (%7E) should not be created by URI producers and, when
      * found in a URI, should be decoded to their corresponding unreserved
-     * characters by URI normalizers.
+     * characters by URI normalizers. This applies to the userinfo, host, path,
+     * query, and fragment components. Since the host is case-insensitive and
+     * PSR-7 requires it to be lowercase, octets decoded in the host are
+     * lowercased (e.g., "%41" becomes "a"). Bracketed IP-literal hosts are
+     * skipped as a legacy tolerance for nonstandard values other
+     * implementations may carry; zone-identifier text was briefly valid URI
+     * syntax under RFC 6874, which RFC 9844 obsoleted and reverted. The
+     * userinfo and host are only rewritten when the value returned by the
+     * implementation matches the normalized form, and a userinfo with an empty
+     * user segment is never rewritten. No percent-encoding normalization is
+     * applied to a component that contains malformed percent syntax, such as a
+     * `%` not followed by two hexadecimal digits.
      *
      * Example: http://example.org/%7Eusern%61me/ → http://example.org/~username/
      */
@@ -237,6 +257,9 @@ final class UriNormalizer
             return Utils::asciiToUpper($match[0]);
         };
 
+        $uri = self::withNormalizedUserInfo($uri, $regex, $callback);
+        $uri = self::withNormalizedHost($uri, $regex, $callback);
+
         return $uri
             ->withPath(self::normalizePercentEncodingInComponent(Uri::rawPath($uri), $regex, $callback))
             ->withQuery(self::normalizePercentEncodingInComponent($uri->getQuery(), $regex, $callback))
@@ -251,6 +274,16 @@ final class UriNormalizer
             return rawurldecode($match[0]);
         };
 
+        // The host is case-insensitive and PSR-7 requires it to be lowercase,
+        // so decoded ALPHA octets (e.g. "%41") must land lowercase even for
+        // implementations whose withHost() does not normalize the case.
+        $hostCallback = function (array $match): string {
+            return Utils::asciiToLower(rawurldecode($match[0]));
+        };
+
+        $uri = self::withNormalizedUserInfo($uri, $regex, $callback);
+        $uri = self::withNormalizedHost($uri, $regex, $hostCallback);
+
         return $uri
             ->withPath(self::normalizePercentEncodingInComponent(Uri::rawPath($uri), $regex, $callback))
             ->withQuery(self::normalizePercentEncodingInComponent($uri->getQuery(), $regex, $callback))
@@ -260,8 +293,97 @@ final class UriNormalizer
     /**
      * @param callable(array): string $callback
      */
+    private static function withNormalizedUserInfo(UriInterface $uri, string $regex, callable $callback): UriInterface
+    {
+        $userInfo = $uri->getUserInfo();
+
+        if (!str_contains($userInfo, '%')) {
+            return $uri;
+        }
+
+        $normalized = self::normalizePercentEncodingInComponent($userInfo, $regex, $callback);
+
+        if ($normalized === $userInfo) {
+            return $uri;
+        }
+
+        // Normalization cannot create a colon: decoding is confined to
+        // unreserved characters and capitalization keeps octets encoded. So
+        // splitting on the first colon preserves the user/password boundary.
+        $parts = explode(':', $normalized, 2);
+
+        // PSR-7 defines withUserInfo('') as removing the userinfo, so a
+        // userinfo with an empty user segment (e.g. ":pass") cannot be
+        // expressed through the setter and is preserved as-is instead.
+        if ($parts[0] === '') {
+            return $uri;
+        }
+
+        $candidate = $uri->withUserInfo($parts[0], $parts[1] ?? null);
+
+        // Normalization must never lose or corrupt information, so verify the
+        // representation the setter returned and leave the component untouched
+        // when the implementation cannot represent the normalized form.
+        if ($candidate->getUserInfo() !== $normalized) {
+            return $uri;
+        }
+
+        return $candidate;
+    }
+
+    /**
+     * @param callable(array): string $callback
+     */
+    private static function withNormalizedHost(UriInterface $uri, string $regex, callable $callback): UriInterface
+    {
+        $host = $uri->getHost();
+
+        // Bracketed IP-literal hosts are skipped as a legacy tolerance for
+        // nonstandard values other implementations may carry, such as a zone
+        // identifier in "[fe80::1%25eth0]"; that text was briefly valid URI
+        // syntax under RFC 6874, which RFC 9844 obsoleted and reverted.
+        if (str_starts_with($host, '[') || !str_contains($host, '%')) {
+            return $uri;
+        }
+
+        $normalized = self::normalizePercentEncodingInComponent($host, $regex, $callback);
+
+        if ($normalized === $host) {
+            return $uri;
+        }
+
+        $candidate = $uri->withHost($normalized);
+
+        // Normalization must never lose or corrupt information, so verify the
+        // representation the setter returned and leave the component untouched
+        // when the implementation cannot represent the normalized form.
+        if ($candidate->getHost() !== $normalized) {
+            return $uri;
+        }
+
+        return $candidate;
+    }
+
+    /**
+     * @param callable(array): string $callback
+     */
     private static function normalizePercentEncodingInComponent(string $component, string $regex, callable $callback): string
     {
+        // Decoding a valid triplet that follows a dangling "%" would complete
+        // the malformed sequence into a new valid triplet ("example%6%31com"
+        // becomes "example%61com"), turning malformed text valid and breaking
+        // idempotence, so a component containing malformed percent syntax is
+        // returned unchanged.
+        $malformed = preg_match('/%(?!'.Rfc3986::HEX_OCTET.')/', $component);
+
+        if ($malformed === false) {
+            throw new \RuntimeException('Unable to scan URI component percent-encoding: '.preg_last_error_msg());
+        }
+
+        if ($malformed === 1) {
+            return $component;
+        }
+
         $normalized = preg_replace_callback($regex, $callback, $component);
 
         if ($normalized === null) {

--- a/tests/UriNormalizerTest.php
+++ b/tests/UriNormalizerTest.php
@@ -6,6 +6,7 @@ namespace GuzzleHttp\Tests\Psr7;
 
 use GuzzleHttp\Psr7\Uri;
 use GuzzleHttp\Psr7\UriNormalizer;
+use GuzzleHttp\Psr7\Utils;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\UriInterface;
 
@@ -29,6 +30,54 @@ class UriNormalizerTest extends TestCase
 
         self::assertInstanceOf(UriInterface::class, $normalizedUri);
         self::assertSame("/$expectEncoding?$expectEncoding#$expectEncoding", (string) $normalizedUri);
+    }
+
+    public function testCapitalizePercentEncodingInUserInfo(): void
+    {
+        $uri = new Uri('http://us%2fer:pa%3ass@example.com/');
+
+        self::assertSame('us%2fer:pa%3ass', $uri->getUserInfo(), 'Not normalized automatically beforehand');
+
+        $normalizedUri = UriNormalizer::normalize($uri, UriNormalizer::CAPITALIZE_PERCENT_ENCODING);
+
+        self::assertInstanceOf(UriInterface::class, $normalizedUri);
+        self::assertSame('http://us%2Fer:pa%3Ass@example.com/', (string) $normalizedUri);
+    }
+
+    public function testCapitalizePercentEncodingInForeignHost(): void
+    {
+        $uri = $this->createMock(UriInterface::class);
+        $uri->expects(self::any())->method('getUserInfo')->willReturn('');
+        $uri->expects(self::any())->method('getHost')->willReturn('ex%c3%a9.example');
+        $uri->expects(self::once())->method('withHost')->with('ex%C3%A9.example')->willReturn(new Uri('http://ex%C3%A9.example'));
+
+        $normalizedUri = UriNormalizer::normalize($uri, UriNormalizer::CAPITALIZE_PERCENT_ENCODING);
+
+        self::assertInstanceOf(UriInterface::class, $normalizedUri);
+        self::assertSame('http://ex%C3%A9.example', (string) $normalizedUri);
+    }
+
+    public function testCapitalizePercentEncodingSkipsUnchangedForeignHost(): void
+    {
+        $uri = $this->createMock(UriInterface::class);
+        $uri->expects(self::any())->method('getUserInfo')->willReturn('');
+        $uri->expects(self::any())->method('getHost')->willReturn('ex%C3%A9.example');
+        $uri->expects(self::never())->method('withHost');
+
+        $normalizedUri = UriNormalizer::normalize($uri, UriNormalizer::CAPITALIZE_PERCENT_ENCODING);
+
+        self::assertInstanceOf(UriInterface::class, $normalizedUri);
+    }
+
+    public function testCapitalizePercentEncodingPreservesLowercasingForeignHost(): void
+    {
+        $uri = new UriNormalizerForeignUri('', 'ex%c3%a9.example');
+
+        $normalizedUri = UriNormalizer::normalize($uri, UriNormalizer::CAPITALIZE_PERCENT_ENCODING);
+
+        self::assertInstanceOf(UriInterface::class, $normalizedUri);
+        self::assertSame('ex%c3%a9.example', $normalizedUri->getHost());
+        self::assertSame($uri, $normalizedUri, 'The original representation is returned untouched');
     }
 
     /**
@@ -60,6 +109,153 @@ class UriNormalizerTest extends TestCase
         return array_map(function ($char) {
             return [(string) $char];
         }, $unreservedChars);
+    }
+
+    public function testDecodeUnreservedCharactersInUserInfo(): void
+    {
+        $uri = new Uri('http://%75ser:pa%73s@example.com/');
+
+        self::assertSame('%75ser:pa%73s', $uri->getUserInfo(), 'Not normalized automatically beforehand');
+
+        $normalizedUri = UriNormalizer::normalize($uri, UriNormalizer::DECODE_UNRESERVED_CHARACTERS);
+
+        self::assertInstanceOf(UriInterface::class, $normalizedUri);
+        self::assertSame('http://user:pass@example.com/', (string) $normalizedUri);
+    }
+
+    public function testDecodeUnreservedCharactersInHost(): void
+    {
+        $uri = new Uri('http://ex%41mple%2Ecom/');
+
+        self::assertSame('ex%41mple%2Ecom', $uri->getHost(), 'Not normalized automatically beforehand');
+
+        $normalizedUri = UriNormalizer::normalize($uri, UriNormalizer::DECODE_UNRESERVED_CHARACTERS);
+
+        self::assertInstanceOf(UriInterface::class, $normalizedUri);
+        self::assertSame('http://example.com/', (string) $normalizedUri);
+    }
+
+    public function testDecodeUnreservedCharactersKeepsReservedOctetsInUserInfo(): void
+    {
+        $uri = new Uri('http://user:pa%3Ass@example.com/');
+        $normalizedUri = UriNormalizer::normalize($uri, UriNormalizer::DECODE_UNRESERVED_CHARACTERS);
+
+        self::assertInstanceOf(UriInterface::class, $normalizedUri);
+        self::assertSame('http://user:pa%3Ass@example.com/', (string) $normalizedUri);
+    }
+
+    public function testDecodeUnreservedCharactersInForeignUserInfo(): void
+    {
+        $uri = $this->createMock(UriInterface::class);
+        $uri->expects(self::any())->method('getUserInfo')->willReturn('us%65r:p%61ss');
+        $uri->expects(self::once())->method('withUserInfo')->with('user', 'pass')->willReturn(new Uri('http://user:pass@example.com'));
+
+        $normalizedUri = UriNormalizer::normalize($uri, UriNormalizer::DECODE_UNRESERVED_CHARACTERS);
+
+        self::assertInstanceOf(UriInterface::class, $normalizedUri);
+        self::assertSame('http://user:pass@example.com', (string) $normalizedUri);
+    }
+
+    public function testDecodeUnreservedCharactersLowercasesDecodedForeignHostOctets(): void
+    {
+        $uri = $this->createMock(UriInterface::class);
+        $uri->expects(self::any())->method('getUserInfo')->willReturn('');
+        $uri->expects(self::any())->method('getHost')->willReturn('ex%41mple%2ecom');
+        $uri->expects(self::once())->method('withHost')->with('example.com')->willReturn(new Uri('http://example.com'));
+
+        $normalizedUri = UriNormalizer::normalize($uri, UriNormalizer::DECODE_UNRESERVED_CHARACTERS);
+
+        self::assertInstanceOf(UriInterface::class, $normalizedUri);
+        self::assertSame('http://example.com', (string) $normalizedUri);
+    }
+
+    public function testDecodeUnreservedCharactersNormalizesLowercasingForeignHost(): void
+    {
+        $uri = new UriNormalizerForeignUri('', 'example%2Ecom');
+
+        $normalizedUri = UriNormalizer::normalize($uri, UriNormalizer::DECODE_UNRESERVED_CHARACTERS);
+
+        self::assertInstanceOf(UriInterface::class, $normalizedUri);
+        self::assertSame('example.com', $normalizedUri->getHost());
+    }
+
+    public function testDecodeUnreservedCharactersPreservesForeignUserInfoWithEmptyUser(): void
+    {
+        $uri = new UriNormalizerForeignUri(':p%61ss', 'example.com');
+
+        $normalizedUri = UriNormalizer::normalize($uri, UriNormalizer::DECODE_UNRESERVED_CHARACTERS);
+
+        self::assertInstanceOf(UriInterface::class, $normalizedUri);
+        self::assertSame(':p%61ss', $normalizedUri->getUserInfo());
+    }
+
+    public function testDecodeUnreservedCharactersLeavesMalformedForeignHostUntouched(): void
+    {
+        $uri = new UriNormalizerForeignUri('', 'example%6%31com');
+
+        $normalizedUri = UriNormalizer::normalize($uri, UriNormalizer::DECODE_UNRESERVED_CHARACTERS);
+        $twiceNormalizedUri = UriNormalizer::normalize($normalizedUri, UriNormalizer::DECODE_UNRESERVED_CHARACTERS);
+
+        self::assertSame('example%6%31com', $normalizedUri->getHost());
+        self::assertSame('example%6%31com', $twiceNormalizedUri->getHost());
+    }
+
+    public function testDecodeUnreservedCharactersDoesNotCallSettersForMalformedComponents(): void
+    {
+        $uri = $this->createMock(UriInterface::class);
+        $uri->expects(self::any())->method('getUserInfo')->willReturn('user:%6%31');
+        $uri->expects(self::any())->method('getHost')->willReturn('example%6%31com');
+        $uri->expects(self::any())->method('getPath')->willReturn('');
+        $uri->expects(self::any())->method('getQuery')->willReturn('');
+        $uri->expects(self::any())->method('getFragment')->willReturn('');
+        $uri->expects(self::never())->method('withUserInfo');
+        $uri->expects(self::never())->method('withHost');
+
+        UriNormalizer::normalize($uri, UriNormalizer::DECODE_UNRESERVED_CHARACTERS);
+    }
+
+    public function testMalformedForeignUserInfoDoesNotBlockHostNormalization(): void
+    {
+        $uri = new UriNormalizerForeignUri('user:%6%31', 'example%2Ecom');
+
+        $normalizedUri = UriNormalizer::normalize($uri, UriNormalizer::DECODE_UNRESERVED_CHARACTERS);
+
+        self::assertSame('user:%6%31', $normalizedUri->getUserInfo());
+        self::assertSame('example.com', $normalizedUri->getHost());
+    }
+
+    public function testNormalizePreservesUserInfoWithEmptyUser(): void
+    {
+        $uri = new Uri('http://:p%61ss@h/');
+
+        self::assertSame(':p%61ss', $uri->getUserInfo(), 'Not normalized automatically beforehand');
+
+        $normalizedUri = UriNormalizer::normalize($uri);
+
+        self::assertInstanceOf(UriInterface::class, $normalizedUri);
+        self::assertSame('http://:p%61ss@h/', (string) $normalizedUri);
+    }
+
+    public function testDecodeUnreservedCharactersSkipsForeignIpLiteralHosts(): void
+    {
+        $uri = $this->createMock(UriInterface::class);
+        $uri->expects(self::any())->method('getUserInfo')->willReturn('');
+        $uri->expects(self::any())->method('getHost')->willReturn('[fe80::1%25%65th0]');
+        $uri->expects(self::never())->method('withHost');
+
+        $normalizedUri = UriNormalizer::normalize($uri, UriNormalizer::DECODE_UNRESERVED_CHARACTERS);
+
+        self::assertInstanceOf(UriInterface::class, $normalizedUri);
+    }
+
+    public function testPercentEncodingNormalizationsAreIdempotent(): void
+    {
+        $uri = new Uri('http://us%65r:pa%3a%73s@ex%61mple.com/p%61th');
+        $normalizedUri = UriNormalizer::normalize($uri);
+
+        self::assertInstanceOf(UriInterface::class, $normalizedUri);
+        self::assertSame('http://user:pa%3Ass@example.com/path', (string) $normalizedUri);
+        self::assertSame('http://user:pa%3Ass@example.com/path', (string) UriNormalizer::normalize($normalizedUri));
     }
 
     /**
@@ -384,6 +580,9 @@ class UriNormalizerTest extends TestCase
             ['http://[::0:1]/', 'http://[::1]/', true],
             ['http://[0:0:0:0:0:0:0:1]/', 'http://[::1]/', true],
             ['http://[::1]/', 'http://[::2]/', false],
+            ['http://example%2Ecom/', 'http://example.com/', true],
+            ['http://%75ser@example.com/', 'http://user@example.com/', true],
+            ['http://user:pa%3Ass@example.com/', 'http://user:pass@example.com/', false],
             ['https://example.org/', 'http://example.org/', false],
             ['https://example.org/', '//example.org/', false],
             ['//example.org/', '//example.org/', true],
@@ -401,5 +600,111 @@ class UriNormalizerTest extends TestCase
 
         self::assertFalse(UriNormalizer::isEquivalent($uri1, $uri2));
         self::assertTrue(UriNormalizer::isEquivalent($uri1, $uri2, UriNormalizer::PRESERVING_NORMALIZATIONS | UriNormalizer::REMOVE_DUPLICATE_SLASHES));
+    }
+}
+
+/**
+ * A URI test double whose withUserInfo() removes the userinfo when the user
+ * is empty and whose withHost() lowercases its whole argument, mirroring
+ * behavior found in other PSR-7 implementations.
+ */
+final class UriNormalizerForeignUri implements UriInterface
+{
+    /** @var string */
+    private $userInfo;
+
+    /** @var string */
+    private $host;
+
+    public function __construct(string $userInfo, string $host)
+    {
+        $this->userInfo = $userInfo;
+        $this->host = $host;
+    }
+
+    public function getScheme(): string
+    {
+        return 'http';
+    }
+
+    public function getAuthority(): string
+    {
+        return ($this->userInfo === '' ? '' : $this->userInfo.'@').$this->host;
+    }
+
+    public function getUserInfo(): string
+    {
+        return $this->userInfo;
+    }
+
+    public function getHost(): string
+    {
+        return $this->host;
+    }
+
+    public function getPort(): ?int
+    {
+        return null;
+    }
+
+    public function getPath(): string
+    {
+        return '/';
+    }
+
+    public function getQuery(): string
+    {
+        return '';
+    }
+
+    public function getFragment(): string
+    {
+        return '';
+    }
+
+    public function withScheme(string $scheme): UriInterface
+    {
+        return $this;
+    }
+
+    public function withUserInfo(string $user, ?string $password = null): UriInterface
+    {
+        $new = clone $this;
+        $new->userInfo = $user === '' ? '' : $user.($password === null ? '' : ':'.$password);
+
+        return $new;
+    }
+
+    public function withHost(string $host): UriInterface
+    {
+        $new = clone $this;
+        $new->host = Utils::asciiToLower($host);
+
+        return $new;
+    }
+
+    public function withPort(?int $port): UriInterface
+    {
+        return $this;
+    }
+
+    public function withPath(string $path): UriInterface
+    {
+        return $this;
+    }
+
+    public function withQuery(string $query): UriInterface
+    {
+        return $this;
+    }
+
+    public function withFragment(string $fragment): UriInterface
+    {
+        return $this;
+    }
+
+    public function __toString(): string
+    {
+        return 'http://'.$this->getAuthority().$this->getPath();
     }
 }


### PR DESCRIPTION
RFC 3986 section 6.2.2 defines percent-encoding normalization for the URI as a whole, but the CAPITALIZE_PERCENT_ENCODING and DECODE_UNRESERVED_CHARACTERS normalizations previously rewrote only the path, query, and fragment, so http://example%2Ecom/ and http://example.com/ were never considered equivalent even though they identify the same resource. This extends both flags to the userinfo and host components, which also matches the normalized representation produced by the native PHP 8.5 URI extension. Decoded unreserved octets in hosts land lowercase to preserve the PSR-7 lowercase host guarantee, and bracketed IP literals are skipped. Because PSR-7 setters are not required to retain a given spelling, each rewrite is verified against the value the implementation actually returns and the component is left untouched when the normalized form cannot be represented, including userinfo with an empty user segment, which withUserInfo() defines as removal. The behavior change is covered in the changelog and upgrading guide. This PR is stacked on #859 and should be merged after it.