### PR TITLE
Prefix relative paths that begin with a colon segment instead of throwing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.13.1 - Upcoming
+
+### Fixed
+
+- Prefix relative paths that begin with a colon segment with `./` instead of throwing
+
 ## 2.13.0 - 2026-07-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -800,6 +800,10 @@ browsers do when resolving a link in a website based on the current request URI.
 
 Converts the relative URI into a new URI that is resolved against the base URI.
 
+When the resolved path is a relative-path reference whose first segment contains a colon, which would be mistaken for a
+scheme name ([RFC 3986 Section 4.2](https://datatracker.ietf.org/doc/html/rfc3986#section-4.2)), it is prefixed with
+`./`, e.g. `./a:b`.
+
 ### `GuzzleHttp\Psr7\UriResolver::removeDotSegments`
 
 `public static function removeDotSegments(string $path): string`
@@ -839,7 +843,14 @@ echo UriResolver::relativize($base, new Uri('http://example.org/a/b/'));   // pr
 
 Returns a normalized URI. The scheme and host component are already normalized to lowercase per PSR-7 UriInterface.
 This methods adds additional normalizations that can be configured with the `$flags` parameter which is a bitmask
-of normalizations to apply. The following normalizations are available:
+of normalizations to apply.
+
+When a normalization rewrites the path of a relative-path reference so that its first segment contains a colon, which
+would be mistaken for a scheme name ([RFC 3986 Section 4.2](https://datatracker.ietf.org/doc/html/rfc3986#section-4.2)),
+the path is prefixed with `./` instead of throwing, e.g. `a%41:` becomes `./aA:` as `aA:` would be an absolute URI
+with the scheme `aa`.
+
+The following normalizations are available:
 
 - `UriNormalizer::PRESERVING_NORMALIZATIONS`
 

--- a/src/UriNormalizer.php
+++ b/src/UriNormalizer.php
@@ -116,6 +116,11 @@ final class UriNormalizer
      * treated equivalent which is not necessarily true according to RFC 3986. But that difference
      * is highly uncommon in reality. So this potential normalization is implied in PSR-7 as well.
      *
+     * When a normalization rewrites the path of a relative-path reference so that its first
+     * segment contains a colon, which would be mistaken for a scheme name (RFC 3986 Section 4.2),
+     * the path is prefixed with "./" instead of throwing, e.g. "a%41:" becomes "./aA:" as "aA:"
+     * would be an absolute URI with the scheme "aa".
+     *
      * @param UriInterface $uri   The URI to normalize
      * @param int          $flags A bitmask of normalizations to apply, see constants
      *
@@ -156,7 +161,7 @@ final class UriNormalizer
                 throw new \RuntimeException('Unable to remove duplicate slashes from URI path: '.preg_last_error_msg());
             }
 
-            $uri = $uri->withPath($path);
+            $uri = self::withGuardedPath($uri, $path);
         }
 
         if ($flags & self::SORT_QUERY_PARAMETERS && $uri->getQuery() !== '') {
@@ -195,8 +200,7 @@ final class UriNormalizer
             return Utils::asciiToUpper($match[0]);
         };
 
-        return $uri
-            ->withPath(self::normalizePercentEncodingInComponent($uri->getPath(), $regex, $callback))
+        return self::withGuardedPath($uri, self::normalizePercentEncodingInComponent($uri->getPath(), $regex, $callback))
             ->withQuery(self::normalizePercentEncodingInComponent($uri->getQuery(), $regex, $callback))
             ->withFragment(self::normalizePercentEncodingInComponent($uri->getFragment(), $regex, $callback));
     }
@@ -209,10 +213,21 @@ final class UriNormalizer
             return rawurldecode($match[0]);
         };
 
-        return $uri
-            ->withPath(self::normalizePercentEncodingInComponent($uri->getPath(), $regex, $callback))
+        return self::withGuardedPath($uri, self::normalizePercentEncodingInComponent($uri->getPath(), $regex, $callback))
             ->withQuery(self::normalizePercentEncodingInComponent($uri->getQuery(), $regex, $callback))
             ->withFragment(self::normalizePercentEncodingInComponent($uri->getFragment(), $regex, $callback));
+    }
+
+    /**
+     * Writes the given path only when it differs from the current one, guarded so the write cannot throw.
+     */
+    private static function withGuardedPath(UriInterface $uri, string $path): UriInterface
+    {
+        if ($path === $uri->getPath()) {
+            return $uri;
+        }
+
+        return $uri->withPath(UriResolver::guardedPath($uri, $path));
     }
 
     /**

--- a/src/UriResolver.php
+++ b/src/UriResolver.php
@@ -51,9 +51,35 @@ final class UriResolver
     }
 
     /**
+     * Returns the path, prefixed with "./" when it would otherwise begin a relative-path reference with a segment
+     * containing a colon.
+     *
+     * Such a segment would be mistaken for a scheme name (RFC 3986 Section 4.2), so a URI without a scheme and
+     * authority cannot hold the path, but reference resolution and percent-encoding normalization can produce one.
+     * The "./" prefix the RFC prescribes resolves back to the same path.
+     *
+     * @see https://datatracker.ietf.org/doc/html/rfc3986#section-4.2
+     *
+     * @internal
+     */
+    public static function guardedPath(UriInterface $uri, string $path): string
+    {
+        if ($uri->getScheme() !== '' || $uri->getAuthority() !== '' || strpos(explode('/', $path, 2)[0], ':') === false) {
+            return $path;
+        }
+
+        return './'.$path;
+    }
+
+    /**
      * Converts the relative URI into a new URI that is resolved against the base URI.
      *
+     * When the resolved path is a relative-path reference whose first segment contains a colon,
+     * which would be mistaken for a scheme name (RFC 3986 Section 4.2), it is prefixed with "./",
+     * e.g. "./a:b".
+     *
      * @see https://datatracker.ietf.org/doc/html/rfc3986#section-5.2
+     * @see https://datatracker.ietf.org/doc/html/rfc3986#section-4.2
      */
     public static function resolve(UriInterface $base, UriInterface $rel): UriInterface
     {
@@ -92,6 +118,10 @@ final class UriResolver
             }
             $targetPath = self::removeDotSegments($targetPath);
             $targetQuery = $rel->getQuery();
+        }
+
+        if ($targetPath !== $base->getPath()) {
+            $targetPath = self::guardedPath($base, $targetPath);
         }
 
         return $base

--- a/tests/UriNormalizerTest.php
+++ b/tests/UriNormalizerTest.php
@@ -149,6 +149,44 @@ class UriNormalizerTest extends TestCase
         self::assertSame('http://example.org//a/c/d.html', (string) $normalizedUri);
     }
 
+    public function testDecodeUnreservedCharactersGuardsColonInFirstSegmentOfRelativePathReference(): void
+    {
+        $uri = new Uri('a%41:');
+        $normalizedUri = UriNormalizer::normalize($uri, UriNormalizer::DECODE_UNRESERVED_CHARACTERS);
+
+        self::assertInstanceOf(UriInterface::class, $normalizedUri);
+        // "aA:" would be parsed as the scheme "aa", so the path needs the "./" prefix
+        self::assertSame('./aA:', (string) $normalizedUri);
+        // the "./" prefix is stable under repeated normalization
+        self::assertSame('./aA:', (string) UriNormalizer::normalize($normalizedUri, UriNormalizer::DECODE_UNRESERVED_CHARACTERS));
+    }
+
+    public function testCapitalizePercentEncodingGuardsColonInFirstSegmentOfRelativePathReference(): void
+    {
+        $uri = new Uri('a%4a:');
+        $normalizedUri = UriNormalizer::normalize($uri, UriNormalizer::CAPITALIZE_PERCENT_ENCODING);
+
+        self::assertInstanceOf(UriInterface::class, $normalizedUri);
+        self::assertSame('./a%4A:', (string) $normalizedUri);
+    }
+
+    public function testRemoveDuplicateSlashesGuardsColonInFirstSegmentOfRelativePathReference(): void
+    {
+        $uri = new Uri('a%41://c');
+        $normalizedUri = UriNormalizer::normalize($uri, UriNormalizer::REMOVE_DUPLICATE_SLASHES);
+
+        self::assertInstanceOf(UriInterface::class, $normalizedUri);
+        self::assertSame('./a%41:/c', (string) $normalizedUri);
+    }
+
+    public function testUnchangedPathOfRelativePathReferenceIsNotGuarded(): void
+    {
+        $uri = new Uri('a_b:c');
+
+        self::assertSame('a_b:c', (string) UriNormalizer::normalize($uri));
+        self::assertSame('a_b:c', (string) UriNormalizer::normalize($uri, UriNormalizer::REMOVE_DUPLICATE_SLASHES));
+    }
+
     public function testPreservingNormalizationsRetainDuplicateSlashes(): void
     {
         $uri = new Uri('http://example.org//a%c2%b1b/./p%61th');
@@ -195,6 +233,8 @@ class UriNormalizerTest extends TestCase
             ['http://example.org:80', 'http://example.org/', true],
             ['http://example.org/../a/.././p%61th?%7a=%5e', 'http://example.org/path?z=%5E', true],
             ['http://example.org/path#fr%61g%c2%b1', 'http://example.org/path#frag%C2%B1', true],
+            ['a%41:', './aA:', true],
+            ['a%41:', 'aA:', false],
             ['https://example.org/', 'http://example.org/', false],
             ['https://example.org/', '//example.org/', false],
             ['//example.org/', '//example.org/', true],

--- a/tests/UriResolverTest.php
+++ b/tests/UriResolverTest.php
@@ -249,6 +249,12 @@ class UriResolverTest extends TestCase
             ['/a/',              './with:colon',  '/a/with:colon'],
             ['/a/',              'b/with:colon',  '/a/b/with:colon'],
             ['/a/',              './:b/',         '/a/:b/'],
+            // a colon in the first segment from merging or dot-segment removal gets the "./" prefix
+            ['',                 './b:',          './b:'],
+            ['a',                '../b:c',        './b:c'],
+            ['x',                'b%41:',         './b%41:'],
+            // an unchanged base path is not prefixed
+            ['a_b:c',            '?q',            'a_b:c?q'],
             // relative path references
             ['a',               'a/b',            'a/b'],
             ['',                 '',              ''],


### PR DESCRIPTION
`UriNormalizer::normalize()` and `UriResolver::resolve()` could throw a `MalformedUriException` for a URI that `new Uri()` had accepted, because percent-encoding normalization, duplicate-slash removal, or path merging can produce a relative-path reference whose first segment contains a colon, which `Uri::withPath()` rightly rejects since such a segment would be mistaken for a scheme name. Decoding `a%41:`, for example, yields `aA:`, which re-parses as the scheme `aa`. This prefixes such a path with `./`, as RFC 3986 Section 4.2 prescribes and as `relativize()` already does, so the result is a valid reference that resolves to the same path. The prefix is only added where the path would otherwise have been rewritten, so the output for URIs that did not throw before is unchanged. This is the 2.x counterpart of the fix for #877.
