### PR TITLE
Escape unsafe values in exception messages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,9 @@
 - Handle `preg_*` engine failures: when the result is used as data, test for
   `false` or `null` and throw a `\RuntimeException` including
   `preg_last_error_msg()`; boolean validation guards must compare strictly, such
-  as `=== 1`, so an engine failure can only ever fail closed.
+  as `=== 1`, so an engine failure can only ever fail closed. Diagnostic
+  escaping is the narrow exception: use a deterministic bytewise fallback rather
+  than throwing, so it cannot obscure the original exception.
 - Anchor validation patterns to the true end of input with the `D` modifier or
   `\z`; a bare `$` accepts a trailing newline.
 - Never embed raw control bytes in exception messages and other diagnostics;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `DiagnosticValue::escape()` to escape controls and malformed UTF-8 in diagnostics
 - Add `GuzzleHttp\Psr7\Exception\TimeoutException` for timed-out stream operations
 - Add `GuzzleHttp\Psr7\Utils::redactUserInfoInString()` to redact the userinfo of a raw URI string within text
 - Promote `GuzzleHttp\Psr7\Rfc3986` to public API with `isValid*()` predicates and `canonicalizeIpv6()`
@@ -95,9 +96,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Extend `CAPITALIZE_PERCENT_ENCODING` and `DECODE_UNRESERVED_CHARACTERS` to userinfo and host
 - Trim header list elements with only spaces, horizontal tabs, and line terminators in `Header::splitList()`
 - Report header parameter PCRE failures explicitly in `Header::parse()`
-- Escape control bytes in invalid header names and values in exception messages
-- Escape control bytes in malformed response start-lines in exception messages
-- Escape control bytes in malformed URI component diagnostics
+- Escape controls and malformed UTF-8 consistently in generated exception messages
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ $request = $request->withHeader('Accept', 'application/json');
 - [URI Helpers](docs/uri-helpers.md)
 - [PSR-17 Factories](docs/psr-17-factories.md)
 - [Message Helpers](docs/message-helpers.md)
+- [Diagnostic Values](docs/diagnostic-values.md)
 - [Header and Query Helpers](docs/header-and-query-helpers.md)
 - [Stream Helpers](docs/stream-helpers.md)
 - [URI and MIME Helpers](docs/uri-and-mime-helpers.md)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -47,9 +47,6 @@ $response = $response->withHeader('Empty-Value', '');
 
 Use `withoutHeader()` to remove a header.
 
-Exception messages for rejected message and multipart header names and values
-now render control bytes with C-style escapes instead of including raw bytes.
-
 #### Request Method Casing
 
 Request methods passed explicitly to `Request`, `ServerRequest`, `withMethod()`,
@@ -185,9 +182,6 @@ URI hosts containing URI delimiters, backslashes, embedded ports passed to
 `withHost()`, malformed IP-literal brackets, unbracketed IPv6, or other
 malformed host forms are no longer accepted. URI schemes containing whitespace
 or control characters are also no longer accepted.
-
-Exception messages for malformed raw URIs, hosts, schemes, and string ports now
-render control bytes with C-style escapes instead of including raw bytes.
 
 If you previously passed a host and port together to `withHost()`, split them
 between `withHost()` and `withPort()`:
@@ -468,8 +462,6 @@ start-line fields more strictly. Malformed request methods, request targets
 containing whitespace or control characters, malformed protocol versions,
 invalid response status codes, invalid response spacing, and reason phrases
 containing invalid control characters now throw `InvalidArgumentException`.
-Exception messages for malformed response start lines render control bytes with
-C-style escapes instead of including raw bytes.
 
 `Request` and `Response` constructors and mutators apply the same validation to
 protocol versions, request targets, status codes, and reason phrases. If you

--- a/docs/diagnostic-values.md
+++ b/docs/diagnostic-values.md
@@ -1,0 +1,30 @@
+# Diagnostic Values
+
+## `GuzzleHttp\Psr7\DiagnosticValue::escape`
+
+`public static function escape(string $value): string`
+
+Escapes C0, DEL, and C1 controls as uppercase `\xNN` sequences.
+
+ASCII bytes from 0x20 through 0x7E and valid UTF-8 characters outside those
+control ranges remain unchanged. If the input is malformed UTF-8 or PCRE cannot
+process it, every byte outside printable ASCII is escaped. Valid C1 characters
+are rendered as `\xNN` using their Unicode code points. During bytewise
+fallback, each original byte outside printable ASCII is rendered in the same
+form. The result is diagnostic text, not a reversible encoding.
+
+This does not encode values for HTML, JSON, shells, terminals, URLs, or protocol
+fields.
+
+Use this helper when including an untrusted value in diagnostic text:
+
+```php
+use GuzzleHttp\Psr7\DiagnosticValue;
+
+$value = "bad\nvalue";
+$message = sprintf('Invalid value: %s', DiagnosticValue::escape($value));
+// Invalid value: bad\x0Avalue
+```
+
+Applications must still encode the completed diagnostic for its final output
+context, such as HTML or JSON.

--- a/src/DiagnosticValue.php
+++ b/src/DiagnosticValue.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GuzzleHttp\Psr7;
+
+/**
+ * Escapes control characters and malformed UTF-8 for use in diagnostics.
+ */
+final class DiagnosticValue
+{
+    private function __construct()
+    {
+    }
+
+    /**
+     * Escapes C0, DEL, and C1 controls as uppercase `\xNN` sequences.
+     *
+     * ASCII bytes from 0x20 through 0x7E and valid UTF-8 characters outside
+     * those control ranges remain unchanged. If the input is malformed UTF-8 or
+     * PCRE cannot process it, every byte outside printable ASCII is escaped.
+     * Valid C1 characters are rendered as `\xNN` using their Unicode code
+     * points. During bytewise fallback, each original byte outside printable
+     * ASCII is rendered in the same form. The result is diagnostic text, not a
+     * reversible encoding.
+     *
+     * This does not encode values for HTML, JSON, shells, terminals, URLs, or
+     * protocol fields.
+     */
+    public static function escape(string $value): string
+    {
+        $escaped = \preg_replace_callback(
+            '/[\x{0000}-\x{001F}\x{007F}-\x{009F}]/u',
+            static function (array $matches): string {
+                $character = $matches[0];
+                $codePoint = \strlen($character) === 1 ? \ord($character) : \ord($character[1]);
+
+                return \sprintf('\\x%02X', $codePoint);
+            },
+            $value
+        );
+
+        return $escaped ?? self::escapeBytes($value);
+    }
+
+    private static function escapeBytes(string $value): string
+    {
+        $escaped = '';
+
+        for ($offset = 0, $length = \strlen($value); $offset < $length; ++$offset) {
+            $byte = \ord($value[$offset]);
+            if ($byte >= 0x20 && $byte <= 0x7E) {
+                $escaped .= $value[$offset];
+
+                continue;
+            }
+
+            $escaped .= \sprintf('\\x%02X', $byte);
+        }
+
+        return $escaped;
+    }
+}

--- a/src/FnStream.php
+++ b/src/FnStream.php
@@ -48,8 +48,7 @@ final class FnStream implements StreamInterface
      */
     public function __get(string $name): void
     {
-        throw new \BadMethodCallException(str_replace('_fn_', '', $name)
-            .'() is not implemented in the FnStream');
+        throw new \BadMethodCallException(\sprintf('%s() is not implemented in the FnStream', DiagnosticValue::escape(str_replace('_fn_', '', $name))));
     }
 
     /**

--- a/src/HttpFactory.php
+++ b/src/HttpFactory.php
@@ -56,7 +56,7 @@ final class HttpFactory implements RequestFactoryInterface, ResponseFactoryInter
             $resource = Utils::tryFopen($file, $mode);
         } catch (\RuntimeException $e) {
             if ('' === $mode || false === \in_array($mode[0], ['r', 'w', 'a', 'x', 'c'], true)) {
-                throw new \InvalidArgumentException(sprintf('Invalid file opening mode "%s"', $mode), 0, $e);
+                throw new \InvalidArgumentException(sprintf('Invalid file opening mode: %s', DiagnosticValue::escape($mode)), 0, $e);
             }
 
             throw $e;

--- a/src/MessageParser.php
+++ b/src/MessageParser.php
@@ -349,7 +349,7 @@ final class MessageParser
         }
 
         if ($matched === 0) {
-            throw new \InvalidArgumentException('Invalid response string: '.\addcslashes($data['start-line'], "\0..\37\177"));
+            throw new \InvalidArgumentException(\sprintf('Invalid response string: %s', DiagnosticValue::escape($data['start-line'])));
         }
 
         return new Response(

--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -233,7 +233,7 @@ trait MessageTrait
     private function assertHeader(string $header): void
     {
         if (!Rfc9110::isToken($header)) {
-            throw new \InvalidArgumentException(sprintf('"%s" is not valid header name.', \addcslashes($header, "\0..\37\177")));
+            throw new \InvalidArgumentException(sprintf('Invalid header name: %s', DiagnosticValue::escape($header)));
         }
     }
 
@@ -269,7 +269,7 @@ trait MessageTrait
         // obscure feature of HTTP/1.1 and thus not accepting folding is not
         // likely to break any legitimate use case.
         if (!Rfc9110::isFieldValue($value)) {
-            throw new \InvalidArgumentException(sprintf('"%s" is not valid header value.', \addcslashes($value, "\0..\37\177")));
+            throw new \InvalidArgumentException(sprintf('Invalid header value: %s', DiagnosticValue::escape($value)));
         }
     }
 }

--- a/src/MultipartStream.php
+++ b/src/MultipartStream.php
@@ -263,14 +263,14 @@ final class MultipartStream implements StreamInterface
     private static function validatePartHeaderName(string $name): void
     {
         if (!Rfc9110::isToken($name)) {
-            throw new \InvalidArgumentException(sprintf('"%s" is not valid multipart part header name.', \addcslashes($name, "\0..\37\177")));
+            throw new \InvalidArgumentException(sprintf('Invalid multipart part header name: %s', DiagnosticValue::escape($name)));
         }
     }
 
     private static function validatePartHeaderValue(string $value): void
     {
         if (!Rfc9110::isFieldValue($value)) {
-            throw new \InvalidArgumentException(sprintf('"%s" is not valid multipart part header value.', \addcslashes($value, "\0..\37\177")));
+            throw new \InvalidArgumentException(sprintf('Invalid multipart part header value: %s', DiagnosticValue::escape($value)));
         }
     }
 

--- a/src/StreamDecoratorTrait.php
+++ b/src/StreamDecoratorTrait.php
@@ -33,7 +33,7 @@ trait StreamDecoratorTrait
             return $this->stream;
         }
 
-        throw new \UnexpectedValueException("$name not found on class");
+        throw new \UnexpectedValueException(\sprintf('%s not found on class', DiagnosticValue::escape($name)));
     }
 
     public function __toString(): string

--- a/src/UploadedFile.php
+++ b/src/UploadedFile.php
@@ -162,9 +162,7 @@ class UploadedFile implements UploadedFileInterface
         }
 
         if (false === $this->moved) {
-            throw new RuntimeException(
-                sprintf('Uploaded file could not be moved to %s', $targetPath)
-            );
+            throw new RuntimeException(sprintf('Uploaded file could not be moved to %s', DiagnosticValue::escape($targetPath)));
         }
     }
 

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -67,7 +67,7 @@ class Uri implements UriInterface, \JsonSerializable
         if ($uri !== '') {
             $parts = UriParser::parse($uri);
             if ($parts === false) {
-                throw new MalformedUriException('Unable to parse URI: '.\addcslashes($uri, "\0..\37\177"));
+                throw new MalformedUriException(\sprintf('Unable to parse URI: %s', DiagnosticValue::escape($uri)));
             }
             try {
                 $this->applyParts($parts);
@@ -348,7 +348,7 @@ class Uri implements UriInterface, \JsonSerializable
     public static function assertValidHost(string $host): void
     {
         if (!Rfc3986::isValidHost($host)) {
-            throw new \InvalidArgumentException(sprintf('Invalid host: "%s"', \addcslashes($host, "\0..\37\177")));
+            throw new \InvalidArgumentException(sprintf('Invalid host: %s', DiagnosticValue::escape($host)));
         }
     }
 
@@ -600,7 +600,7 @@ class Uri implements UriInterface, \JsonSerializable
         $scheme = Utils::asciiToLower($scheme);
 
         if (!Rfc3986::isValidScheme($scheme)) {
-            throw new \InvalidArgumentException(sprintf('Invalid scheme: "%s"', \addcslashes($scheme, "\0..\37\177")));
+            throw new \InvalidArgumentException(sprintf('Invalid scheme: %s', DiagnosticValue::escape($scheme)));
         }
 
         return $scheme;
@@ -700,7 +700,7 @@ class Uri implements UriInterface, \JsonSerializable
     private static function describeInvalidPort($port): string
     {
         if (\is_string($port)) {
-            return \addcslashes($port, "\0..\37\177");
+            return DiagnosticValue::escape($port);
         }
 
         if (\is_int($port)) {

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -485,12 +485,7 @@ final class Utils
      */
     private static function assertValidModifyRequestChange(string $key, string $expected, $value): void
     {
-        throw new \InvalidArgumentException(\sprintf(
-            'Utils::modifyRequest() change "%s" must be %s; %s provided.',
-            $key,
-            $expected,
-            \get_debug_type($value)
-        ));
+        throw new \InvalidArgumentException(\sprintf('Utils::modifyRequest() change "%s" must be %s; %s provided.', DiagnosticValue::escape($key), $expected, \get_debug_type($value)));
     }
 
     /**
@@ -726,12 +721,7 @@ final class Utils
     {
         $ex = null;
         set_error_handler(static function (int $errno, string $errstr) use ($filename, $mode, &$ex): bool {
-            $ex = new \RuntimeException(sprintf(
-                'Unable to open "%s" using mode "%s": %s',
-                $filename,
-                $mode,
-                $errstr
-            ));
+            $ex = new \RuntimeException(sprintf('Unable to open %s using mode %s: %s', DiagnosticValue::escape($filename), DiagnosticValue::escape($mode), DiagnosticValue::escape($errstr)));
 
             return true;
         });
@@ -740,12 +730,7 @@ final class Utils
             /** @var resource $handle */
             $handle = fopen($filename, $mode);
         } catch (\Throwable $e) {
-            $ex = new \RuntimeException(sprintf(
-                'Unable to open "%s" using mode "%s": %s',
-                $filename,
-                $mode,
-                $e->getMessage()
-            ), 0, $e);
+            $ex = new \RuntimeException(sprintf('Unable to open %s using mode %s: %s', DiagnosticValue::escape($filename), DiagnosticValue::escape($mode), DiagnosticValue::escape($e->getMessage())), 0, $e);
         }
 
         restore_error_handler();
@@ -776,10 +761,7 @@ final class Utils
     {
         $ex = null;
         set_error_handler(static function (int $errno, string $errstr) use (&$ex): bool {
-            $ex = new \RuntimeException(sprintf(
-                'Unable to read stream contents: %s',
-                $errstr
-            ));
+            $ex = new \RuntimeException(sprintf('Unable to read stream contents: %s', DiagnosticValue::escape($errstr)));
 
             return true;
         });
@@ -800,10 +782,7 @@ final class Utils
         } catch (\Throwable $e) {
             $ex = StreamTimeout::isResourceReadTimedOut($stream)
                 ? new TimeoutException('Unable to read stream contents: timed out', 0, $e)
-                : new \RuntimeException(sprintf(
-                    'Unable to read stream contents: %s',
-                    $e->getMessage()
-                ), 0, $e);
+                : new \RuntimeException(sprintf('Unable to read stream contents: %s', DiagnosticValue::escape($e->getMessage())), 0, $e);
         }
 
         restore_error_handler();

--- a/tests/DiagnosticValueTest.php
+++ b/tests/DiagnosticValueTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GuzzleHttp\Tests\Psr7;
+
+use GuzzleHttp\Psr7\DiagnosticValue;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \GuzzleHttp\Psr7\DiagnosticValue
+ */
+class DiagnosticValueTest extends TestCase
+{
+    /**
+     * @dataProvider valueProvider
+     */
+    public function testEscapesDiagnosticValues(string $value, string $expected): void
+    {
+        $escaped = DiagnosticValue::escape($value);
+
+        self::assertSame($expected, $escaped);
+        self::assertSame(1, \preg_match('//u', $escaped));
+    }
+
+    public static function valueProvider(): iterable
+    {
+        yield 'empty' => ['', ''];
+
+        $printableAscii = '';
+        for ($byte = 0x20; $byte <= 0x7E; ++$byte) {
+            $printableAscii .= \chr($byte);
+        }
+        yield 'printable ASCII' => [$printableAscii, $printableAscii];
+        yield 'printable UTF-8' => ["caf\xC3\xA9 \xE2\x98\x83", "caf\xC3\xA9 \xE2\x98\x83"];
+
+        for ($codePoint = 0; $codePoint <= 0x1F; ++$codePoint) {
+            yield \sprintf('C0 U+%04X', $codePoint) => [\chr($codePoint), \sprintf('\\x%02X', $codePoint)];
+        }
+
+        yield 'DEL U+007F' => ["\x7F", '\\x7F'];
+
+        for ($codePoint = 0x80; $codePoint <= 0x9F; ++$codePoint) {
+            yield \sprintf('C1 U+%04X', $codePoint) => ["\xC2".\chr($codePoint), \sprintf('\\x%02X', $codePoint)];
+        }
+
+        yield 'malformed continuation byte' => ["\x80", '\\x80'];
+        yield 'malformed incomplete sequence' => ["\xE2\x98", '\\xE2\\x98'];
+        yield 'malformed overlong sequence' => ["\xC0\xAF", '\\xC0\\xAF'];
+        yield 'printable UTF-8 before malformed byte' => ["snowman \xE2\x98\x83\xFF", 'snowman \\xE2\\x98\\x83\\xFF'];
+    }
+}

--- a/tests/HttpFactoryTest.php
+++ b/tests/HttpFactoryTest.php
@@ -10,6 +10,19 @@ use PHPUnit\Framework\TestCase;
 
 class HttpFactoryTest extends TestCase
 {
+    public function testCreateStreamFromFileEscapesInvalidMode(): void
+    {
+        $factory = new HttpFactory();
+
+        try {
+            $factory->createStreamFromFile(__FILE__, "\n");
+            self::fail('Expected InvalidArgumentException was not thrown.');
+        } catch (\InvalidArgumentException $e) {
+            self::assertSame('Invalid file opening mode: \\x0A', $e->getMessage());
+            self::assertInstanceOf(\RuntimeException::class, $e->getPrevious());
+        }
+    }
+
     public function testCreateUploadedFileRejectsInvalidInferredSize(): void
     {
         $factory = new HttpFactory();

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -832,7 +832,7 @@ class MessageTest extends TestCase
     public function testParseResponseEscapesControlsInInvalidStartLineDiagnostic(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid response string: HTTP/1.1 200 OK\\000');
+        $this->expectExceptionMessage('Invalid response string: HTTP/1.1 200 OK\\x00');
 
         Psr7\Message::parseResponse("HTTP/1.1 200 OK\0\r\n\r\n");
     }

--- a/tests/MultipartStreamTest.php
+++ b/tests/MultipartStreamTest.php
@@ -266,7 +266,7 @@ class MultipartStreamTest extends TestCase
     public function testRejectsGeneratedContentDispositionNameWithNul(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('is not valid multipart part header value.');
+        $this->expectExceptionMessage('Invalid multipart part header value:');
 
         new MultipartStream([
             [
@@ -888,7 +888,7 @@ class MultipartStreamTest extends TestCase
     public function testRejectsGeneratedContentDispositionFilenameWithNul(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('is not valid multipart part header value.');
+        $this->expectExceptionMessage('Invalid multipart part header value:');
 
         new MultipartStream([
             [
@@ -1147,10 +1147,10 @@ class MultipartStreamTest extends TestCase
 
     public static function invalidCustomPartHeaderNameProvider(): iterable
     {
-        yield 'empty' => ['', '"" is not valid multipart part header name.'];
-        yield 'space' => ['Bad Header', '"Bad Header" is not valid multipart part header name.'];
-        yield 'carriage return' => ["Bad\rHeader", '"Bad\\rHeader" is not valid multipart part header name.'];
-        yield 'line feed' => ["Bad\nHeader", '"Bad\\nHeader" is not valid multipart part header name.'];
+        yield 'empty' => ['', 'Invalid multipart part header name: '];
+        yield 'space' => ['Bad Header', 'Invalid multipart part header name: Bad Header'];
+        yield 'carriage return' => ["Bad\rHeader", 'Invalid multipart part header name: Bad\\x0DHeader'];
+        yield 'line feed' => ["Bad\nHeader", 'Invalid multipart part header name: Bad\\x0AHeader'];
     }
 
     /**
@@ -1174,15 +1174,15 @@ class MultipartStreamTest extends TestCase
     {
         yield 'carriage return' => [
             "ok\rX-Injected: yes",
-            '"ok\\rX-Injected: yes" is not valid multipart part header value.',
+            'Invalid multipart part header value: ok\\x0DX-Injected: yes',
         ];
         yield 'line feed' => [
             "ok\nX-Injected: yes",
-            '"ok\\nX-Injected: yes" is not valid multipart part header value.',
+            'Invalid multipart part header value: ok\\x0AX-Injected: yes',
         ];
         yield 'nul' => [
             "ok\0bad",
-            '"ok\\000bad" is not valid multipart part header value.',
+            'Invalid multipart part header value: ok\\x00bad',
         ];
     }
 

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -473,12 +473,7 @@ class RequestTest extends TestCase
      */
     public function testContainsNotAllowedCharsOnHeaderField(string $header): void
     {
-        $this->expectExceptionMessage(
-            sprintf(
-                '"%s" is not valid header name',
-                $header
-            )
-        );
+        $this->expectExceptionMessage(sprintf('Invalid header name: %s', $header));
         $r = new Request(
             'GET',
             'http://foo.com/baz?bar=bam',
@@ -611,10 +606,7 @@ class RequestTest extends TestCase
     public function testContainsNotAllowedCharsOnHeaderValue(string $value): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(sprintf(
-            '"%s" is not valid header value',
-            \addcslashes($value, "\0..\37\177")
-        ));
+        $this->expectExceptionMessage(sprintf('Invalid header value: %s', Psr7\DiagnosticValue::escape($value)));
 
         $r = new Request(
             'GET',

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -337,7 +337,7 @@ class ResponseTest extends TestCase
     public static function invalidHeaderProvider(): iterable
     {
         return [
-            ['', '', '"" is not valid header name'],
+            ['', '', 'Invalid header name: '],
             ['foo', [], 'Header value must be a non-empty array or string.'],
             ['foo', false, 'Header value must be a string or array of strings but bool provided.'],
             ['foo', new \stdClass(),  'Header value must be a string or array of strings but stdClass provided.'],
@@ -363,15 +363,17 @@ class ResponseTest extends TestCase
     public static function invalidWithHeaderProvider(): iterable
     {
         yield from self::invalidHeaderProvider();
-        yield ['', 'foo', '"" is not valid header name.'];
-        yield ["Content-Type\r\n\r\n", 'foo', '"Content-Type\\r\\n\\r\\n" is not valid header name.'];
-        yield ["Content-Type\r\n", 'foo', '"Content-Type\\r\\n" is not valid header name.'];
-        yield ["Content-Type\n", 'foo', '"Content-Type\\n" is not valid header name.'];
-        yield ["\r\nContent-Type", 'foo', '"\\r\\nContent-Type" is not valid header name.'];
-        yield ["\nContent-Type", 'foo', '"\\nContent-Type" is not valid header name.'];
-        yield ["\n", 'foo', '"\\n" is not valid header name.'];
-        yield ["\r\n", 'foo', '"\\r\\n" is not valid header name.'];
-        yield ["\t", 'foo', '"\\t" is not valid header name.'];
+        yield ['', 'foo', 'Invalid header name: '];
+        yield ["Content-Type\r\n\r\n", 'foo', 'Invalid header name: Content-Type\\x0D\\x0A\\x0D\\x0A'];
+        yield ["Content-Type\r\n", 'foo', 'Invalid header name: Content-Type\\x0D\\x0A'];
+        yield ["Content-Type\n", 'foo', 'Invalid header name: Content-Type\\x0A'];
+        yield ["\r\nContent-Type", 'foo', 'Invalid header name: \\x0D\\x0AContent-Type'];
+        yield ["\nContent-Type", 'foo', 'Invalid header name: \\x0AContent-Type'];
+        yield ["\n", 'foo', 'Invalid header name: \\x0A'];
+        yield ["\r\n", 'foo', 'Invalid header name: \\x0D\\x0A'];
+        yield ["\t", 'foo', 'Invalid header name: \\x09'];
+        yield ["\xC2\x9B", 'foo', 'Invalid header name: \\x9B'];
+        yield ["\xFF", 'foo', 'Invalid header name: \\xFF'];
     }
 
     /**

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -196,7 +196,7 @@ class UriTest extends TestCase
     public function testRejectsIpv6UriWithTrailingNewline(): void
     {
         $this->expectException(MalformedUriException::class);
-        $this->expectExceptionMessage('Unable to parse URI: http://[::1]\\n');
+        $this->expectExceptionMessage('Unable to parse URI: http://[::1]\\x0A');
 
         new Uri("http://[::1]\n");
     }
@@ -439,7 +439,7 @@ class UriTest extends TestCase
     public function testInvalidSchemeDiagnosticEscapesControlBytes(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid scheme: "ht\\ntp"');
+        $this->expectExceptionMessage('Invalid scheme: ht\\x0Atp');
 
         (new Uri())->withScheme("ht\ntp");
     }
@@ -457,7 +457,7 @@ class UriTest extends TestCase
     public function testInvalidHostDiagnosticEscapesControlBytes(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid host: "example.com\\r\\nx-injected: yes"');
+        $this->expectExceptionMessage('Invalid host: example.com\\x0D\\x0Ax-injected: yes');
 
         (new Uri())->withHost("example.com\r\nX-Injected: yes");
     }
@@ -465,7 +465,7 @@ class UriTest extends TestCase
     public function testInvalidStringPortDiagnosticEscapesControlBytes(): void
     {
         $this->expectException(MalformedUriException::class);
-        $this->expectExceptionMessage('Invalid port: 80\\n. Must be between 0 and 65535');
+        $this->expectExceptionMessage('Invalid port: 80\\x0A. Must be between 0 and 65535');
 
         Uri::fromParts(['port' => "80\n"]);
     }

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -763,15 +763,23 @@ class UtilsTest extends TestCase
     public function testThrowsExceptionNotWarning(): void
     {
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Unable to open "/path/to/does/not/exist" using mode "r"');
+        $this->expectExceptionMessage('Unable to open /path/to/does/not/exist using mode r');
 
         Psr7\Utils::tryFopen('/path/to/does/not/exist', 'r');
+    }
+
+    public function testTryFopenEscapesFilenameInException(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Unable to open /path/to/does\\x0Anot-exist using mode r');
+
+        Psr7\Utils::tryFopen("/path/to/does\nnot-exist", 'r');
     }
 
     public function testThrowsExceptionNotValueError(): void
     {
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Unable to open "" using mode "r"');
+        $this->expectExceptionMessage('Unable to open  using mode r');
 
         Psr7\Utils::tryFopen('', 'r');
     }
@@ -846,6 +854,23 @@ class UtilsTest extends TestCase
             self::fail('Expected timeout exception.');
         } catch (Psr7\Exception\TimeoutException $e) {
             self::assertSame('Unable to read stream contents: timed out', $e->getMessage());
+            self::assertSame($previous, $e->getPrevious());
+        } finally {
+            fclose($resource);
+        }
+    }
+
+    public function testTryGetContentsEscapesWrappedFailureMessage(): void
+    {
+        $previous = new \ErrorException("read\nfailed\xFF");
+        PhpStreamMock::$streamGetContentsThrowable = $previous;
+        $resource = Psr7\Utils::tryFopen('php://temp', 'r+');
+
+        try {
+            Psr7\Utils::tryGetContents($resource);
+            self::fail('Expected read exception.');
+        } catch (\RuntimeException $e) {
+            self::assertSame('Unable to read stream contents: read\\x0Afailed\\xFF', $e->getMessage());
             self::assertSame($previous, $e->getPrevious());
         } finally {
             fclose($resource);
@@ -1865,6 +1890,10 @@ class UtilsTest extends TestCase
             'set_headers value bool' => [
                 ['set_headers' => ['X-Test' => false]],
                 'Utils::modifyRequest() change "set_headers.X-Test" must be string|non-empty-array<array-key, string>; bool provided.',
+            ],
+            'set_headers control in key' => [
+                ['set_headers' => ["X\nTest" => false]],
+                'Utils::modifyRequest() change "set_headers.X\\x0ATest" must be string|non-empty-array<array-key, string>; bool provided.',
             ],
             'set_headers value empty array' => [
                 ['set_headers' => ['X-Test' => []]],


### PR DESCRIPTION
PSR-7 3 currently embeds rejected protocol values, file paths, and native PHP diagnostics directly in generated exception messages. This adds public `DiagnosticValue::escape()` to preserve valid UTF-8 outside control ranges while rendering controls and malformed bytes visibly, then applies it only where PSR-7 selects dynamic exception values. It consolidates earlier unreleased escaping changes and removes their exception-wording notes from the upgrading guide. Raw inputs and previous exceptions remain unchanged, and callers still encode completed diagnostics for their final output context.