### PR TITLE
Test that noncanonical IPv4 host spellings are not address-normalized

### DIFF
--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -302,6 +302,41 @@ class UriTest extends TestCase
         (new Uri())->withHost($host);
     }
 
+    /**
+     * @dataProvider getIpv4HostSpellings
+     */
+    public function testIpv4HostSpellingIsPreserved(string $host): void
+    {
+        $uri = (new Uri())->withHost($host);
+
+        self::assertSame($host, $uri->getHost());
+        self::assertSame($host, $uri->getAuthority());
+        self::assertSame('//'.$host, (string) $uri);
+    }
+
+    /**
+     * @dataProvider getIpv4HostSpellings
+     */
+    public function testParsedIpv4HostSpellingIsPreserved(string $host): void
+    {
+        $uri = new Uri('http://'.$host.'/path');
+
+        self::assertSame($host, $uri->getHost());
+        self::assertSame($host, $uri->getAuthority());
+        self::assertSame('http://'.$host.'/path', (string) $uri);
+    }
+
+    public static function getIpv4HostSpellings(): iterable
+    {
+        yield 'dotted quad' => ['127.0.0.1'];
+        yield 'two part' => ['127.1'];
+        yield 'decimal' => ['2130706433'];
+        yield 'hexadecimal' => ['0x7f000001'];
+        yield 'octal' => ['0177.0.0.1'];
+        yield 'zero padded octets' => ['127.000.000.001'];
+        yield 'zero padded final octet' => ['127.0.0.01'];
+    }
+
     public static function getInvalidHostsWithControlCharacters(): iterable
     {
         for ($i = 0; $i <= 0x20; ++$i) {


### PR DESCRIPTION
Backport of the coverage proposed for 3.0 in #873, written to this branch's test idiom rather than cherry-picked.

An IPv4 address written in one of the `inet_aton()` shorthands is a registered name under RFC 3986, whose `IPv4address` rule requires exactly four dotted decimal octets. Such a host is therefore handled as a registered name: apart from PSR-7's required host lowercasing, it is not canonicalized as an address. RFC 3986 section 7.4 excludes these formats from URI syntax precisely because platform implementations disagree about what they denote.

The behaviour was untested on this branch: no host provider carries a bare IPv4 address, the only IPv4 text in the suite being inside IPv6 literals, and none of these spellings appears anywhere in it. Pinning the contract prevents a future change from silently reinterpreting a registered name as an address.

The tests assert that `getHost()`, `getAuthority()` and stringification do not address-normalize the spelling through either the parsing path or `withHost()`. They cover a canonical dotted quad and the two-part, decimal, hexadecimal, octal and zero-padded forms. All seven behave identically on 2.13 and 3.0. Test-only; no `src/` change.
