### PR TITLE
Harden automatic exception diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.1.0 - Upcoming
+
+### Added
+
+- Add `Utils::redactUriForMessage()` and
+  `Utils::redactUriStringForMessage()` for safe automatic diagnostics
+
+### Changed
+
+- Omit rejected header values and sensitive URI components from automatic
+  exception messages
+
 ## 3.0.0 - 2026-07-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `Utils::redactUriForMessage()` and
-  `Utils::redactUriStringForMessage()` for safe automatic diagnostics
+- Add `Utils::redactUriForMessage()` and `Utils::redactUriStringForMessage()` for URI diagnostics
 
 ### Changed
 
-- Omit rejected header values and sensitive URI components from automatic
-  exception messages
+- Omit rejected header values and sensitive URI components from automatic exception messages
 
 ## 3.0.0 - 2026-07-20
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,16 +1,6 @@
 Guzzle PSR-7 Upgrade Guide
 ==========================
 
-3.0 to 3.1
-----------
-
-#### Automatic Diagnostic Redaction
-
-Exceptions for rejected ordinary and multipart header values now identify the
-header and validation category without copying the rejected value. Malformed
-URI exceptions replace userinfo, omit the query and fragment, and retain the
-scheme, host, port, and path where those components can be determined safely.
-
 2.x to 3.0
 ----------
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,6 +1,16 @@
 Guzzle PSR-7 Upgrade Guide
 ==========================
 
+3.0 to 3.1
+----------
+
+#### Automatic Diagnostic Redaction
+
+Exceptions for rejected ordinary and multipart header values now identify the
+header and validation category without copying the rejected value. Malformed
+URI exceptions replace userinfo, omit the query and fragment, and retain the
+scheme, host, port, and path where those components can be determined safely.
+
 2.x to 3.0
 ----------
 

--- a/docs/uri-and-mime-helpers.md
+++ b/docs/uri-and-mime-helpers.md
@@ -32,6 +32,28 @@ userinfo.
 A URI that does not parse has no trustworthy authority boundary, so everything
 between any scheme and its last `@` is redacted as a safe-side fallback.
 
+## `GuzzleHttp\Psr7\Utils::redactUriForMessage`
+
+`public static function redactUriForMessage(UriInterface $uri): string`
+
+Formats a URI for automatic diagnostics.
+
+The whole userinfo component is replaced by "***", and the query and
+fragment are removed. The scheme, host, port, and path are preserved.
+The returned string is diagnostic-escaped and the formatter never
+throws.
+
+## `GuzzleHttp\Psr7\Utils::redactUriStringForMessage`
+
+`public static function redactUriStringForMessage(string $uri): string`
+
+Formats a raw URI for automatic diagnostics, including malformed input.
+
+The whole userinfo component is replaced by "***", and the query and
+fragment are removed. The scheme, host, port, and path are preserved
+where their boundaries can be determined safely. The returned string is
+diagnostic-escaped and the formatter never throws.
+
 ## `GuzzleHttp\Psr7\Utils::uriFor`
 
 `public static function uriFor(string|UriInterface $uri): UriInterface`

--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -78,7 +78,7 @@ trait MessageTrait
     public function withHeader(string $name, $value): MessageInterface
     {
         $this->assertHeader($name);
-        $value = $this->normalizeHeaderValue($value);
+        $value = $this->normalizeHeaderValue($name, $value);
         $normalized = Utils::asciiToLower($name);
 
         $new = clone $this;
@@ -97,7 +97,7 @@ trait MessageTrait
     public function withAddedHeader(string $name, $value): MessageInterface
     {
         $this->assertHeader($name);
-        $value = $this->normalizeHeaderValue($value);
+        $value = $this->normalizeHeaderValue($name, $value);
         $normalized = Utils::asciiToLower($name);
 
         $new = clone $this;
@@ -166,7 +166,7 @@ trait MessageTrait
             $header = (string) $header;
 
             $this->assertHeader($header);
-            $value = $this->normalizeHeaderValue($value);
+            $value = $this->normalizeHeaderValue($header, $value);
             $normalized = Utils::asciiToLower($header);
             if (isset($this->headerNames[$normalized])) {
                 $header = $this->headerNames[$normalized];
@@ -183,17 +183,17 @@ trait MessageTrait
      *
      * @return string[]
      */
-    private function normalizeHeaderValue($value): array
+    private function normalizeHeaderValue(string $header, $value): array
     {
         if (is_array($value) && $value === []) {
             throw new \InvalidArgumentException('Header value must be a non-empty array or string.');
         }
 
         if (!is_array($value)) {
-            return $this->trimAndValidateHeaderValues([$value]);
+            return $this->trimAndValidateHeaderValues($header, [$value]);
         }
 
-        return $this->trimAndValidateHeaderValues($value);
+        return $this->trimAndValidateHeaderValues($header, $value);
     }
 
     /**
@@ -210,9 +210,9 @@ trait MessageTrait
      *
      * @see https://datatracker.ietf.org/doc/html/rfc9110#section-5.5
      */
-    private function trimAndValidateHeaderValues(array $values): array
+    private function trimAndValidateHeaderValues(string $header, array $values): array
     {
-        return array_map(function ($value): string {
+        return array_map(function ($value) use ($header): string {
             if (!is_string($value)) {
                 throw new \InvalidArgumentException(sprintf(
                     'Header value must be a string or array of strings but %s provided.',
@@ -221,7 +221,7 @@ trait MessageTrait
             }
 
             $trimmed = trim($value, " \t");
-            $this->assertValue($trimmed);
+            $this->assertValue($header, $trimmed);
 
             return $trimmed;
         }, array_values($values));
@@ -254,7 +254,7 @@ trait MessageTrait
      * obs-text       = %x80-FF
      * obs-fold       = CRLF 1*( SP / HTAB )
      */
-    private function assertValue(string $value): void
+    private function assertValue(string $header, string $value): void
     {
         // The regular expression intentionally does not support the obs-fold
         // production, because as per RFC 9112#5.2:
@@ -269,7 +269,15 @@ trait MessageTrait
         // obscure feature of HTTP/1.1 and thus not accepting folding is not
         // likely to break any legitimate use case.
         if (!Rfc9110::isFieldValue($value)) {
-            throw new \InvalidArgumentException(sprintf('Invalid header value: %s', DiagnosticValue::escape($value)));
+            $reason = strpbrk($value, "\r\n") !== false
+                ? 'must not contain CR or LF characters'
+                : 'contains an invalid control character';
+
+            throw new \InvalidArgumentException(sprintf(
+                'Header "%s" %s.',
+                DiagnosticValue::escape($header),
+                $reason
+            ));
         }
     }
 }

--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -273,11 +273,7 @@ trait MessageTrait
                 ? 'must not contain CR or LF characters'
                 : 'contains an invalid control character';
 
-            throw new \InvalidArgumentException(sprintf(
-                'Header "%s" %s.',
-                DiagnosticValue::escape($header),
-                $reason
-            ));
+            throw new \InvalidArgumentException(sprintf('Header "%s" %s.', DiagnosticValue::escape($header), $reason));
         }
     }
 }

--- a/src/MultipartStream.php
+++ b/src/MultipartStream.php
@@ -72,7 +72,7 @@ final class MultipartStream implements StreamInterface
             $key = (string) $key;
 
             self::validatePartHeaderName($key);
-            self::validatePartHeaderValue($value);
+            self::validatePartHeaderValue($key, $value);
 
             $str .= "{$key}: {$value}\r\n";
         }
@@ -252,7 +252,7 @@ final class MultipartStream implements StreamInterface
                 throw new \InvalidArgumentException('Multipart part header value must be a string.');
             }
 
-            self::validatePartHeaderValue($value);
+            self::validatePartHeaderValue($key, $value);
 
             $normalized[$key] = $value;
         }
@@ -267,10 +267,18 @@ final class MultipartStream implements StreamInterface
         }
     }
 
-    private static function validatePartHeaderValue(string $value): void
+    private static function validatePartHeaderValue(string $name, string $value): void
     {
         if (!Rfc9110::isFieldValue($value)) {
-            throw new \InvalidArgumentException(sprintf('Invalid multipart part header value: %s', DiagnosticValue::escape($value)));
+            $reason = strpbrk($value, "\r\n") !== false
+                ? 'must not contain CR or LF characters'
+                : 'contains an invalid control character';
+
+            throw new \InvalidArgumentException(sprintf(
+                'Multipart part header "%s" %s.',
+                DiagnosticValue::escape($name),
+                $reason
+            ));
         }
     }
 

--- a/src/MultipartStream.php
+++ b/src/MultipartStream.php
@@ -274,11 +274,7 @@ final class MultipartStream implements StreamInterface
                 ? 'must not contain CR or LF characters'
                 : 'contains an invalid control character';
 
-            throw new \InvalidArgumentException(sprintf(
-                'Multipart part header "%s" %s.',
-                DiagnosticValue::escape($name),
-                $reason
-            ));
+            throw new \InvalidArgumentException(sprintf('Multipart part header "%s" %s.', DiagnosticValue::escape($name), $reason));
         }
     }
 

--- a/src/Request.php
+++ b/src/Request.php
@@ -150,7 +150,7 @@ class Request implements RequestInterface
             $host .= ':'.$port;
         }
 
-        $this->assertValue($host);
+        $this->assertValue('Host', $host);
 
         return $host;
     }

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -69,7 +69,7 @@ class Uri implements UriInterface, \JsonSerializable
         if ($uri !== '') {
             $parts = UriParser::parse($uri);
             if ($parts === false) {
-                throw new MalformedUriException(\sprintf('Unable to parse URI: %s', DiagnosticValue::escape($uri)));
+                throw new MalformedUriException(\sprintf('Unable to parse URI: %s', Utils::redactUriStringForMessage($uri)));
             }
             try {
                 $this->applyParts($parts);

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -584,6 +584,56 @@ final class Utils
     }
 
     /**
+     * Formats a URI for automatic diagnostics.
+     *
+     * The whole userinfo component is replaced by "***", and the query and
+     * fragment are removed. The scheme, host, port, and path are preserved.
+     * The returned string is diagnostic-escaped and the formatter never
+     * throws.
+     */
+    public static function redactUriForMessage(
+        #[\SensitiveParameter]
+        UriInterface $uri
+    ): string {
+        try {
+            $raw = (string) $uri;
+        } catch (\Throwable $e) {
+            return '[unavailable URI]';
+        }
+
+        try {
+            if ($uri->getUserInfo() !== '') {
+                $uri = $uri->withUserInfo('***');
+            }
+
+            return DiagnosticValue::escape((string) $uri->withQuery('')->withFragment(''));
+        } catch (\Throwable $e) {
+            return self::redactUriStringForMessage($raw);
+        }
+    }
+
+    /**
+     * Formats a raw URI for automatic diagnostics, including malformed input.
+     *
+     * The whole userinfo component is replaced by "***", and the query and
+     * fragment are removed. The scheme, host, port, and path are preserved
+     * where their boundaries can be determined safely. The returned string is
+     * diagnostic-escaped and the formatter never throws.
+     */
+    public static function redactUriStringForMessage(
+        #[\SensitiveParameter]
+        string $uri
+    ): string {
+        try {
+            $uri = self::redactUserInfoInString($uri, $uri);
+
+            return DiagnosticValue::escape(\substr($uri, 0, \strcspn($uri, '?#')));
+        } catch (\Throwable $e) {
+            return '[unavailable URI]';
+        }
+    }
+
+    /**
      * Create a new stream based on the input type.
      *
      * Options are provided as an associative array that can contain the

--- a/tests/MultipartStreamTest.php
+++ b/tests/MultipartStreamTest.php
@@ -266,7 +266,9 @@ class MultipartStreamTest extends TestCase
     public function testRejectsGeneratedContentDispositionNameWithNul(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid multipart part header value:');
+        $this->expectExceptionMessage(
+            'Multipart part header "Content-Disposition" contains an invalid control character.'
+        );
 
         new MultipartStream([
             [
@@ -888,7 +890,9 @@ class MultipartStreamTest extends TestCase
     public function testRejectsGeneratedContentDispositionFilenameWithNul(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid multipart part header value:');
+        $this->expectExceptionMessage(
+            'Multipart part header "Content-Disposition" contains an invalid control character.'
+        );
 
         new MultipartStream([
             [
@@ -1158,31 +1162,33 @@ class MultipartStreamTest extends TestCase
      */
     public function testRejectsInvalidCustomPartHeaderValues(string $value, string $message): void
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage($message);
-
-        new MultipartStream([
-            [
-                'name' => 'field',
-                'contents' => 'body',
-                'headers' => ['X-Test' => $value],
-            ],
-        ], 'boundary');
+        try {
+            new MultipartStream([
+                [
+                    'name' => 'field',
+                    'contents' => 'body',
+                    'headers' => ['X-Test' => $value],
+                ],
+            ], 'boundary');
+            self::fail('Expected an invalid multipart part header value exception.');
+        } catch (\InvalidArgumentException $e) {
+            self::assertSame($message, $e->getMessage());
+        }
     }
 
     public static function invalidCustomPartHeaderValueProvider(): iterable
     {
         yield 'carriage return' => [
             "ok\rX-Injected: yes",
-            'Invalid multipart part header value: ok\\x0DX-Injected: yes',
+            'Multipart part header "X-Test" must not contain CR or LF characters.',
         ];
         yield 'line feed' => [
             "ok\nX-Injected: yes",
-            'Invalid multipart part header value: ok\\x0AX-Injected: yes',
+            'Multipart part header "X-Test" must not contain CR or LF characters.',
         ];
         yield 'nul' => [
             "ok\0bad",
-            'Invalid multipart part header value: ok\\x00bad',
+            'Multipart part header "X-Test" contains an invalid control character.',
         ];
     }
 

--- a/tests/MultipartStreamTest.php
+++ b/tests/MultipartStreamTest.php
@@ -266,9 +266,7 @@ class MultipartStreamTest extends TestCase
     public function testRejectsGeneratedContentDispositionNameWithNul(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
-            'Multipart part header "Content-Disposition" contains an invalid control character.'
-        );
+        $this->expectExceptionMessage('Multipart part header "Content-Disposition" contains an invalid control character.');
 
         new MultipartStream([
             [
@@ -890,9 +888,7 @@ class MultipartStreamTest extends TestCase
     public function testRejectsGeneratedContentDispositionFilenameWithNul(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(
-            'Multipart part header "Content-Disposition" contains an invalid control character.'
-        );
+        $this->expectExceptionMessage('Multipart part header "Content-Disposition" contains an invalid control character.');
 
         new MultipartStream([
             [

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -605,16 +605,22 @@ class RequestTest extends TestCase
      */
     public function testContainsNotAllowedCharsOnHeaderValue(string $value): void
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage(sprintf('Invalid header value: %s', Psr7\DiagnosticValue::escape($value)));
+        $reason = strpbrk($value, "\r\n") !== false
+            ? 'must not contain CR or LF characters'
+            : 'contains an invalid control character';
 
-        $r = new Request(
-            'GET',
-            'http://foo.com/baz?bar=bam',
-            [
-                'testing' => $value,
-            ]
-        );
+        try {
+            new Request(
+                'GET',
+                'http://foo.com/baz?bar=bam',
+                [
+                    'testing' => $value,
+                ]
+            );
+            self::fail('Expected an invalid header value exception.');
+        } catch (\InvalidArgumentException $e) {
+            self::assertSame(sprintf('Header "testing" %s.', $reason), $e->getMessage());
+        }
     }
 
     public static function provideHeaderValuesContainingNotAllowedChars(): iterable

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -201,6 +201,14 @@ class UriTest extends TestCase
         new Uri("http://[::1]\n");
     }
 
+    public function testMalformedUriDiagnosticOmitsSensitiveComponents(): void
+    {
+        $this->expectException(MalformedUriException::class);
+        $this->expectExceptionMessage('Unable to parse URI: https://***@example.com:bad/path');
+
+        new Uri('https://user:pass@example.com:bad/path?token=secret#private');
+    }
+
     public function testRejectsIpv6UriWithInvalidSuffix(): void
     {
         $this->expectException(MalformedUriException::class);

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -703,6 +703,57 @@ class UtilsTest extends TestCase
         yield 'empty userinfo' => ['http://@localhost', 'http://@localhost', 'http://@localhost'];
     }
 
+    /**
+     * @dataProvider redactUriForMessageProvider
+     */
+    public function testRedactUriForMessage(string $expected, string $uri): void
+    {
+        self::assertSame($expected, Psr7\Utils::redactUriForMessage(new Psr7\Uri($uri)));
+    }
+
+    public static function redactUriForMessageProvider(): iterable
+    {
+        yield 'credentials and sensitive components' => [
+            'https://***@example.com:8443/path',
+            'https://user:pass@example.com:8443/path?token=secret#private',
+        ];
+        yield 'username only' => [
+            'https://***@0x7f000001/path',
+            'https://token@0x7f000001/path?secret',
+        ];
+        yield 'no credentials' => [
+            'https://example.com/path',
+            'https://example.com/path?token=secret#private',
+        ];
+    }
+
+    public function testRedactUriForMessageFallsBackWhenComponentAccessThrows(): void
+    {
+        $uri = $this->createMock(UriInterface::class);
+        $uri->method('__toString')->willReturn('https://user:pass@example.com/path?token=secret');
+        $uri->method('getUserInfo')->willThrowException(new \RuntimeException('failed'));
+
+        self::assertSame('https://***@example.com/path', Psr7\Utils::redactUriForMessage($uri));
+    }
+
+    /**
+     * @dataProvider redactUriStringForMessageProvider
+     */
+    public function testRedactUriStringForMessage(string $expected, string $uri): void
+    {
+        self::assertSame($expected, Psr7\Utils::redactUriStringForMessage($uri));
+    }
+
+    public static function redactUriStringForMessageProvider(): iterable
+    {
+        yield 'malformed port and credentials' => [
+            'https://***@example.com:bad/path',
+            'https://user:pass@example.com:bad/path?token=secret#private',
+        ];
+        yield 'relative reference' => ['/path', '/path?token=secret#private'];
+        yield 'diagnostic control escaping' => ['http://[::1]\\x0A', "http://[::1]\n"];
+    }
+
     public function testCalculatesHash(): void
     {
         $s = Psr7\Utils::streamFor('foobazbar');


### PR DESCRIPTION
Rejected header values and URI credentials can be copied into automatic exception messages and then proliferate through logging systems. This omits ordinary and multipart header values while retaining the header name and rejection category, adds non-throwing parsed and raw URI diagnostic formatters that preserve scheme, host, port, and path while removing userinfo, query, and fragment data, and applies the raw formatter to malformed URI exceptions.