### PR TITLE
Test that noncanonical IPv4 host spellings are not address-normalized

### DIFF
--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -519,6 +519,41 @@ class UriTest extends TestCase
     }
 
     /**
+     * @dataProvider getIpv4HostSpellings
+     */
+    public function testIpv4HostSpellingIsPreserved(string $host): void
+    {
+        $uri = (new Uri())->withHost($host);
+
+        self::assertSame($host, $uri->getHost());
+        self::assertSame($host, $uri->getAuthority());
+        self::assertSame('//'.$host, (string) $uri);
+    }
+
+    /**
+     * @dataProvider getIpv4HostSpellings
+     */
+    public function testParsedIpv4HostSpellingIsPreserved(string $host): void
+    {
+        $uri = new Uri('http://'.$host.'/path');
+
+        self::assertSame($host, $uri->getHost());
+        self::assertSame($host, $uri->getAuthority());
+        self::assertSame('http://'.$host.'/path', (string) $uri);
+    }
+
+    public static function getIpv4HostSpellings(): iterable
+    {
+        yield 'dotted quad' => ['127.0.0.1'];
+        yield 'two part' => ['127.1'];
+        yield 'decimal' => ['2130706433'];
+        yield 'hexadecimal' => ['0x7f000001'];
+        yield 'octal' => ['0177.0.0.1'];
+        yield 'zero padded octets' => ['127.000.000.001'];
+        yield 'zero padded final octet' => ['127.0.0.01'];
+    }
+
+    /**
      * @dataProvider getInvalidHosts
      */
     public function testHostMustBeValid(string $host): void


### PR DESCRIPTION
`Rfc3986::isValidHost()` accepts registered names permissively. An IPv4 address written in one of the `inet_aton()` shorthands is a registered name under RFC 3986, whose `IPv4address` rule requires exactly four dotted decimal octets. Such a host is therefore handled as a registered name: apart from PSR-7's required host lowercasing, it is not canonicalized as an address.

That behaviour is deliberate and worth pinning because it is currently untested: `getValidHosts()` carries no IPv4 entry, and none of these spellings appears anywhere in the test suite. Canonicalizing them as addresses would reinterpret registered names, and RFC 3986 section 7.4 excludes these formats from URI syntax precisely because platform implementations disagree about what they denote.

These tests assert that `getHost()`, `getAuthority()` and stringification do not address-normalize the spelling through either the parsing path or `withHost()`. They cover a canonical dotted quad and the two-part, decimal, hexadecimal, octal and zero-padded forms.
