### PR TITLE
Centralize HTTP lexical predicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Extend `CAPITALIZE_PERCENT_ENCODING` and `DECODE_UNRESERVED_CHARACTERS` to userinfo and host
 - Trim header list elements with only spaces, horizontal tabs, and line terminators in `Header::splitList()`
 - Report header parameter PCRE failures explicitly in `Header::parse()`
+- Escape control bytes in invalid header names and values in exception messages
 
 ### Removed
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -47,6 +47,9 @@ $response = $response->withHeader('Empty-Value', '');
 
 Use `withoutHeader()` to remove a header.
 
+Exception messages for rejected message and multipart header names and values
+now render control bytes with C-style escapes instead of including raw bytes.
+
 #### Request Method Casing
 
 Request methods passed explicitly to `Request`, `ServerRequest`, `withMethod()`,

--- a/src/Message.php
+++ b/src/Message.php
@@ -13,19 +13,6 @@ final class Message
 {
     private const DEFAULT_BODY_SUMMARY_TRUNCATE_AT = 120;
 
-    /**
-     * Method token (tchar+) for use in a regex.
-     *
-     * @see https://datatracker.ietf.org/doc/html/rfc9110#section-5.6.2
-     */
-    private const REQUEST_METHOD_TOKEN = '[!#$%&\'*+.^_`|~0-9A-Za-z-]+';
-
-    /**
-     * Request-target bytes accepted by the start-line parser (no CTL, SP, or
-     * DEL), for use in a regex.
-     */
-    private const REQUEST_TARGET_CHARS = '[^\x00-\x20\x7F]+';
-
     private function __construct()
     {
     }
@@ -251,7 +238,7 @@ final class Message
         [$startLine, $rawHeaders] = $headerParts;
 
         $versionMatch = preg_match(
-            '/(?:^HTTP\/|^'.self::REQUEST_METHOD_TOKEN.' '.self::REQUEST_TARGET_CHARS.' HTTP\/)(\d+(?:\.\d+)?)/i',
+            '/(?:^HTTP\/|^'.Rfc9110::TOKEN_PATTERN.' '.Rfc9112::REQUEST_TARGET_PATTERN.' HTTP\/)('.Rfc9112::PROTOCOL_VERSION_PATTERN.')/i',
             $startLine,
             $matches
         );
@@ -441,7 +428,7 @@ final class Message
         $data = self::parseMessage($message);
         $matches = [];
         $matched = preg_match(
-            '/^(?P<method>'.self::REQUEST_METHOD_TOKEN.') (?P<target>'.self::REQUEST_TARGET_CHARS.') HTTP\/(?P<version>\d+(?:\.\d+)?)$/D',
+            '/^(?P<method>'.Rfc9110::TOKEN_PATTERN.') (?P<target>'.Rfc9112::REQUEST_TARGET_PATTERN.') HTTP\/(?P<version>'.Rfc9112::PROTOCOL_VERSION_PATTERN.')$/D',
             $data['start-line'],
             $matches
         );
@@ -570,7 +557,11 @@ final class Message
         // According to https://datatracker.ietf.org/doc/html/rfc9112#section-4
         // the space between status-code and reason-phrase is required. But
         // browsers accept responses without space and reason as well.
-        $matched = preg_match('/^HTTP\/(?P<version>\d+(?:\.\d+)?) (?P<status>[1-5][0-9]{2})(?: (?P<reason>[\x09\x20-\x7E\x80-\xFF]*))?$/D', $data['start-line'], $matches);
+        $matched = preg_match(
+            '/^HTTP\/(?P<version>'.Rfc9112::PROTOCOL_VERSION_PATTERN.') (?P<status>[1-5][0-9]{2})(?: (?P<reason>'.Rfc9110::FIELD_VALUE_PATTERN.'))?$/D',
+            $data['start-line'],
+            $matches
+        );
 
         if ($matched === false) {
             throw new \RuntimeException('Unable to parse response start line: '.preg_last_error_msg());

--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -232,16 +232,14 @@ trait MessageTrait
      */
     private function assertHeader(string $header): void
     {
-        if (!preg_match('/^[a-zA-Z0-9\'`#$%&*+.^_|~!-]+$/D', $header)) {
-            throw new \InvalidArgumentException(
-                sprintf('"%s" is not valid header name.', $header)
-            );
+        if (!Rfc9110::isToken($header)) {
+            throw new \InvalidArgumentException(sprintf('"%s" is not valid header name.', \addcslashes($header, "\0..\37\177")));
         }
     }
 
     private function assertProtocolVersion(string $version): void
     {
-        if (!preg_match('/^\d+(?:\.\d+)?$/D', $version)) {
+        if (!Rfc9112::isValidProtocolVersion($version)) {
             throw new \InvalidArgumentException('Protocol version must be a valid HTTP version number.');
         }
     }
@@ -270,10 +268,8 @@ trait MessageTrait
         // sending folded headers is likely very rare. Line folding is a fairly
         // obscure feature of HTTP/1.1 and thus not accepting folding is not
         // likely to break any legitimate use case.
-        if (!preg_match('/^[\x20\x09\x21-\x7E\x80-\xFF]*$/D', $value)) {
-            throw new \InvalidArgumentException(
-                sprintf('"%s" is not valid header value.', $value)
-            );
+        if (!Rfc9110::isFieldValue($value)) {
+            throw new \InvalidArgumentException(sprintf('"%s" is not valid header value.', \addcslashes($value, "\0..\37\177")));
         }
     }
 }

--- a/src/MultipartStream.php
+++ b/src/MultipartStream.php
@@ -262,15 +262,15 @@ final class MultipartStream implements StreamInterface
 
     private static function validatePartHeaderName(string $name): void
     {
-        if (!preg_match('/^[a-zA-Z0-9\'`#$%&*+.^_|~!-]+$/D', $name)) {
-            throw new \InvalidArgumentException(sprintf('"%s" is not valid multipart part header name.', $name));
+        if (!Rfc9110::isToken($name)) {
+            throw new \InvalidArgumentException(sprintf('"%s" is not valid multipart part header name.', \addcslashes($name, "\0..\37\177")));
         }
     }
 
     private static function validatePartHeaderValue(string $value): void
     {
-        if (!preg_match('/^[\x20\x09\x21-\x7E\x80-\xFF]*$/D', $value)) {
-            throw new \InvalidArgumentException(sprintf('"%s" is not valid multipart part header value.', $value));
+        if (!Rfc9110::isFieldValue($value)) {
+            throw new \InvalidArgumentException(sprintf('"%s" is not valid multipart part header value.', \addcslashes($value, "\0..\37\177")));
         }
     }
 

--- a/src/Request.php
+++ b/src/Request.php
@@ -170,7 +170,7 @@ class Request implements RequestInterface
 
     private function assertMethod(string $method): void
     {
-        if (!preg_match('/^[!#$%&\'*+.^_`|~0-9A-Za-z-]+$/D', $method)) {
+        if (!Rfc9110::isToken($method)) {
             throw new InvalidArgumentException('Method must be a valid HTTP token.');
         }
     }
@@ -192,13 +192,7 @@ class Request implements RequestInterface
 
     private static function assertRequestTarget(string $requestTarget): void
     {
-        $hasInvalidChars = preg_match('/[\x00-\x20\x7F]/', $requestTarget);
-
-        if ($hasInvalidChars === false) {
-            throw new \RuntimeException('Unable to validate request target: '.preg_last_error_msg());
-        }
-
-        if ($requestTarget === '' || $hasInvalidChars === 1) {
+        if (!Rfc9112::isValidRequestTarget($requestTarget)) {
             throw new InvalidArgumentException(
                 'Invalid request target provided; cannot be empty or contain whitespace or control characters'
             );

--- a/src/Response.php
+++ b/src/Response.php
@@ -152,7 +152,7 @@ class Response implements ResponseInterface
 
     private function assertReasonPhrase(string $reasonPhrase): void
     {
-        if (!preg_match('/^[\x09\x20-\x7E\x80-\xFF]*$/D', $reasonPhrase)) {
+        if (!Rfc9112::isValidReasonPhrase($reasonPhrase)) {
             throw new \InvalidArgumentException('Reason phrase must not contain invalid control characters.');
         }
     }

--- a/src/Rfc9110.php
+++ b/src/Rfc9110.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GuzzleHttp\Psr7;
+
+/**
+ * @internal
+ */
+final class Rfc9110
+{
+    /**
+     * A token for use in a regular expression.
+     *
+     * @see https://datatracker.ietf.org/doc/html/rfc9110#section-5.6.2
+     */
+    public const TOKEN_PATTERN = '[!#$%&\'*+.^_`|~0-9A-Za-z-]+';
+
+    /**
+     * A field value for use in a regular expression.
+     *
+     * Obsolete line folding is intentionally excluded.
+     *
+     * @see https://datatracker.ietf.org/doc/html/rfc9110#section-5.5
+     */
+    public const FIELD_VALUE_PATTERN = '[\x09\x20-\x7E\x80-\xFF]*';
+
+    private function __construct()
+    {
+    }
+
+    public static function isToken(string $value): bool
+    {
+        return preg_match('/^'.self::TOKEN_PATTERN.'$/D', $value) === 1;
+    }
+
+    public static function isFieldValue(string $value): bool
+    {
+        return preg_match('/^'.self::FIELD_VALUE_PATTERN.'$/D', $value) === 1;
+    }
+}

--- a/src/Rfc9112.php
+++ b/src/Rfc9112.php
@@ -9,6 +9,17 @@ namespace GuzzleHttp\Psr7;
  */
 final class Rfc9112
 {
+    /**
+     * An HTTP protocol version for use in a regular expression.
+     */
+    public const PROTOCOL_VERSION_PATTERN = '\d+(?:\.\d+)?';
+
+    /**
+     * The request-target bytes accepted by the HTTP/1 start-line grammar for
+     * use in a regular expression.
+     */
+    public const REQUEST_TARGET_PATTERN = '[^\x00-\x20\x7F]+';
+
     private function __construct()
     {
     }
@@ -24,6 +35,21 @@ final class Rfc9112
      */
     public const HEADER_REGEX = "(^([^()<>@,;:\\\"/[\]?={}\x01-\x20\x7F]++):[ \t]*+((?:[ \t]*+[\x21-\x7E\x80-\xFF]++)*+)[ \t]*+\r?\n)m";
     public const HEADER_FOLD_REGEX = "(\r?\n[ \t]++)";
+
+    public static function isValidProtocolVersion(string $version): bool
+    {
+        return preg_match('/^'.self::PROTOCOL_VERSION_PATTERN.'$/D', $version) === 1;
+    }
+
+    public static function isValidRequestTarget(string $target): bool
+    {
+        return preg_match('/^'.self::REQUEST_TARGET_PATTERN.'$/D', $target) === 1;
+    }
+
+    public static function isValidReasonPhrase(string $reasonPhrase): bool
+    {
+        return Rfc9110::isFieldValue($reasonPhrase);
+    }
 
     /**
      * @return array{0: string, 1: int|null}|null

--- a/src/ServerRequestGlobalsFactory.php
+++ b/src/ServerRequestGlobalsFactory.php
@@ -381,13 +381,7 @@ final class ServerRequestGlobalsFactory
 
         // Preserve the received absolute-form target unless it cannot be used as
         // a PSR-7 request target without normalization.
-        $hasInvalidTargetChars = preg_match('/[\x00-\x20\x7F]/', $requestTarget);
-
-        if ($hasInvalidTargetChars === false) {
-            throw new \RuntimeException('Unable to inspect request target: '.preg_last_error_msg());
-        }
-
-        $normalizeRequestTarget = $hasInvalidTargetChars === 1
+        $normalizeRequestTarget = !Rfc9112::isValidRequestTarget($requestTarget)
             || self::hasEmptyPortInAbsoluteFormRequestTarget($requestTarget);
 
         return [$targetUri, $normalizeRequestTarget ? (string) $targetUri : $requestTarget];

--- a/src/UploadedFileNormalizer.php
+++ b/src/UploadedFileNormalizer.php
@@ -77,9 +77,7 @@ final class UploadedFileNormalizer
     private static function assertFileSpec(array $value): void
     {
         if (!isset($value['tmp_name'], $value['size'], $value['error'])) {
-            throw new InvalidArgumentException(
-                'Invalid file specification; expected keys "tmp_name", "size", and "error".'
-            );
+            throw new InvalidArgumentException('Invalid file specification; expected keys "tmp_name", "size", and "error".');
         }
     }
 
@@ -99,9 +97,7 @@ final class UploadedFileNormalizer
 
         foreach (array_keys($files['tmp_name']) as $key) {
             if (!array_key_exists($key, $files['size']) || !array_key_exists($key, $files['error'])) {
-                throw new InvalidArgumentException(
-                    'Invalid nested file specification; expected "tmp_name", "size", and "error" arrays to have matching keys.'
-                );
+                throw new InvalidArgumentException('Invalid nested file specification; expected "tmp_name", "size", and "error" arrays to have matching keys.');
             }
 
             $spec = [
@@ -121,18 +117,13 @@ final class UploadedFileNormalizer
     {
         foreach (['tmp_name', 'size', 'error'] as $key) {
             if (!isset($files[$key]) || !is_array($files[$key])) {
-                throw new InvalidArgumentException(
-                    'Invalid nested file specification; expected keys "tmp_name", "size", and "error" to be arrays.'
-                );
+                throw new InvalidArgumentException('Invalid nested file specification; expected keys "tmp_name", "size", and "error" to be arrays.');
             }
         }
 
         foreach (['name', 'type'] as $key) {
             if (isset($files[$key]) && !is_array($files[$key])) {
-                throw new InvalidArgumentException(sprintf(
-                    'Invalid nested file specification; expected key "%s" to be an array when present.',
-                    $key
-                ));
+                throw new InvalidArgumentException(sprintf('Invalid nested file specification; expected key "%s" to be an array when present.', $key));
             }
         }
     }

--- a/tests/MultipartStreamTest.php
+++ b/tests/MultipartStreamTest.php
@@ -1131,10 +1131,10 @@ class MultipartStreamTest extends TestCase
     /**
      * @dataProvider invalidCustomPartHeaderNameProvider
      */
-    public function testRejectsInvalidCustomPartHeaderNames(string $header): void
+    public function testRejectsInvalidCustomPartHeaderNames(string $header, string $message): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('is not valid multipart part header name.');
+        $this->expectExceptionMessage($message);
 
         new MultipartStream([
             [
@@ -1147,19 +1147,19 @@ class MultipartStreamTest extends TestCase
 
     public static function invalidCustomPartHeaderNameProvider(): iterable
     {
-        yield 'empty' => [''];
-        yield 'space' => ['Bad Header'];
-        yield 'carriage return' => ["Bad\rHeader"];
-        yield 'line feed' => ["Bad\nHeader"];
+        yield 'empty' => ['', '"" is not valid multipart part header name.'];
+        yield 'space' => ['Bad Header', '"Bad Header" is not valid multipart part header name.'];
+        yield 'carriage return' => ["Bad\rHeader", '"Bad\\rHeader" is not valid multipart part header name.'];
+        yield 'line feed' => ["Bad\nHeader", '"Bad\\nHeader" is not valid multipart part header name.'];
     }
 
     /**
      * @dataProvider invalidCustomPartHeaderValueProvider
      */
-    public function testRejectsInvalidCustomPartHeaderValues(string $value): void
+    public function testRejectsInvalidCustomPartHeaderValues(string $value, string $message): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('is not valid multipart part header value.');
+        $this->expectExceptionMessage($message);
 
         new MultipartStream([
             [
@@ -1172,9 +1172,18 @@ class MultipartStreamTest extends TestCase
 
     public static function invalidCustomPartHeaderValueProvider(): iterable
     {
-        yield 'carriage return' => ["ok\rX-Injected: yes"];
-        yield 'line feed' => ["ok\nX-Injected: yes"];
-        yield 'nul' => ["ok\0bad"];
+        yield 'carriage return' => [
+            "ok\rX-Injected: yes",
+            '"ok\\rX-Injected: yes" is not valid multipart part header value.',
+        ];
+        yield 'line feed' => [
+            "ok\nX-Injected: yes",
+            '"ok\\nX-Injected: yes" is not valid multipart part header value.',
+        ];
+        yield 'nul' => [
+            "ok\0bad",
+            '"ok\\000bad" is not valid multipart part header value.',
+        ];
     }
 
     public function testRejectsNonStringCustomPartHeaderValue(): void

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -611,7 +611,10 @@ class RequestTest extends TestCase
     public function testContainsNotAllowedCharsOnHeaderValue(string $value): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(sprintf('"%s" is not valid header value', $value));
+        $this->expectExceptionMessage(sprintf(
+            '"%s" is not valid header value',
+            \addcslashes($value, "\0..\37\177")
+        ));
 
         $r = new Request(
             'GET',

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -364,14 +364,14 @@ class ResponseTest extends TestCase
     {
         yield from self::invalidHeaderProvider();
         yield ['', 'foo', '"" is not valid header name.'];
-        yield ["Content-Type\r\n\r\n", 'foo', "\"Content-Type\r\n\r\n\" is not valid header name."];
-        yield ["Content-Type\r\n", 'foo', "\"Content-Type\r\n\" is not valid header name."];
-        yield ["Content-Type\n", 'foo', "\"Content-Type\n\" is not valid header name."];
-        yield ["\r\nContent-Type", 'foo', "\"\r\nContent-Type\" is not valid header name."];
-        yield ["\nContent-Type", 'foo', "\"\nContent-Type\" is not valid header name."];
-        yield ["\n", 'foo', "\"\n\" is not valid header name."];
-        yield ["\r\n", 'foo', "\"\r\n\" is not valid header name."];
-        yield ["\t", 'foo', "\"\t\" is not valid header name."];
+        yield ["Content-Type\r\n\r\n", 'foo', '"Content-Type\\r\\n\\r\\n" is not valid header name.'];
+        yield ["Content-Type\r\n", 'foo', '"Content-Type\\r\\n" is not valid header name.'];
+        yield ["Content-Type\n", 'foo', '"Content-Type\\n" is not valid header name.'];
+        yield ["\r\nContent-Type", 'foo', '"\\r\\nContent-Type" is not valid header name.'];
+        yield ["\nContent-Type", 'foo', '"\\nContent-Type" is not valid header name.'];
+        yield ["\n", 'foo', '"\\n" is not valid header name.'];
+        yield ["\r\n", 'foo', '"\\r\\n" is not valid header name.'];
+        yield ["\t", 'foo', '"\\t" is not valid header name.'];
     }
 
     /**

--- a/tests/Rfc9110Test.php
+++ b/tests/Rfc9110Test.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GuzzleHttp\Tests\Psr7;
+
+use GuzzleHttp\Psr7\Rfc9110;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \GuzzleHttp\Psr7\Rfc9110
+ */
+class Rfc9110Test extends TestCase
+{
+    public function testIsTokenClassifiesEveryByte(): void
+    {
+        $tokenBytes = "!#$%&'*+-.^_`|~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+        for ($byte = 0; $byte <= 0xFF; ++$byte) {
+            $value = chr($byte);
+
+            self::assertSame(
+                strpos($tokenBytes, $value) !== false,
+                Rfc9110::isToken($value),
+                sprintf('Unexpected token result for byte 0x%02X', $byte)
+            );
+        }
+
+        self::assertFalse(Rfc9110::isToken(''));
+        self::assertTrue(Rfc9110::isToken('M-SEARCH'));
+        self::assertFalse(Rfc9110::isToken("GET\n"));
+    }
+
+    public function testIsFieldValueClassifiesEveryByte(): void
+    {
+        for ($byte = 0; $byte <= 0xFF; ++$byte) {
+            $value = chr($byte);
+            $expected = $byte === 0x09 || ($byte >= 0x20 && $byte !== 0x7F);
+
+            self::assertSame(
+                $expected,
+                Rfc9110::isFieldValue($value),
+                sprintf('Unexpected field value result for byte 0x%02X', $byte)
+            );
+        }
+
+        self::assertTrue(Rfc9110::isFieldValue(''));
+        self::assertTrue(Rfc9110::isFieldValue("value \t\x80"));
+        self::assertFalse(Rfc9110::isFieldValue("value\n"));
+    }
+}

--- a/tests/Rfc9112Test.php
+++ b/tests/Rfc9112Test.php
@@ -7,8 +7,72 @@ namespace GuzzleHttp\Tests\Psr7;
 use GuzzleHttp\Psr7\Rfc9112;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers \GuzzleHttp\Psr7\Rfc9112
+ */
 class Rfc9112Test extends TestCase
 {
+    /**
+     * @dataProvider protocolVersionProvider
+     */
+    public function testIsValidProtocolVersion(string $version, bool $expected): void
+    {
+        self::assertSame($expected, Rfc9112::isValidProtocolVersion($version));
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: bool}>
+     */
+    public static function protocolVersionProvider(): iterable
+    {
+        yield 'integer' => ['1', true];
+        yield 'major and minor' => ['1.1', true];
+        yield 'multiple digits' => ['100.200', true];
+        yield 'empty' => ['', false];
+        yield 'prefix' => ['HTTP/1.1', false];
+        yield 'missing minor' => ['1.', false];
+        yield 'missing major' => ['.1', false];
+        yield 'multiple dots' => ['1.1.1', false];
+        yield 'trailing newline' => ["1.1\n", false];
+        yield 'high byte' => ["1.\xFF", false];
+    }
+
+    public function testIsValidRequestTargetClassifiesEveryByte(): void
+    {
+        for ($byte = 0; $byte <= 0xFF; ++$byte) {
+            $value = chr($byte);
+            $expected = $byte >= 0x21 && $byte !== 0x7F;
+
+            self::assertSame(
+                $expected,
+                Rfc9112::isValidRequestTarget($value),
+                sprintf('Unexpected request target result for byte 0x%02X', $byte)
+            );
+        }
+
+        self::assertFalse(Rfc9112::isValidRequestTarget(''));
+        self::assertTrue(Rfc9112::isValidRequestTarget('/path?query=value'));
+        self::assertFalse(Rfc9112::isValidRequestTarget("/path\n"));
+    }
+
+    public function testIsValidReasonPhraseClassifiesEveryByte(): void
+    {
+        for ($byte = 0; $byte <= 0xFF; ++$byte) {
+            $value = chr($byte);
+            $expected = $byte === 0x09 || ($byte >= 0x20 && $byte !== 0x7F);
+
+            self::assertSame(
+                $expected,
+                Rfc9112::isValidReasonPhrase($value),
+                sprintf('Unexpected reason phrase result for byte 0x%02X', $byte)
+            );
+        }
+
+        self::assertTrue(Rfc9112::isValidReasonPhrase(''));
+        self::assertTrue(Rfc9112::isValidReasonPhrase("OK \t\x80"));
+        self::assertFalse(Rfc9112::isValidReasonPhrase("OK\r\n"));
+    }
+
     /**
      * @dataProvider absoluteFormProvider
      */


### PR DESCRIPTION
Introduces internal Rfc9110::isToken(), Rfc9110::isFieldValue(), Rfc9112::isValidProtocolVersion(), Rfc9112::isValidRequestTarget(), and Rfc9112::isValidReasonPhrase(), then routes Request, Response, MessageTrait, MultipartStream, Message parsing, and globals hydration through the shared grammar constants and predicates. Adds exhaustive byte-level tests. The only intentional behavior change is that rejected header names and values now escape control bytes in exception messages.