### PR TITLE
Prefix stranded file host paths with /. instead of throwing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Prefix relative paths that begin with a colon segment with `./` instead of throwing
 - Apply the `/.` prefix for authority-less `//` paths to percent-encoding normalizations as well
 - Keep colon-leading first path segments when reading the paths of scheme-less non-native URIs
+- Stop throwing when removing the default `file` host strands a `//` path, prefixing it with `/.`
 
 ## 3.0.0 - 2026-07-20
 

--- a/docs/uri-helpers.md
+++ b/docs/uri-helpers.md
@@ -388,7 +388,11 @@ The following normalizations are available:
     `file:///myfile`, and `file://localhost/myfile` are equivalent according to
     RFC 3986.
 
-    Example: `file://localhost/myfile` → `file:///myfile`
+    When removing the host leaves a URI without an authority whose path begins
+    with `//`, the path is serialized with a `/.` prefix.
+
+    Example: `file://localhost/myfile` → `file:///myfile`,
+    `file://localhost//x` → `file:///.//x`
 
 - `UriNormalizer::REMOVE_DEFAULT_PORT`
 

--- a/src/UriNormalizer.php
+++ b/src/UriNormalizer.php
@@ -86,7 +86,11 @@ final class UriNormalizer
      * second format in the Uri class. See
      * `GuzzleHttp\Psr7\Uri::composeComponents`.
      *
+     * When removing the host leaves a URI without an authority whose path
+     * begins with `//`, the path is serialized with a `/.` prefix.
+     *
      * Example: file://localhost/myfile → file:///myfile
+     * Example: file://localhost//x → file:///.//x
      */
     public const REMOVE_DEFAULT_HOST = 8;
 
@@ -195,6 +199,14 @@ final class UriNormalizer
         }
 
         if ($flags & self::REMOVE_DEFAULT_HOST && $uri->getScheme() === 'file' && $uri->getHost() === 'localhost') {
+            if ($uri->getUserInfo() === '' && $uri->getPort() === null) {
+                $path = Uri::rawPath($uri);
+                if (str_starts_with($path, '//')) {
+                    // "/." keeps a "//" path unambiguous once the authority is gone
+                    $uri = $uri->withPath('/.'.$path);
+                }
+            }
+
             $uri = $uri->withHost('');
         }
 

--- a/tests/UriNormalizerTest.php
+++ b/tests/UriNormalizerTest.php
@@ -296,6 +296,28 @@ class UriNormalizerTest extends TestCase
         self::assertSame('file:', (string) $normalizedUri);
     }
 
+    public function testRemoveDefaultHostGuardsStrandedPathOfFileUri(): void
+    {
+        $uri = new Uri('file://localhost//x');
+        $normalizedUri = UriNormalizer::normalize($uri, UriNormalizer::REMOVE_DEFAULT_HOST);
+
+        self::assertInstanceOf(UriInterface::class, $normalizedUri);
+        // the path cannot begin with "//" once the authority is gone
+        self::assertSame('file:///.//x', (string) $normalizedUri);
+        // the "/." prefix is stable under repeated normalization
+        self::assertSame('file:///.//x', (string) UriNormalizer::normalize($normalizedUri, UriNormalizer::REMOVE_DEFAULT_HOST));
+        self::assertSame('file:///.//x', (string) UriNormalizer::normalize($uri));
+    }
+
+    public function testRemoveDefaultHostKeepsAuthorityWithUserInfoOrPort(): void
+    {
+        $userInfoUri = new Uri('file://user@localhost//x');
+        $portUri = new Uri('file://localhost:21//x');
+
+        self::assertSame('file://user@//x', (string) UriNormalizer::normalize($userInfoUri, UriNormalizer::REMOVE_DEFAULT_HOST));
+        self::assertSame('file://:21//x', (string) UriNormalizer::normalize($portUri, UriNormalizer::REMOVE_DEFAULT_HOST));
+    }
+
     public function testRemoveDefaultPort(): void
     {
         $uri = $this->createMock(UriInterface::class);
@@ -651,6 +673,8 @@ class UriNormalizerTest extends TestCase
             ['file:///myfile', 'file://localhost/myfile', true],
             ['file:foo', 'file:bar', false],
             ['file:foo', 'file://foo', false],
+            ['file://localhost//x', 'file:////x', true],
+            ['file://localhost//x', 'file:///x', false],
         ];
     }
 


### PR DESCRIPTION
`UriNormalizer::normalize()` threw a `MalformedUriException` for the valid URI `file://localhost//x` when `REMOVE_DEFAULT_HOST` removed the localhost host, because the leftover authority-less URI cannot hold a path that begins with `//`. This serializes such a path with the `/.` prefix before removing the host, matching how dot-segment removal and the percent-encoding normalizations already serialize stranded `//` paths, so removing the default host can no longer throw, and `file://localhost//x` and `file:////x` now normalize to the same `file:///.//x` and compare equivalent. A host removal that leaves userinfo or a port keeps the authority and is unchanged. The collision has existed since the normalization was introduced in 2016.
