### PR TITLE
Trigger a runtime deprecation for Header::normalize()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Use locale-independent ASCII case folding everywhere case is normalized
+- Trigger a runtime deprecation for previously deprecated functionality in 2.3.0
 
 ## 2.12.5 - 2026-07-13
 

--- a/src/Header.php
+++ b/src/Header.php
@@ -95,6 +95,8 @@ final class Header
      */
     public static function normalize($header): array
     {
+        \trigger_deprecation('guzzlehttp/psr7', '2.3', 'Header::normalize() is deprecated and will be removed in guzzlehttp/psr7 3.0. Use Header::splitList() instead.');
+
         $result = [];
         foreach ((array) $header as $value) {
             foreach (self::splitList($value) as $parsed) {


### PR DESCRIPTION
`Header::normalize()` has been marked `@deprecated` in favour of `Header::splitList()` since 2.3.0 but never emitted a runtime deprecation, leaving callers unaware of their usage before its removal in 3.0. This adds the missing `trigger_deprecation()` call, using `2.3` as the version to match where the deprecation was originally introduced. The method already delegates to the non-deprecated `Header::splitList()`, so no inlining is required and callers receive a single notice.
