### PR TITLE
Trust embedded exception messages

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -730,7 +730,7 @@ final class Utils
             /** @var resource $handle */
             $handle = fopen($filename, $mode);
         } catch (\Throwable $e) {
-            $ex = new \RuntimeException(sprintf('Unable to open %s using mode %s: %s', DiagnosticValue::escape($filename), DiagnosticValue::escape($mode), DiagnosticValue::escape($e->getMessage())), 0, $e);
+            $ex = new \RuntimeException(sprintf('Unable to open %s using mode %s: %s', DiagnosticValue::escape($filename), DiagnosticValue::escape($mode), $e->getMessage()), 0, $e);
         }
 
         restore_error_handler();
@@ -782,7 +782,7 @@ final class Utils
         } catch (\Throwable $e) {
             $ex = StreamTimeout::isResourceReadTimedOut($stream)
                 ? new TimeoutException('Unable to read stream contents: timed out', 0, $e)
-                : new \RuntimeException(sprintf('Unable to read stream contents: %s', DiagnosticValue::escape($e->getMessage())), 0, $e);
+                : new \RuntimeException(sprintf('Unable to read stream contents: %s', $e->getMessage()), 0, $e);
         }
 
         restore_error_handler();

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -860,23 +860,6 @@ class UtilsTest extends TestCase
         }
     }
 
-    public function testTryGetContentsEscapesWrappedFailureMessage(): void
-    {
-        $previous = new \ErrorException("read\nfailed\xFF");
-        PhpStreamMock::$streamGetContentsThrowable = $previous;
-        $resource = Psr7\Utils::tryFopen('php://temp', 'r+');
-
-        try {
-            Psr7\Utils::tryGetContents($resource);
-            self::fail('Expected read exception.');
-        } catch (\RuntimeException $e) {
-            self::assertSame('Unable to read stream contents: read\\x0Afailed\\xFF', $e->getMessage());
-            self::assertSame($previous, $e->getPrevious());
-        } finally {
-            fclose($resource);
-        }
-    }
-
     public function testCreatesUriForValue(): void
     {
         self::assertInstanceOf('GuzzleHttp\Psr7\Uri', Psr7\Utils::uriFor('/foo'));


### PR DESCRIPTION
PSR-7 3 escapes raw filenames, modes, and PHP warning text when building diagnostics, but caught exceptions already supply complete diagnostic messages. This preserves those messages unchanged when `tryFopen()` and `tryGetContents()` wrap them, while retaining the original exception as previous and keeping raw input escaping intact. No changelog entry is needed because this corrects unreleased 3.0 behavior.