### PR TITLE
Extract URI parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Report header parameter PCRE failures explicitly in `Header::parse()`
 - Escape control bytes in invalid header names and values in exception messages
 - Escape control bytes in malformed response start-lines in exception messages
+- Escape control bytes in malformed URI component diagnostics
 
 ### Removed
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -186,6 +186,9 @@ URI hosts containing URI delimiters, backslashes, embedded ports passed to
 malformed host forms are no longer accepted. URI schemes containing whitespace
 or control characters are also no longer accepted.
 
+Exception messages for malformed raw URIs, hosts, schemes, and string ports now
+render control bytes with C-style escapes instead of including raw bytes.
+
 If you previously passed a host and port together to `withHost()`, split them
 between `withHost()` and `withPort()`:
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -130,7 +130,7 @@ parameters:
 			message: '#^Parameter \#1 \$callback of function array_map expects \(callable\(int\<0, 65535\>\|string\)\: mixed\)\|null, ''urldecode'' given\.$#'
 			identifier: argument.type
 			count: 1
-			path: src/Uri.php
+			path: src/UriParser.php
 
 		-
 			message: '#^Strict comparison using \=\=\= between non\-falsy\-string and '''' will always evaluate to false\.$#'

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -65,9 +65,9 @@ class Uri implements UriInterface, \JsonSerializable
     public function __construct(string $uri = '')
     {
         if ($uri !== '') {
-            $parts = self::parse($uri);
+            $parts = UriParser::parse($uri);
             if ($parts === false) {
-                throw new MalformedUriException("Unable to parse URI: $uri");
+                throw new MalformedUriException('Unable to parse URI: '.\addcslashes($uri, "\0..\37\177"));
             }
             try {
                 $this->applyParts($parts);
@@ -77,136 +77,6 @@ class Uri implements UriInterface, \JsonSerializable
                 throw new MalformedUriException($e->getMessage(), 0, $e);
             }
         }
-    }
-
-    /**
-     * UTF-8 aware \parse_url() replacement.
-     *
-     * The internal function produces broken output for non ASCII domain names
-     * (IDN) when used with locales other than "C".
-     *
-     * On the other hand, cURL understands IDN correctly only when UTF-8 locale
-     * is configured ("C.UTF-8", "en_US.UTF-8", etc.).
-     *
-     * @see https://bugs.php.net/bug.php?id=52923
-     * @see https://www.php.net/manual/en/function.parse-url.php#114817
-     * @see https://curl.se/libcurl/c/CURLOPT_URL.html#ENCODING
-     *
-     * @return array|false
-     */
-    private static function parse(string $url)
-    {
-        if (self::isPathNoSchemeReference($url)) {
-            return self::parsePathNoSchemeReference($url);
-        }
-
-        // Preserve bracketed IP-literals (IPv6 or IPvFuture) in scheme, userinfo,
-        // and network-path authorities before encoding. Userinfo is encoded
-        // separately so raw bytes cannot reach parse_url(), which mutates
-        // control characters instead of failing.
-        $prefix = '';
-        $ipv6Prefix = preg_match('%\A((?:[0-9A-Za-z+.-]+:)?//)(?:([^/?#@]*)(@))?(\[[^\]\x00-\x20\x7F/?#@]+\])(.*)\z%s', $url, $matches);
-
-        if ($ipv6Prefix === false) {
-            return false;
-        }
-
-        if ($ipv6Prefix === 1) {
-            /** @var array{0:string, 1:string, 2:string, 3:string, 4:string, 5:string} $matches */
-            $suffix = $matches[5];
-
-            // After the bracketed host only an optional numeric port and/or a
-            // path, query, or fragment may follow. Anything else (for example
-            // `:80@evil` or `:80x`) would let parse_url() reinterpret a
-            // different host.
-            if (preg_match('%\A(?::[0-9]*)?(?:[/?#].*)?\z%s', $suffix) !== 1) {
-                return false;
-            }
-
-            // RFC 3986 IP-literals contain no percent-encoding, so reject any
-            // "%" in the bracketed host rather than letting the urldecode()
-            // below turn an encoded octet into a different literal. This keeps
-            // parsing aligned with withHost()/Rfc3986::isValidHost().
-            if (str_contains($matches[4], '%')) {
-                return false;
-            }
-
-            $prefix = $matches[1];
-
-            if ($matches[3] === '@') {
-                /** @var string|null */
-                $encodedUserInfo = preg_replace_callback(
-                    '%[^:/@?&=#]+%usD',
-                    static function (array $matches): string {
-                        return urlencode($matches[0]);
-                    },
-                    $matches[2]
-                );
-
-                if ($encodedUserInfo === null) {
-                    return false;
-                }
-
-                $prefix .= $encodedUserInfo.'@';
-            }
-
-            $prefix .= $matches[4];
-            $url = $suffix;
-        }
-
-        /** @var string|null */
-        $encodedUrl = preg_replace_callback(
-            '%[^:/@?&=#]+%usD',
-            static function (array $matches): string {
-                return urlencode($matches[0]);
-            },
-            $url
-        );
-
-        if ($encodedUrl === null) {
-            return false;
-        }
-
-        $result = parse_url($prefix.$encodedUrl);
-
-        if ($result === false) {
-            return false;
-        }
-
-        return array_map('urldecode', $result);
-    }
-
-    private static function isPathNoSchemeReference(string $url): bool
-    {
-        if ($url === '' || str_starts_with($url, '/') || str_starts_with($url, '?') || str_starts_with($url, '#')) {
-            return false;
-        }
-
-        $firstSegment = substr($url, 0, strcspn($url, '/?#'));
-
-        return !str_contains($firstSegment, ':');
-    }
-
-    /**
-     * @return array{path: string, query?: string, fragment?: string}
-     */
-    private static function parsePathNoSchemeReference(string $url): array
-    {
-        $parts = [];
-
-        if (false !== ($fragmentPosition = strpos($url, '#'))) {
-            $parts['fragment'] = substr($url, $fragmentPosition + 1);
-            $url = substr($url, 0, $fragmentPosition);
-        }
-
-        if (false !== ($queryPosition = strpos($url, '?'))) {
-            $parts['query'] = substr($url, $queryPosition + 1);
-            $url = substr($url, 0, $queryPosition);
-        }
-
-        $parts['path'] = $url;
-
-        return $parts;
     }
 
     public function __toString(): string
@@ -478,7 +348,7 @@ class Uri implements UriInterface, \JsonSerializable
     public static function assertValidHost(string $host): void
     {
         if (!Rfc3986::isValidHost($host)) {
-            throw new \InvalidArgumentException(sprintf('Invalid host: "%s"', $host));
+            throw new \InvalidArgumentException(sprintf('Invalid host: "%s"', \addcslashes($host, "\0..\37\177")));
         }
     }
 
@@ -730,7 +600,7 @@ class Uri implements UriInterface, \JsonSerializable
         $scheme = Utils::asciiToLower($scheme);
 
         if (!Rfc3986::isValidScheme($scheme)) {
-            throw new \InvalidArgumentException(sprintf('Invalid scheme: "%s"', $scheme));
+            throw new \InvalidArgumentException(sprintf('Invalid scheme: "%s"', \addcslashes($scheme, "\0..\37\177")));
         }
 
         return $scheme;
@@ -830,7 +700,7 @@ class Uri implements UriInterface, \JsonSerializable
     private static function describeInvalidPort($port): string
     {
         if (\is_string($port)) {
-            return $port;
+            return \addcslashes($port, "\0..\37\177");
         }
 
         if (\is_int($port)) {

--- a/src/UriParser.php
+++ b/src/UriParser.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GuzzleHttp\Psr7;
+
+/**
+ * @internal
+ */
+final class UriParser
+{
+    private function __construct()
+    {
+    }
+
+    /**
+     * UTF-8 aware \parse_url() replacement.
+     *
+     * The internal function produces broken output for non ASCII domain names
+     * (IDN) when used with locales other than "C".
+     *
+     * On the other hand, cURL understands IDN correctly only when UTF-8 locale
+     * is configured ("C.UTF-8", "en_US.UTF-8", etc.).
+     *
+     * @see https://bugs.php.net/bug.php?id=52923
+     * @see https://www.php.net/manual/en/function.parse-url.php#114817
+     * @see https://curl.se/libcurl/c/CURLOPT_URL.html#ENCODING
+     *
+     * @return array|false
+     */
+    public static function parse(string $url)
+    {
+        if (self::isPathNoSchemeReference($url)) {
+            return self::parsePathNoSchemeReference($url);
+        }
+
+        // Preserve bracketed IP-literals (IPv6 or IPvFuture) in scheme, userinfo,
+        // and network-path authorities before encoding. Userinfo is encoded
+        // separately so raw bytes cannot reach parse_url(), which mutates
+        // control characters instead of failing.
+        $prefix = '';
+        $ipv6Prefix = preg_match('%\A((?:[0-9A-Za-z+.-]+:)?//)(?:([^/?#@]*)(@))?(\[[^\]\x00-\x20\x7F/?#@]+\])(.*)\z%s', $url, $matches);
+
+        if ($ipv6Prefix === false) {
+            return false;
+        }
+
+        if ($ipv6Prefix === 1) {
+            /** @var array{0:string, 1:string, 2:string, 3:string, 4:string, 5:string} $matches */
+            $suffix = $matches[5];
+
+            // After the bracketed host only an optional numeric port and/or a
+            // path, query, or fragment may follow. Anything else (for example
+            // `:80@evil` or `:80x`) would let parse_url() reinterpret a
+            // different host.
+            if (preg_match('%\A(?::[0-9]*)?(?:[/?#].*)?\z%s', $suffix) !== 1) {
+                return false;
+            }
+
+            // RFC 3986 IP-literals contain no percent-encoding, so reject any
+            // "%" in the bracketed host rather than letting the urldecode()
+            // below turn an encoded octet into a different literal. This keeps
+            // parsing aligned with withHost()/Rfc3986::isValidHost().
+            if (str_contains($matches[4], '%')) {
+                return false;
+            }
+
+            $prefix = $matches[1];
+
+            if ($matches[3] === '@') {
+                /** @var string|null */
+                $encodedUserInfo = preg_replace_callback(
+                    '%[^:/@?&=#]+%usD',
+                    static function (array $matches): string {
+                        return urlencode($matches[0]);
+                    },
+                    $matches[2]
+                );
+
+                if ($encodedUserInfo === null) {
+                    return false;
+                }
+
+                $prefix .= $encodedUserInfo.'@';
+            }
+
+            $prefix .= $matches[4];
+            $url = $suffix;
+        }
+
+        /** @var string|null */
+        $encodedUrl = preg_replace_callback(
+            '%[^:/@?&=#]+%usD',
+            static function (array $matches): string {
+                return urlencode($matches[0]);
+            },
+            $url
+        );
+
+        if ($encodedUrl === null) {
+            return false;
+        }
+
+        $result = parse_url($prefix.$encodedUrl);
+
+        if ($result === false) {
+            return false;
+        }
+
+        return array_map('urldecode', $result);
+    }
+
+    private static function isPathNoSchemeReference(string $url): bool
+    {
+        if ($url === '' || str_starts_with($url, '/') || str_starts_with($url, '?') || str_starts_with($url, '#')) {
+            return false;
+        }
+
+        $firstSegment = substr($url, 0, strcspn($url, '/?#'));
+
+        return !str_contains($firstSegment, ':');
+    }
+
+    /**
+     * @return array{path: string, query?: string, fragment?: string}
+     */
+    private static function parsePathNoSchemeReference(string $url): array
+    {
+        $parts = [];
+
+        if (false !== ($fragmentPosition = strpos($url, '#'))) {
+            $parts['fragment'] = substr($url, $fragmentPosition + 1);
+            $url = substr($url, 0, $fragmentPosition);
+        }
+
+        if (false !== ($queryPosition = strpos($url, '?'))) {
+            $parts['query'] = substr($url, $queryPosition + 1);
+            $url = substr($url, 0, $queryPosition);
+        }
+
+        $parts['path'] = $url;
+
+        return $parts;
+    }
+}

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -11,6 +11,7 @@ use Psr\Http\Message\UriInterface;
 
 /**
  * @covers \GuzzleHttp\Psr7\Uri
+ * @covers \GuzzleHttp\Psr7\UriParser
  */
 class UriTest extends TestCase
 {
@@ -195,6 +196,7 @@ class UriTest extends TestCase
     public function testRejectsIpv6UriWithTrailingNewline(): void
     {
         $this->expectException(MalformedUriException::class);
+        $this->expectExceptionMessage('Unable to parse URI: http://[::1]\\n');
 
         new Uri("http://[::1]\n");
     }
@@ -434,6 +436,14 @@ class UriTest extends TestCase
         Uri::fromParts(['scheme' => "ht\ntp", 'host' => 'example.com']);
     }
 
+    public function testInvalidSchemeDiagnosticEscapesControlBytes(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid scheme: "ht\\ntp"');
+
+        (new Uri())->withScheme("ht\ntp");
+    }
+
     /**
      * @dataProvider getInvalidHostsWithControlCharacters
      */
@@ -442,6 +452,22 @@ class UriTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
 
         (new Uri())->withHost($host);
+    }
+
+    public function testInvalidHostDiagnosticEscapesControlBytes(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid host: "example.com\\r\\nx-injected: yes"');
+
+        (new Uri())->withHost("example.com\r\nX-Injected: yes");
+    }
+
+    public function testInvalidStringPortDiagnosticEscapesControlBytes(): void
+    {
+        $this->expectException(MalformedUriException::class);
+        $this->expectExceptionMessage('Invalid port: 80\\n. Must be between 0 and 65535');
+
+        Uri::fromParts(['port' => "80\n"]);
     }
 
     public static function getInvalidHostsWithControlCharacters(): iterable


### PR DESCRIPTION
Moves the URI constructor parsing machinery into internal UriParser::parse(), leaving component application, normalization, validation, default ports, and mutation on Uri. Existing URI coverage exercises the extracted parser, including the recent IPv6, percent-encoding, and ws/wss changes. The only intentional behavior change is escaped control bytes in malformed raw URI, host, scheme, and string-port diagnostics.