### PR TITLE
Add PHP 8.6 to the CI matrix and version guidance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+        php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5', '8.6']
 
     steps:
       - name: Set up PHP

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+        php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5', '8.6']
 
     steps:
       - name: Set up PHP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `Utils::redactUriForMessage()` and `Utils::redactUriStringForMessage()` for URI diagnostics
+- Add PHP 8.6 to the supported and tested versions
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `Utils::redactUriForMessage()` and `Utils::redactUriStringForMessage()` for URI diagnostics
-- Add PHP 8.6 to the supported and tested versions
+- Add support for PHP 8.6
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ composer require guzzlehttp/psr7
 
 | Version | Status       | PHP Version  |
 |---------|--------------|--------------|
-| 3.0     | Latest       | >=7.4,<8.6   |
-| 2.13    | Maintenance  | >=7.2.5,<8.6 |
+| 3.1     | Latest       | >=7.4,<8.7   |
+| 2.13    | Maintenance  | >=7.2.5,<8.7 |
 | 1.9     | End of Life  | >=5.4,<8.2   |
 
 ## Quick Start


### PR DESCRIPTION
The full test suite passes under PHP 8.6.0beta1 without code changes, so this adds PHP 8.6 to the CI matrices and version guidance, and corrects a stale 3.0 reference in the README version table along the way.
