### PR TITLE
Keep a colon-leading first path segment when reading scheme-less non-native URIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Prefix relative paths that begin with a colon segment with `./` instead of throwing
 - Apply the `/.` prefix for authority-less `//` paths to percent-encoding normalizations as well
+- Keep colon-leading first path segments when reading the paths of scheme-less non-native URIs
 
 ## 3.0.0 - 2026-07-20
 

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -411,7 +411,10 @@ class Uri implements UriInterface, \JsonSerializable
      * components, including the leading slash the string form adds to a
      * rootless path when an authority is present; for subclasses and other
      * implementations the path is split from the string form per RFC 3986
-     * Appendix B, without validating or decoding any other component.
+     * Appendix B, without validating or decoding any other component. The
+     * scheme is only split off when the instance reports one, as a relative
+     * reference can begin with a segment containing a colon that the Appendix
+     * B expression would otherwise read as a scheme.
      *
      * @throws \RuntimeException If the path cannot be split from the string form.
      *
@@ -429,7 +432,10 @@ class Uri implements UriInterface, \JsonSerializable
             return $uri->path;
         }
 
-        $count = preg_match('%^(?:[^:/?#]+:)?(?://[^/?#]*)?([^?#]*)%', (string) $uri, $matches);
+        $pattern = $uri->getScheme() === ''
+            ? '%^(?://[^/?#]*)?([^?#]*)%'
+            : '%^(?:[^:/?#]+:)?(?://[^/?#]*)?([^?#]*)%';
+        $count = preg_match($pattern, (string) $uri, $matches);
 
         if ($count === false) {
             throw new \RuntimeException('Unable to read the URI path: '.preg_last_error_msg());

--- a/tests/UriNormalizerTest.php
+++ b/tests/UriNormalizerTest.php
@@ -471,6 +471,17 @@ class UriNormalizerTest extends TestCase
         self::assertSame('file:foo/bar', (string) $normalizedUri);
     }
 
+    public function testNormalizePreservesColonInFirstSegmentFromExtendedInstances(): void
+    {
+        $uri = new class('git@example.com:user/repo') extends Uri {
+        };
+
+        $normalizedUri = UriNormalizer::normalize($uri);
+
+        self::assertInstanceOf(UriInterface::class, $normalizedUri);
+        self::assertSame('git@example.com:user/repo', (string) $normalizedUri);
+    }
+
     public function testSortQueryParameters(): void
     {
         $uri = new Uri('?lang=en&article=fred');

--- a/tests/UriResolverTest.php
+++ b/tests/UriResolverTest.php
@@ -65,6 +65,14 @@ class UriResolverTest extends TestCase
         self::assertSame('https://other.example/b?x=y#fragment', (string) $targetUri);
     }
 
+    public function testResolveKeepsColonInFirstSegmentOfSchemeLessReferenceImplementation(): void
+    {
+        $referenceUri = self::customUri('git@example.com:user/repo');
+        $targetUri = UriResolver::resolve(new Uri('https://example.com/a/b'), $referenceUri);
+
+        self::assertSame('https://example.com/a/git@example.com:user/repo', (string) $targetUri);
+    }
+
     public function testResolvePreservesBaseUriImplementationWhenReferenceInheritsAuthority(): void
     {
         $baseUri = self::customUri('https://example.com/a/b/c?old=1#old');

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -780,6 +780,17 @@ class UriTest extends TestCase
         self::assertSame(Uri::rawPath(new Uri('//example.com/foo')), Uri::rawPath($rootlessUri));
     }
 
+    public function testRawPathKeepsColonInFirstSegmentOfSchemeLessExtendedInstances(): void
+    {
+        $extendedUri = new class('git@example.com:user/repo') extends Uri {
+        };
+
+        self::assertSame('', $extendedUri->getScheme());
+        // the RFC 3986 Appendix B expression alone would read "git@example.com" as the scheme
+        self::assertSame('git@example.com:user/repo', Uri::rawPath($extendedUri));
+        self::assertSame(Uri::rawPath(new Uri('git@example.com:user/repo')), Uri::rawPath($extendedUri));
+    }
+
     public function testAddAndRemoveQueryValues(): void
     {
         $uri = new Uri();


### PR DESCRIPTION
For a `Uri` subclass or another `UriInterface` implementation, `Uri::rawPath()` re-parses the path from the URI's string form using the RFC 3986 Appendix B expression, which reads any leading run of characters up to a colon as the scheme. A scheme-less relative reference whose first segment contains a colon, such as `git@example.com:user/repo`, therefore lost that prefix wherever the raw path is used: it normalized to `user/repo` and resolved against `http://h/x/y` to `http://h/x/user/repo`. This matches the scheme part only when the instance actually reports a scheme, so the path of such references now survives normalization and resolution unchanged. Direct `Uri` instances were unaffected, as their raw path is derived from the stored components.
