### PR TITLE
Prefix relative paths that begin with a colon segment instead of throwing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.0.1 - Upcoming
+
+### Fixed
+
+- Prefix relative paths that begin with a colon segment with `./` instead of throwing
+- Apply the `/.` prefix for authority-less `//` paths to percent-encoding normalizations as well
+
 ## 3.0.0 - 2026-07-20
 
 ### Added

--- a/docs/uri-helpers.md
+++ b/docs/uri-helpers.md
@@ -256,6 +256,10 @@ the current request URI.
 
 Converts the relative URI into a new URI that is resolved against the base URI.
 
+When the resolved path is a relative-path reference whose first segment contains
+a colon, which would be mistaken for a scheme name (RFC 3986 Section 4.2), it is
+prefixed with `./`, e.g. `./a:b`.
+
 ### `GuzzleHttp\Psr7\UriResolver::removeDotSegments`
 
 `public static function removeDotSegments(string $path): string`
@@ -320,6 +324,13 @@ component as `getQuery()`, `getFragment()` etc. always return a string. This
 means the URIs `/?#` and `/` are treated equivalent which is not necessarily
 true according to RFC 3986. But that difference is highly uncommon in reality.
 So this potential normalization is implied in PSR-7 as well.
+
+A path the URI cannot hold, such as a `//`-leading path without an authority or
+a relative-path reference whose first segment contains a colon, is prefixed with
+`/.` or `./` respectively instead of throwing, as `UriResolver::resolve()` does.
+The percent-encoding normalizations only do so where they rewrote the path. For
+example, decoding `a%41:` yields `./aA:`, since `aA:` would be an absolute URI
+with the scheme `aa`.
 
 The following normalizations are available:
 

--- a/src/UriNormalizer.php
+++ b/src/UriNormalizer.php
@@ -166,6 +166,13 @@ final class UriNormalizer
      * uncommon in reality. So this potential normalization is implied in PSR-7
      * as well.
      *
+     * A path the URI cannot hold, such as a `//`-leading path without an
+     * authority or a relative-path reference whose first segment contains a
+     * colon, is prefixed with `/.` or `./` respectively instead of throwing, as
+     * `UriResolver::resolve()` does. The percent-encoding normalizations only
+     * do so where they rewrote the path. For example, decoding `a%41:` yields
+     * `./aA:`, since `aA:` would be an absolute URI with the scheme `aa`.
+     *
      * @param UriInterface $uri   The URI to normalize
      * @param int          $flags A bitmask of normalizations to apply, see constants
      *
@@ -260,8 +267,7 @@ final class UriNormalizer
         $uri = self::withNormalizedUserInfo($uri, $regex, $callback);
         $uri = self::withNormalizedHost($uri, $regex, $callback);
 
-        return $uri
-            ->withPath(self::normalizePercentEncodingInComponent(Uri::rawPath($uri), $regex, $callback))
+        return self::withGuardedPath($uri, self::normalizePercentEncodingInComponent(Uri::rawPath($uri), $regex, $callback))
             ->withQuery(self::normalizePercentEncodingInComponent($uri->getQuery(), $regex, $callback))
             ->withFragment(self::normalizePercentEncodingInComponent($uri->getFragment(), $regex, $callback));
     }
@@ -284,10 +290,22 @@ final class UriNormalizer
         $uri = self::withNormalizedUserInfo($uri, $regex, $callback);
         $uri = self::withNormalizedHost($uri, $regex, $hostCallback);
 
-        return $uri
-            ->withPath(self::normalizePercentEncodingInComponent(Uri::rawPath($uri), $regex, $callback))
+        return self::withGuardedPath($uri, self::normalizePercentEncodingInComponent(Uri::rawPath($uri), $regex, $callback))
             ->withQuery(self::normalizePercentEncodingInComponent($uri->getQuery(), $regex, $callback))
             ->withFragment(self::normalizePercentEncodingInComponent($uri->getFragment(), $regex, $callback));
+    }
+
+    /**
+     * Writes the given path only when it differs from the current one, guarded
+     * so the write cannot throw.
+     */
+    private static function withGuardedPath(UriInterface $uri, string $path): UriInterface
+    {
+        if ($path === Uri::rawPath($uri)) {
+            return $uri;
+        }
+
+        return $uri->withPath(UriResolver::guardedPath($uri, $path));
     }
 
     /**

--- a/src/UriResolver.php
+++ b/src/UriResolver.php
@@ -65,8 +65,8 @@ final class UriResolver
     }
 
     /**
-     * Returns the path, prefixed with "/." when it would otherwise start the
-     * URI's string form with an authority-like "//".
+     * Returns the path, prefixed with "/." or "./" when the URI could not
+     * otherwise hold it.
      *
      * A URI without an authority cannot hold a path beginning with "//" (RFC
      * 3986 Section 3.3), but removeDotSegments() can produce one. The "/."
@@ -76,28 +76,47 @@ final class UriResolver
      * written, so the path cannot be mistaken for an authority and the prefix
      * is not added.
      *
+     * A relative-path reference cannot begin with a segment containing a colon
+     * (RFC 3986 Section 4.2), as it would be mistaken for a scheme name, but
+     * reference resolution and percent-encoding normalization can produce one.
+     * The "./" prefix the RFC prescribes resolves back to the same path.
+     *
      * @see https://url.spec.whatwg.org/#url-serializing
+     * @see https://datatracker.ietf.org/doc/html/rfc3986#section-4.2
      *
      * @internal
      */
     public static function guardedPath(UriInterface $uri, string $path): string
     {
-        if (!str_starts_with($path, '//') || $uri->getAuthority() !== '') {
+        if ($uri->getAuthority() !== '') {
             return $path;
         }
 
-        if ($uri instanceof Uri && ($uri->getScheme() === 'http' || $uri->getScheme() === 'https')) {
-            return $path;
+        if (str_starts_with($path, '//')) {
+            if ($uri instanceof Uri && ($uri->getScheme() === 'http' || $uri->getScheme() === 'https')) {
+                return $path;
+            }
+
+            return '/.'.$path;
         }
 
-        return '/.'.$path;
+        if ($uri->getScheme() === '' && str_contains(explode('/', $path, 2)[0], ':')) {
+            return './'.$path;
+        }
+
+        return $path;
     }
 
     /**
      * Converts the relative URI into a new URI that is resolved against the
      * base URI.
      *
+     * When the resolved path is a relative-path reference whose first segment
+     * contains a colon, which would be mistaken for a scheme name (RFC 3986
+     * Section 4.2), it is prefixed with `./`, e.g. `./a:b`.
+     *
      * @see https://datatracker.ietf.org/doc/html/rfc3986#section-5.2
+     * @see https://datatracker.ietf.org/doc/html/rfc3986#section-4.2
      */
     public static function resolve(UriInterface $base, UriInterface $rel): UriInterface
     {

--- a/tests/UriNormalizerTest.php
+++ b/tests/UriNormalizerTest.php
@@ -412,6 +412,54 @@ class UriNormalizerTest extends TestCase
         self::assertSame('urn:/.//x', (string) $normalizedUri);
     }
 
+    public function testDecodeUnreservedCharactersGuardsColonInFirstSegmentOfRelativePathReference(): void
+    {
+        $uri = new Uri('a%41:');
+        $normalizedUri = UriNormalizer::normalize($uri, UriNormalizer::DECODE_UNRESERVED_CHARACTERS);
+
+        self::assertInstanceOf(UriInterface::class, $normalizedUri);
+        // "aA:" would be parsed as the scheme "aa", so the path needs the "./" prefix
+        self::assertSame('./aA:', (string) $normalizedUri);
+        // the "./" prefix is stable under repeated normalization
+        self::assertSame('./aA:', (string) UriNormalizer::normalize($normalizedUri, UriNormalizer::DECODE_UNRESERVED_CHARACTERS));
+    }
+
+    public function testCapitalizePercentEncodingGuardsColonInFirstSegmentOfRelativePathReference(): void
+    {
+        $uri = new Uri('a%4a:');
+        $normalizedUri = UriNormalizer::normalize($uri, UriNormalizer::CAPITALIZE_PERCENT_ENCODING);
+
+        self::assertInstanceOf(UriInterface::class, $normalizedUri);
+        self::assertSame('./a%4A:', (string) $normalizedUri);
+    }
+
+    public function testRemoveDuplicateSlashesGuardsColonInFirstSegmentOfRelativePathReference(): void
+    {
+        $uri = new Uri('a%41://c');
+        $normalizedUri = UriNormalizer::normalize($uri, UriNormalizer::REMOVE_DUPLICATE_SLASHES);
+
+        self::assertInstanceOf(UriInterface::class, $normalizedUri);
+        self::assertSame('./a%41:/c', (string) $normalizedUri);
+    }
+
+    public function testPercentEncodingNormalizationsDoNotGuardUnchangedRelativePathReference(): void
+    {
+        $uri = new Uri('a_b:c');
+
+        self::assertSame('a_b:c', (string) UriNormalizer::normalize($uri));
+        // dot-segment and duplicate-slash removal always guard the path they write
+        self::assertSame('./a_b:c', (string) UriNormalizer::normalize($uri, UriNormalizer::REMOVE_DUPLICATE_SLASHES));
+    }
+
+    public function testDecodeUnreservedCharactersGuardsPathOfAuthorityLessUri(): void
+    {
+        $uri = new Uri('file:////%7e');
+        $normalizedUri = UriNormalizer::normalize($uri, UriNormalizer::DECODE_UNRESERVED_CHARACTERS);
+
+        self::assertInstanceOf(UriInterface::class, $normalizedUri);
+        self::assertSame('file:///.//~', (string) $normalizedUri);
+    }
+
     public function testNormalizePreservesRootlessFileUriFromExtendedInstances(): void
     {
         $uri = new class('file:foo/bar') extends Uri {
@@ -575,6 +623,8 @@ class UriNormalizerTest extends TestCase
             ['http://example.org/..//a', 'http://example.org//a', true],
             ['http://example.org/..//a', 'http://example.org/a', false],
             ['urn:/..//x', 'urn:/.//x', true],
+            ['a%41:', './aA:', true],
+            ['a%41:', 'aA:', false],
             ['http:/a/..//b', 'http:/%61/..//b', true],
             ['http://example.org/path#fr%61g%c2%b1', 'http://example.org/path#frag%C2%B1', true],
             ['http://[::0:1]/', 'http://[::1]/', true],

--- a/tests/UriResolverTest.php
+++ b/tests/UriResolverTest.php
@@ -300,6 +300,10 @@ class UriResolverTest extends TestCase
             ['/a/',              './with:colon',  '/a/with:colon'],
             ['/a/',              'b/with:colon',  '/a/b/with:colon'],
             ['/a/',              './:b/',         '/a/:b/'],
+            // a colon in the first segment from merging or dot-segment removal gets the "./" prefix
+            ['',                 './b:',          './b:'],
+            ['a',                '../b:c',        './b:c'],
+            ['x',                'b%41:',         './b%41:'],
             // relative path references
             ['a',               'a/b',            'a/b'],
             ['',                 '',              ''],


### PR DESCRIPTION
`UriNormalizer::normalize()` and `UriResolver::resolve()` could throw a `MalformedUriException` for a URI that `new Uri()` had accepted, because percent-encoding normalization, duplicate-slash removal, or path merging can produce a relative-path reference whose first segment contains a colon, which `Uri::withPath()` rightly rejects since such a segment would be mistaken for a scheme name. Decoding `a%41:`, for example, yields `aA:`, which re-parses as the scheme `aa`. The percent-encoding normalizations also bypassed the `/.` guard that dot-segment removal gained in #818, so decoding `file:////%7e` threw as well. This routes them through `UriResolver::guardedPath()`, which now also prefixes a colon-leading relative path with `./`, as RFC 3986 Section 4.2 prescribes and as `relativize()` already does, so the result is a valid reference that resolves to the same path. The percent-encoding normalizations, which make up the default preserving set, only add a prefix where they actually rewrote the path, so their output for URIs that did not throw before is unchanged; dot-segment and duplicate-slash removal and `resolve()` guard the path they write unconditionally, as they already did for `/.`. Fixes #877.
