### PR TITLE
Document that host validity is a statement about URI syntax

### DIFF
--- a/docs/uri-helpers.md
+++ b/docs/uri-helpers.md
@@ -102,6 +102,11 @@ IDNA is treated as a client concern. Consumers that need DNS IDNs must perform
 the conversion themselves, for example via Guzzle's `idn_conversion` request
 option.
 
+Validity here is a statement about URI syntax only. It does not imply that the
+host resolves, or that a client will connect to the name exactly as written.
+Consumers that need a particular address must resolve the host themselves and
+check the addresses returned, rather than the spelling.
+
 ### `GuzzleHttp\Psr7\Rfc3986::isValidPort`
 
 `public static function isValidPort(string $port): bool`

--- a/docs/uri-helpers.md
+++ b/docs/uri-helpers.md
@@ -103,9 +103,12 @@ the conversion themselves, for example via Guzzle's `idn_conversion` request
 option.
 
 Validity here is a statement about URI syntax only. It does not imply that the
-host resolves, or that a client will connect to the name exactly as written.
-Consumers that need a particular address must resolve the host themselves and
-check the addresses returned, rather than the spelling.
+host resolves or that a client will interpret it exactly as written. A PSR-7 URI
+object does not know which resolver or transport will consume it, so it cannot
+establish destination identity. Consumers that restrict the destination must
+enforce that policy at the client or transport boundary and ensure the
+connection uses an approved address; checking the spelling or a separate DNS
+lookup is insufficient.
 
 ### `GuzzleHttp\Psr7\Rfc3986::isValidPort`
 


### PR DESCRIPTION
The `isValidHost()` documentation sets out what the predicate accepts and preserves, including raw and percent-encoded non-ASCII data, and notes that IDNA is a client concern. It does not state the corollary: what a caller may conclude from a positive result.

The predicate is a syntax check over the RFC 3986 grammar, so a valid host is not necessarily resolvable and validity does not establish the destination a client will select. A PSR-7 URI object does not know which resolver or transport will consume it. The new paragraph therefore puts destination policy at the consuming client or transport boundary and warns that checking the spelling or performing a separate DNS lookup is insufficient.

No behaviour change, so there is no changelog entry. The paragraph is documentation-only and has no PHPDoc counterpart to keep in sync; the synced pair in this section is the `isValidHost()` opening paragraph and the docblock in `src/Rfc3986.php`.
