### PR TITLE
Treat ports 80 and 443 as defaults for the ws and wss schemes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Stop throwing from `UriResolver::relativize()` when an equal-path target's last path segment contains a colon
 - Harden URI host validation (delimiters, backslashes, IPv6, embedded ports); require schemes to start with a letter
 - Validate `Uri::fromParts()` ports instead of casting them
+- Treat ports 80 and 443 as defaults for the `ws` and `wss` schemes
+- Use the `ws` and `wss` default ports in `UriComparator::isCrossOrigin()` port comparisons
 - Redact all non-empty URI userinfo in `Utils::redactUserInfo()`
 - Rebuild server request URIs from `$_SERVER` by `REQUEST_METHOD`, using target authority before `SERVER_PORT`
 - Remove userinfo from absolute-form `REQUEST_URI` targets in `ServerRequest::fromGlobals()`

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -821,6 +821,59 @@ use GuzzleHttp\Psr7\UriNormalizer;
 (string) UriNormalizer::normalize(new Uri('http://%75ser@ex%61mple.com/'));
 ```
 
+#### URI Ports and Authority Handling
+
+Several 3.0 changes affect how URI ports are accepted, validated, and rendered.
+Each is described in its own section above:
+
+- `UriInterface::withPort()` now requires `int|null`; see "Native PSR-7
+  Parameter Types".
+- `Uri::fromParts()` validates ports instead of casting them, and `withHost()`
+  rejects embedded `host:port` values; see "URI Host and Scheme Validation".
+- A generic `Uri` can represent ports 0 through 65535. Inbound HTTP authority
+  parsing is stricter: `Message::parseRequest()` rejects zero-valued ports but
+  accepts nonzero leading-zero ports, normalizing the reconstructed URI while
+  preserving the raw `Host` or request-target text; see "HTTP Start-line
+  Parsing" and "URI Host and Scheme Validation".
+- Server globals reject a zero-valued `HTTP_HOST` and validate `SERVER_PORT`
+  when fallback authority reconstruction needs it. A recognized absolute-form
+  or CONNECT `REQUEST_URI` authority takes precedence and can still produce a
+  URI with port zero; see "URI Host and Scheme Validation".
+- Synthesized `Host` headers now include any non-default URI port; see "Request
+  Modification Changes" and "Request Host Synchronization".
+
+`Uri` now knows the default ports of the `ws` and `wss` schemes, 80 and 443 per
+RFC 6455. An explicit default port on a `ws` or `wss` URI is removed when the
+URI is constructed or modified, `Uri::isDefaultPort()` returns `true` for such
+URIs, and `UriNormalizer::normalize()` with the `REMOVE_DEFAULT_PORT` flag
+removes the port from other `UriInterface` implementations as well. In 2.x,
+these ports were preserved.
+
+```php
+use GuzzleHttp\Psr7\Uri;
+
+// 2.x: ws://example.com:80/chat
+// 3.0: ws://example.com/chat
+(string) new Uri('ws://example.com:80/chat');
+
+// 2.x: 443
+// 3.0: null
+(new Uri('wss://example.com:443'))->getPort();
+```
+
+Because a native `Uri` never carries a default `ws` or `wss` port, the `Host`
+header synchronized from such a request URI omits the port. `Request` and
+`Message` `Host` synthesis and `Utils::modifyRequest()` still append an explicit
+default port that a `ws` or `wss` URI from another `UriInterface` implementation
+reports.
+
+`UriComparator::isCrossOrigin()` now applies these default ports when comparing
+effective ports, so two `ws` or `wss` URIs that differ only by an explicit
+default port, such as `ws://example.com/` and `ws://example.com:80/`, are
+same-origin no matter which `UriInterface` implementation supplies them. In 2.x,
+such pairs were considered cross-origin. Schemes other than `http`, `https`,
+`ws`, and `wss` still receive no implicit default port.
+
 1.x to 2.0
 ----------
 

--- a/docs/uri-helpers.md
+++ b/docs/uri-helpers.md
@@ -228,8 +228,8 @@ canonicalized to their RFC 5952 form from any PSR-7 implementation before
 comparison, so equivalent spellings of the same address are same-origin.
 IPvFuture literals and bracketed values that cannot be parsed as an IPv6
 address, such as those carrying zone identifiers, still compare as
-case-insensitive text. Missing ports use the default port for `http` or
-`https`. Other schemes do not receive implicit default ports.
+case-insensitive text. Missing ports use the default port for `http`, `https`,
+`ws`, or `wss`. Other schemes do not receive implicit default ports.
 
 This helper only compares URI origins. It does not implement redirect handling
 or credential policy.

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -35,6 +35,8 @@ class Uri implements UriInterface, \JsonSerializable
         'imap' => 143,
         'pop' => 110,
         'ldap' => 389,
+        'ws' => 80,
+        'wss' => 443,
     ];
 
     private const QUERY_SEPARATORS_REPLACEMENT = ['=' => '%3D', '&' => '%26', '+' => '%2B'];

--- a/src/UriComparator.php
+++ b/src/UriComparator.php
@@ -25,8 +25,8 @@ final class UriComparator
      * same-origin. IPvFuture literals and bracketed values that cannot be
      * parsed as an IPv6 address, such as those carrying zone identifiers,
      * still compare as case-insensitive text. Missing ports use the default
-     * port for `http` or `https`. Other schemes do not receive implicit
-     * default ports.
+     * port for `http`, `https`, `ws`, or `wss`. Other schemes do not receive
+     * implicit default ports.
      *
      * This helper only compares URI origins. It does not implement redirect
      * handling or credential policy.
@@ -78,11 +78,11 @@ final class UriComparator
             return $port;
         }
 
-        if ('http' === $uri->getScheme()) {
+        if (\in_array($uri->getScheme(), ['http', 'ws'], true)) {
             return 80;
         }
 
-        if ('https' === $uri->getScheme()) {
+        if (\in_array($uri->getScheme(), ['https', 'wss'], true)) {
             return 443;
         }
 

--- a/tests/UriComparatorTest.php
+++ b/tests/UriComparatorTest.php
@@ -46,8 +46,8 @@ class UriComparatorTest extends TestCase
             ['custom://example.com/', 'custom://example.com:80/', true],
             ['custom://example.com/', 'custom://example.com/other', false],
             ['ftp://example.com/', 'ftp://example.com:80/', true],
-            ['ws://example.com/', 'ws://example.com:80/', true],
-            ['wss://example.com/', 'wss://example.com:443/', true],
+            ['ws://example.com/', 'ws://example.com:80/', false],
+            ['wss://example.com/', 'wss://example.com:443/', false],
         ];
     }
 
@@ -121,5 +121,35 @@ class UriComparatorTest extends TestCase
         $modified->method('getPort')->willReturn(21);
 
         self::assertTrue(UriComparator::isCrossOrigin($original, $modified));
+    }
+
+    public function testWsSchemeMissingPortUsesSchemeDefault(): void
+    {
+        $original = $this->createMock(UriInterface::class);
+        $original->method('getHost')->willReturn('example.com');
+        $original->method('getScheme')->willReturn('ws');
+        $original->method('getPort')->willReturn(null);
+
+        $modified = $this->createMock(UriInterface::class);
+        $modified->method('getHost')->willReturn('example.com');
+        $modified->method('getScheme')->willReturn('ws');
+        $modified->method('getPort')->willReturn(80);
+
+        self::assertFalse(UriComparator::isCrossOrigin($original, $modified));
+    }
+
+    public function testWssSchemeMissingPortUsesSchemeDefault(): void
+    {
+        $original = $this->createMock(UriInterface::class);
+        $original->method('getHost')->willReturn('example.com');
+        $original->method('getScheme')->willReturn('wss');
+        $original->method('getPort')->willReturn(null);
+
+        $modified = $this->createMock(UriInterface::class);
+        $modified->method('getHost')->willReturn('example.com');
+        $modified->method('getScheme')->willReturn('wss');
+        $modified->method('getPort')->willReturn(443);
+
+        self::assertFalse(UriComparator::isCrossOrigin($original, $modified));
     }
 }

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -611,6 +611,9 @@ class UriTest extends TestCase
             ['imap', 143, true],
             ['pop', 110, true],
             ['ldap', 389, true],
+            ['ws', 80, true],
+            ['ws', 8080, false],
+            ['wss', 443, true],
         ];
     }
 
@@ -1159,6 +1162,29 @@ class UriTest extends TestCase
         self::assertSame('example.com', $uri->getAuthority());
 
         $uri = (new Uri('http://example.com'))->withPort(80);
+        self::assertNull($uri->getPort());
+        self::assertSame('example.com', $uri->getAuthority());
+    }
+
+    public function testPortIsNullIfStandardPortForWebSocketScheme(): void
+    {
+        // WSS standard port
+        $uri = new Uri('wss://example.com:443/chat');
+        self::assertNull($uri->getPort());
+        self::assertSame('example.com', $uri->getAuthority());
+        self::assertSame('wss://example.com/chat', (string) $uri);
+
+        $uri = (new Uri('wss://example.com'))->withPort(443);
+        self::assertNull($uri->getPort());
+        self::assertSame('example.com', $uri->getAuthority());
+
+        // WS standard port
+        $uri = new Uri('ws://example.com:80/chat');
+        self::assertNull($uri->getPort());
+        self::assertSame('example.com', $uri->getAuthority());
+        self::assertSame('ws://example.com/chat', (string) $uri);
+
+        $uri = (new Uri('ws://example.com'))->withPort(80);
         self::assertNull($uri->getPort());
         self::assertSame('example.com', $uri->getAuthority());
     }


### PR DESCRIPTION
RFC 6455 section 3 defines 80 and 443 as the default ports for the ws and wss schemes, but they were missing from the default port map, so explicit default ports survived construction and UriComparator::isCrossOrigin() treated ws://example.com/ and ws://example.com:80/ as different origins. This adds both entries so default ports are stripped at construction like the other schemes in the map, isDefaultPort() and the REMOVE_DEFAULT_PORT normalization agree, and UriComparator::isCrossOrigin() compares effective ports for ws and wss, so explicit and omitted default ports describe the same origin for any PSR-7 implementation while other schemes still receive no implicit default. The behavior change, including the origin comparison consequences, is covered in the changelog and upgrading guide. This PR is stacked on #860 and should be merged last; it completes the consolidated ports section of the upgrading guide.